### PR TITLE
[FIX] qweb: t-component + class with extra whitespaces

### DIFF
--- a/src/qweb_extensions.ts
+++ b/src/qweb_extensions.ts
@@ -476,6 +476,7 @@ QWeb.addDirective({
         classCode =
           classAttr
             .split(" ")
+            .filter(c => !!c)
             .map(c => `vn.elm.classList.add('${c}')`)
             .join(";") + ";";
       }

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -1464,6 +1464,23 @@ describe("class and style attributes with t-component", () => {
     expect(fixture.innerHTML).toBe(`<div><div class="c b"></div></div>`);
   });
 
+  test("class with extra whitespaces", async () => {
+    env.qweb.addTemplate(
+      "ParentWidget",
+      `<div>
+            <Child class="a  b c   d"/>
+      </div>`
+    );
+    class ParentWidget extends Widget {
+      components = { Child };
+    }
+    env.qweb.addTemplate("Child", `<div/>`);
+    class Child extends Widget {}
+    const widget = new ParentWidget(env);
+    await widget.mount(fixture);
+    expect(fixture.innerHTML).toBe(`<div><div class="a b c d"></div></div>`);
+  });
+
   test("style is properly added on widget root el", async () => {
     env.qweb.addTemplate(
       "ParentWidget",


### PR DESCRIPTION
Crashed due to `DOMTokenList.add(string)` requiring non-empty string.