### PR TITLE
imp: commit a mutation in a mutation

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -74,7 +74,7 @@ export class Store extends EventBus {
     this.observer.allowMutations = true;
 
 
-    this.mutations[type].call(
+    const res = this.mutations[type].call(
       null,
       {
         commit: this.commit.bind(this),
@@ -103,6 +103,7 @@ export class Store extends EventBus {
       });
     }
     this._commitLevel--;
+    return res;
   }
 }
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -95,6 +95,21 @@ describe("basic use", () => {
     expect(store.state.n).toBe(11);
   });
 
+  test("return data from committing a mutation", () => {
+    const state = { n: 1 };
+    const mutations = {
+      inc({ state }) {
+        return ++state.n;
+      },
+    };
+    const store = new Store({ state, mutations });
+
+    expect(store.state.n).toBe(1);
+    const res = store.commit("inc");
+    expect(store.state.n).toBe(2);
+    expect(res).toBe(2);
+  });
+
   test("dispatch allow synchronizing between actions", async () => {
     const state = { n: 1 };
     const mutations = {


### PR DESCRIPTION
Before this commit, in order to reuse a commit in another commit, we had to define a function away from the `mutations` object. This leads to code like:
```js
function _createChannel({ state, set }, data) {
  set(state, data.id, data);
}
const mutations = {
   createChannels({ state, set }, channelsData) {
      channelsData.forEach(data => _createChannel({ state, set }, data));
   },
   createChannel({ state, set }, data) {
      _createChannel({ state, set }, data)
   }
};
```
With this commit, above code looks like this:
```js
const mutations = {
   createChannels({ commit }, channelsData) {
      channelsData.forEach(data => commit("createChannel", data));
   },
   createChannel({ state, set }, data) {
      set(state, data.id, data);
   }
};
```