### PR TITLE
[REF] component: mount: remove renderBeforeRemount option

### DIFF
--- a/doc/reference/component.md
+++ b/doc/reference/component.md
@@ -237,16 +237,15 @@ component.
 
 We explain here all the public methods of the `Component` class.
 
-- **`mount(target, renderBeforeRemount=false)`** (async): this is the main way a
+- **`mount(target)`** (async): this is the main way a
   component is added to the DOM: the root component is mounted to a target
   HTMLElement. Obviously, this is asynchronous, since each children need to be
   created as well. Most applications will need to call `mount` exactly once, on
   the root component.
 
-  The `renderBeforeRemount` argument is useful when a component is unmounted and remounted.
-  In that case, we may want to rerender the component _before_ it is remounted, if
-  we know that its state (or something in the environment, or ...) has changed.
-  In that case, it should simply set to `true`.
+  Note that if a component is mounted, unmounted and remounted, it will be
+  automatically re-rendered to ensure that changes in its state (or something
+  in the environment, or in the store, or ...) will be taken into account.
 
 - **`unmount()`**: in case a component needs to be detached/removed from the DOM, this
   method can be used. Most applications should not call `unmount`, this is more

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -276,17 +276,10 @@ export class Component<T extends Env, Props extends {}> {
    *
    * Note that a component can be mounted an unmounted several times
    */
-  async mount(target: HTMLElement, renderBeforeRemount: boolean = false): Promise<void> {
+  async mount(target: HTMLElement): Promise<void> {
     const __owl__ = this.__owl__;
     if (__owl__.isMounted) {
       return Promise.resolve();
-    }
-    if (__owl__.vnode && !renderBeforeRemount) {
-      target.appendChild(this.el!);
-      if (document.body.contains(target)) {
-        this.__callMounted();
-      }
-      return;
     }
     if (!(target instanceof HTMLElement)) {
       let message = `Component '${

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -4911,10 +4911,8 @@ describe("unmounting and remounting", () => {
     expect(fixture.innerHTML).toBe("<div>1</div>");
     widget.unmount();
     expect(fixture.innerHTML).toBe("");
+    await nextTick(); // wait for changes to be detected before remounting
     await widget.mount(fixture);
-    expect(fixture.innerHTML).toBe("<div>1</div>");
-    widget.unmount();
-    await widget.mount(fixture, true);
     expect(fixture.innerHTML).toBe("<div>3</div>");
   });
 });


### PR DESCRIPTION
Re-render the component all the time before remounting it, which
seems safer anyway.

In the test, we had to add a nextTick to wait for the changes to
be notified (before, we waited thanks to the additional call to
mount). If we don't do the nextTick, mount is called, and render
is called right after (before the promise returned by mount is
resolved). This scenario doesn't work right now (see #441).

Closes #381