### PR TITLE
[DOC] component: remove misleading order on willUnmount

### DIFF
--- a/doc/component.md
+++ b/doc/component.md
@@ -312,5 +312,4 @@ the DOM. This is a good place to remove some listeners, for example.
   }
 ```
 
-This is the opposite method of `mounted`. The `willUnmount` method will be
-called in reverse order: first the children, then the parents.
+This is the opposite method of `mounted`.


### PR DESCRIPTION
Some hooks call order are clearly defined: `[willX]` hooks are
called first on parent, then on children, and `[Xed]` are called in
the reverse order: first children, then parent.

This is also true for `willUnmount`: first on parent, then on
children.