### PR TITLE
[FIX] component: do not validate props twice

### DIFF
--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -412,9 +412,6 @@ QWeb.addDirective({
     ctx.addLine(
       `if (!W${componentID}) {throw new Error('Cannot find the definition of component "' + componentKey${componentID} + '"')}`
     );
-    if (QWeb.dev) {
-      ctx.addLine(`utils.validateProps(W${componentID}, props${componentID})`);
-    }
     ctx.addLine(`w${componentID} = new W${componentID}(parent, props${componentID});`);
     ctx.addLine(`parent.__owl__.cmap[${templateId}] = w${componentID}.__owl__.id;`);
 

--- a/tests/component/__snapshots__/props_validation.test.ts.snap
+++ b/tests/component/__snapshots__/props_validation.test.ts.snap
@@ -33,7 +33,6 @@ exports[`props validation props are validated in dev mode (code snapshot) 1`] = 
         let componentKey4 = \`Child\`;
         let W4 = context.constructor.components[componentKey4] || QWeb.components[componentKey4]|| context['Child'];
         if (!W4) {throw new Error('Cannot find the definition of component \\"' + componentKey4 + '\\"')}
-        utils.validateProps(W4, props4)
         w4 = new W4(parent, props4);
         parent.__owl__.cmap[templateId4] = w4.__owl__.id;
         def3 = w4.__prepare(extra.fiber, undefined, undefined);

--- a/tests/component/props_validation.test.ts
+++ b/tests/component/props_validation.test.ts
@@ -352,4 +352,22 @@ describe("default props", () => {
     expect(w.props.p).toBe(4);
     expect(fixture.innerHTML).toMatchSnapshot();
   });
+
+  test("can set default required boolean values", async () => {
+    class TestWidget extends Widget {
+      static props = ["p", "q"];
+      static defaultProps = { p: true, q: false };
+      static template = xml`<span><t t-if="props.p">hey</t><t t-if="!props.q">hey</t></span>`;
+    }
+
+    class App extends Widget {
+        static template = xml`<div><TestWidget/></div>`;
+        static components = { TestWidget };
+    }
+
+    const w = new App(env, {});
+    await w.mount(fixture);
+    expect(fixture.innerHTML).toBe('<div><span>heyhey</span></div>')
+  });
+
 });


### PR DESCRIPTION
it is not useful to do it in the component directive, especially since
it is done in the constructor, and the default props are not applied.

closes #379