### PR TITLE
[FIX] store: getter as 3rd argument of useStore

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -84,7 +84,7 @@ const isStrictEqual = (a, b) => a === b;
 export function useStore(selector, options: SelectorOptions = {}): any {
   const component: Component<any, any> = Component.current!;
   const store = options.store || (component.env.store as Store);
-  let result = selector(store.state, component.props);
+  let result = selector(store.state, component.props, store.getters);
   const hashFn = store.observer.deepRevNumber.bind(store.observer);
   let revNumber = hashFn(result) || result;
   const isEqual = options.isEqual || isStrictEqual;
@@ -94,7 +94,7 @@ export function useStore(selector, options: SelectorOptions = {}): any {
   const updateFunctions = store.updateFunctions[component.__owl__.id];
   updateFunctions.push(function(): boolean {
     const oldResult = result;
-    result = selector(store!.state, component.props);
+    result = selector(store!.state, component.props, store.getters);
     const newRevNumber = hashFn(result);
     if (
       (newRevNumber > 0 && revNumber !== newRevNumber) ||
@@ -118,7 +118,7 @@ export function useStore(selector, options: SelectorOptions = {}): any {
   onWillUpdateProps(props => {
     // FIXME: only do that if not keepalive + do it in destroy in that case
     delete store.updateFunctions[component.__owl__.id];
-    result = selector(store.state, props);
+    result = selector(store.state, props, store.getters);
   });
   return new Proxy(result, {
     get(target, k) {

--- a/tests/store_hooks.test.ts
+++ b/tests/store_hooks.test.ts
@@ -304,6 +304,38 @@ describe("connecting a component to store", () => {
     expect(fixture.innerHTML).toBe("<div><span>jupiler</span><span>hoegaarden</span></div>");
   });
 
+  test("useStore receives getters as third argument", async () => {
+    const state = { todos: [{ id: 1, text: "jupiler" }] };
+    const getters = {
+      text({ state }, id) {
+        return state.todos.find(todo => todo.id === id).text;
+      }
+    };
+    const store = new Store({ state, getters });
+
+    class TodoItem extends Component<any, any> {
+      static template = xml`<span><t t-esc="storeProps.text"/></span>`;
+      storeProps = useStore((state, props, getters) => {
+        return { text: getters.text(props.id), };
+      });
+    }
+
+    class TodoList extends Component<any, any> {
+      static template = xml`
+        <div>
+          <TodoItem t-foreach="todos" t-as="todo" id="todo.id" t-key="todo.id"/>
+        </div>`;
+      static components = { TodoItem };
+      todos = useStore(state => state.todos);
+    }
+
+    (<any>env).store = store;
+    const app = new TodoList(env);
+
+    await app.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div><span>jupiler</span></div>");
+  });
+
   test("can call useGetters to receive store getters", async () => {
     const state = {
       importantID: 1,


### PR DESCRIPTION
Revision on 895fe7c60fa6d84e4e95d09e9d5e229a1103548c

Commit above turned old static method `mapStoreToProps`
into the hook `useStore`. For some reasons, it removed
`getters` as the 3rd argument of the selector, which this
commit re-introduced.