### PR TITLE
[FIX] component: reset fiber to null before patching

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -622,7 +622,7 @@ export class Component<T extends Env, Props extends {}> {
    * Only called by qweb t-component directive
    */
   __mount(fiber: Fiber, elm: HTMLElement): VNode {
-    if (fiber !== this.__owl__.currentFiber) {
+    if (fiber !== this.__owl__.currentFiber && this.__owl__.currentFiber) {
       fiber = this.__owl__.currentFiber!; // TODO: check if we can remove fiber arg
     }
     const vnode = fiber.vnode!;
@@ -631,7 +631,6 @@ export class Component<T extends Env, Props extends {}> {
       (<any>vnode).data.class = Object.assign((<any>vnode).data.class || {}, __owl__.classObj);
     }
     __owl__.vnode = patch(elm, vnode);
-    __owl__.currentFiber = null;
     if (__owl__.parent!.__owl__.isMounted && !__owl__.isMounted) {
       this.__callMounted();
     }

--- a/src/component/fiber.ts
+++ b/src/component/fiber.ts
@@ -193,6 +193,7 @@ export class Fiber {
     const patchQueue: Fiber[] = [];
     const doWork: (Fiber) => Fiber | null = function(f) {
       if (f.shouldPatch) {
+        f.component.__owl__.currentFiber = null;
         patchQueue.push(f);
         return f.child;
       }
@@ -211,7 +212,6 @@ export class Fiber {
       const fiber = patchQueue[i];
       component = fiber.component;
       component.__patch(fiber.vnode);
-      component.__owl__.currentFiber = null;
     }
     for (let i = patchLen - 1; i >= 0; i--) {
       component = patchQueue[i].component;

--- a/src/context.ts
+++ b/src/context.ts
@@ -139,10 +139,10 @@ export function useContextWithCB(ctx: Context, component: Component<any, any>, m
     }
   });
   const __destroy = component.__destroy;
-  component.__destroy = (parent) => {
+  component.__destroy = parent => {
     ctx.off("update", component);
     delete mapping[id];
     __destroy.call(component, parent);
-  }
+  };
   return ctx.state;
 }


### PR DESCRIPTION
Before this commit, some components were reset, some other were not,
while patching the UI.  With this commit, we do reset the currentFiber
to null before starting the patching process.

This solves some weird issues such as the one shown in the test.

part of #473