### PR TITLE
[FIX] qweb/component: better handling for t-debug

### DIFF
--- a/src/qweb_core.ts
+++ b/src/qweb_core.ts
@@ -319,10 +319,13 @@ export class QWeb extends EventBus {
       );
     }
     if (isDebug) {
-      console.log(
-        `Template: ${this.templates[name].elem.outerHTML}\nCompiled code:\n` +
-          template.toString()
-      );
+      const tpl = this.templates[name];
+      if (tpl) {
+        const msg = `Template: ${
+          tpl.elem.outerHTML
+        }\nCompiled code:\n${template.toString()}`;
+        console.log(msg);
+      }
     }
     return template;
   }

--- a/src/qweb_directives.ts
+++ b/src/qweb_directives.ts
@@ -304,7 +304,7 @@ QWeb.addDirective({
 //------------------------------------------------------------------------------
 QWeb.addDirective({
   name: "debug",
-  priority: 99,
+  priority: 1,
   atNodeEncounter({ ctx }) {
     ctx.addLine("debugger;");
   }
@@ -315,7 +315,7 @@ QWeb.addDirective({
 //------------------------------------------------------------------------------
 QWeb.addDirective({
   name: "log",
-  priority: 99,
+  priority: 1,
   atNodeEncounter({ ctx, value }) {
     const expr = ctx.formatExpression(value);
     ctx.addLine(`console.log(${expr})`);

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -3055,6 +3055,31 @@ describe("t-slot directive", () => {
       '<div><span><span>some content</span></span></div>'
     );
   });
+
+  test("t-debug on a t-set (defining a slot)", async () => {
+    const consoleLog = console.log;
+    console.log = jest.fn();
+
+    env.qweb.addTemplates(`
+        <templates>
+          <div t-name="Parent">
+            <Dialog><t t-set="content" t-debug="1">abc</t></Dialog>
+          </div>
+          <span t-name="Dialog">
+            <t t-slot="content"/>
+          </span>
+        </templates>
+    `);
+    class Dialog extends Widget {}
+    class Parent extends Widget {
+      components = { Dialog };
+    }
+    const parent = new Parent(env);
+    await parent.mount(fixture);
+    expect(console.log).toHaveBeenCalledTimes(0);
+    console.log = consoleLog;
+  });
+
 });
 
 describe("t-model directive", () => {


### PR DESCRIPTION
- fix issue with t-debug on a t-set (defining a slot)
- put t-debug and t-log at a very low (high) priority to make sure they
  are executed before other directives

closes #201