### PR TITLE
[FIX] package, vdom: condition always true, TS 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sass": "^1.16.1",
     "source-map-support": "^0.5.10",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.6.4",
+    "typescript": "^3.7.2",
     "uglify-es": "^3.3.9"
   },
   "jest": {

--- a/src/vdom/html_to_vdom.ts
+++ b/src/vdom/html_to_vdom.ts
@@ -20,10 +20,8 @@ function htmlToVNode(node: ChildNode): VNode {
     attrs[attr.name] = attr.textContent;
   }
   const children: VNode[] = [];
-  if (node.hasChildNodes) {
-    for (let c of node.childNodes) {
-      children.push(htmlToVNode(c));
-    }
+  for (let c of node.childNodes) {
+    children.push(htmlToVNode(c));
   }
   return h((node as Element).tagName, { attrs }, children);
 }


### PR DESCRIPTION
Before this commit, a condition deemed always true made
the building crash. The happened with TypeScript == 3.7.2

After this commit, the required typescript version has been
changed, as well as the incriminated true condition