### PR TITLE
[FIX] qweb: add missing not equals operators

### DIFF
--- a/src/qweb_expressions.ts
+++ b/src/qweb_expressions.ts
@@ -82,7 +82,7 @@ const STATIC_TOKEN_MAP: { [key: string]: TKind } = {
   ")": "RIGHT_PAREN"
 };
 
-const OPERATORS = ".,===,==,+,!,||,&&,>=,>,<=,<,?,-,*,/,%".split(',');
+const OPERATORS = ".,===,==,+,!==,!=,!,||,&&,>=,>,<=,<,?,-,*,/,%".split(',');
 
 type Tokenizer = (expr: string) => Token | false;
 

--- a/tests/qweb_expressions.test.ts
+++ b/tests/qweb_expressions.test.ts
@@ -40,11 +40,13 @@ describe("tokenizer", () => {
   });
 
   test("various operators", () => {
-    expect(tokenize(">= <= < >")).toEqual([
+    expect(tokenize(">= <= < > !== !=")).toEqual([
       { type: "OPERATOR", value: ">=" },
       { type: "OPERATOR", value: "<=" },
       { type: "OPERATOR", value: "<" },
       { type: "OPERATOR", value: ">" },
+      { type: "OPERATOR", value: "!==" },
+      { type: "OPERATOR", value: "!=" },
     ]);
   });
 


### PR DESCRIPTION
Implement "!=" and "!==" operator support in QWeb.