### PR TITLE
[FIX] store: connected component deeply reactive with undefined, null…

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -255,6 +255,10 @@ export function makeObserver(): Observer {
 //------------------------------------------------------------------------------
 
 function revNumber<T extends Object>(o: T): number {
+  if (!o || typeof o !== "object") {
+    // not enough for strings
+    return 0;
+  }
   if (!("__owl__" in o)) {
     return 0;
   }
@@ -262,6 +266,10 @@ function revNumber<T extends Object>(o: T): number {
 }
 
 function deepRevNumber<T extends Object>(o: T): number {
+  if (!o || typeof o !== "object") {
+    // not enough for strings
+    return 0;
+  }
   if (!("__owl__" in o)) {
     return 0;
   }
@@ -287,18 +295,11 @@ export function connect(mapStateToProps, options: any = {}) {
           if ("__owl__" in storeProps) {
             hashFunction = s => defaultRevFunction(s.storeProps);
           } else {
-            let areKeyObservable = false;
-            for (let key in storeProps) {
-              areKeyObservable =
-                areKeyObservable || (storeProps[key] && typeof (storeProps[key]) === "object" && "__owl__" in storeProps[key]);
-            }
-            if (areKeyObservable) {
-              hashFunction = function({ storeProps }) {
-                return Object.values(storeProps).reduce(
-                  (sum: number, val: any) => sum + defaultRevFunction(val),
-                  0
-                );
-              };
+            hashFunction = function({ storeProps }) {
+              return Object.values(storeProps).reduce(
+                (sum: number, val: any) => sum + defaultRevFunction(val),
+                0
+              );
             }
           }
         }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -783,11 +783,83 @@ describe("connecting a component to store", () => {
     await app.updateState({ beerId: 1 });
     expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>selected:jupiler</span></div></div>");
 
-    store.commit('consume', 1);
+    store.commit("consume", 1);
     await nextTick();
     expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>selected:jupiler</span><span>consumed:jupiler</span></div></div>");
 
     await app.updateState({ beerId: 0 });
     expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>consumed:jupiler</span></div></div>");
+  });
+
+  test("connected component deeply reactive with undefined, null and string props", async () => {
+    class Beer extends Component<any, any, any> {
+      inlineTemplate = `<div>
+          <span>taster:<t t-esc="props.taster"/></span>
+          <span t-if="props.selected">selected:<t t-esc="props.selected.name"/></span>
+          <span t-if="props.consumed">consumed:<t t-esc="props.consumed.name"/></span>
+        </div>`;
+    }
+    const ConnectedBeer = connect((state, props) => {
+      return {
+        selected: state.beers[props.id],
+        consumed: state.beers[state.consumedID] || null,
+        taster: state.taster,
+      };
+    })(Beer);
+
+    class App extends Component<any, any, any> {
+      inlineTemplate = `<div>
+              <t t-widget="ConnectedBeer" t-props="{id: state.beerId}"/>
+          </div>`;
+      widgets = { ConnectedBeer };
+      state = { beerId: 0 };
+    }
+
+    const mutations = {
+      changeTaster({ state }, newTaster) {
+        state.taster = newTaster;
+      },
+      consume({ state }, beerId) {
+        state.consumedID = beerId;
+      },
+      renameBeer({ state }, { beerId, name }) {
+        state.beers[beerId].name = name;
+      },
+    };
+    const state = {
+      beers: {
+        1: { name: "jupiler" }
+      },
+      consumedID: null,
+      taster: "aaron"
+    };
+    const store = new Store({ state, mutations });
+    (<any>env).store = store;
+    const app = new App(env);
+
+    await app.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span></div></div>");
+
+    await app.updateState({ beerId: 1 });
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>selected:jupiler</span></div></div>");
+
+    store.commit("renameBeer", { beerId: 1, name: "kwak" });
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>selected:kwak</span></div></div>");
+
+    store.commit("consume", 1);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>selected:kwak</span><span>consumed:kwak</span></div></div>");
+
+    await app.updateState({ beerId: 0 });
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>consumed:kwak</span></div></div>");
+
+    store.commit("renameBeer", { beerId: 1, name: "jupiler" });
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:aaron</span><span>consumed:jupiler</span></div></div>");
+
+    store.commit("changeTaster", "matthieu");
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><div><span>taster:matthieu</span><span>consumed:jupiler</span></div></div>");
   });
 });


### PR DESCRIPTION
… and string props

Revision on https://github.com/odoo/owl/commit/9f77344c3a19592d4a37df43b65f9e647fe41f24

Deeply reactive version of fix above.

Test currently crashes with string:

```
connecting a component to store › connected component deeply reactive with undefined, null and string props

    expect(received).toBe(expected) // Object.is equality

    Expected: "<div><div><span>taster:matthieu</span><span>consumed:jupiler</span></div></div>"
    Received: "<div><div><span>taster:aaron</span><span>consumed:jupiler</span></div></div>"

      861 |     store.commit("changeTaster", "matthieu");
      862 |     await nextTick();
    > 863 |     expect(fixture.innerHTML).toBe("<div><div><span>taster:matthieu</span><span>consumed:jupiler</span></div></div>");
          |                               ^
      864 |   });
      865 | });
      866 | 

      at Object.<anonymous> (tests/store.test.ts:863:31)
      at step (tests/store.test.ts:45:23)
      at Object.next (tests/store.test.ts:26:53)
      at fulfilled (tests/store.test.ts:17:58)
```