### PR TITLE
[FIX] qweb: cascading t-call and t-raw="0"

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -28,9 +28,12 @@ QWeb.utils.getFragment = function(str: string): DocumentFragment {
 QWeb.utils.htmlToVDOM = htmlToVDOM;
 
 function compileValueNode(value: any, node: Element, qweb: QWeb, ctx: CompilationContext) {
-  if (value === "0" && ctx.caller) {
-    qweb._compileNode(ctx.caller, ctx);
-    return;
+  if (value === "0") {
+    const caller = ctx.getCaller();
+    if (caller) {
+      qweb._compileNode(caller, ctx.getInliningContext());
+      return;
+    }
   }
 
   if (value.xml instanceof NodeList && !value.id) {

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -910,6 +910,46 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
 }"
 `;
 
+exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
+"function anonymous(context,extra
+) {
+    var h = this.h;
+    let c1 = [], p1 = {key:1};
+    var vn1 = h('div', p1, c1);
+    let c5 = [], p5 = {key:5};
+    var vn5 = h('div', p5, c5);
+    c1.push(vn5);
+    let c8 = [], p8 = {key:8};
+    var vn8 = h('div', p8, c8);
+    c5.push(vn8);
+    let c11 = [], p11 = {key:11};
+    var vn11 = h('div', p11, c11);
+    c8.push(vn11);
+    let c12 = [], p12 = {key:12};
+    var vn12 = h('span', p12, c12);
+    c11.push(vn12);
+    c12.push({text: \`cascade 2\`});
+    let c13 = [], p13 = {key:13};
+    var vn13 = h('span', p13, c13);
+    c11.push(vn13);
+    c13.push({text: \`cascade 1\`});
+    let c14 = [], p14 = {key:14};
+    var vn14 = h('span', p14, c14);
+    c11.push(vn14);
+    c14.push({text: \`cascade 0\`});
+    let c15 = [], p15 = {key:15};
+    var vn15 = h('span', p15, c15);
+    c11.push(vn15);
+    c15.push({text: \`hey\`});
+    c11.push({text: \` \`});
+    let c16 = [], p16 = {key:16};
+    var vn16 = h('span', p16, c16);
+    c11.push(vn16);
+    c16.push({text: \`yay\`});
+    return vn1;
+}"
+`;
+
 exports[`t-call (template calling inherit context 1`] = `
 "function anonymous(context,extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -673,6 +673,39 @@ describe("t-call (template calling", () => {
     expect(renderToString(qweb, "main")).toBe(expected);
   });
 
+  test("cascading t-call t-raw='0'", () => {
+    qweb.addTemplates(`
+        <templates>
+            <div t-name="finalTemplate">
+              <span>cascade 2</span>
+              <t t-raw="0"/>
+            </div>
+
+            <div t-name="subSubTemplate">
+              <t t-call="finalTemplate">
+                <span>cascade 1</span>
+                <t t-raw="0"/>
+              </t>
+            </div>
+
+            <div t-name="SubTemplate">
+              <t t-call="subSubTemplate">
+                <span>cascade 0</span>
+                <t t-raw="0"/>
+              </t>
+            </div>
+
+            <div t-name="main">
+              <t t-call="SubTemplate">
+                <span>hey</span> <span>yay</span>
+              </t>
+            </div>
+        </templates>
+    `);
+    const expected = "<div><div><div><div><span>cascade 2</span><span>cascade 1</span><span>cascade 0</span><span>hey</span> <span>yay</span></div></div></div></div>";
+    expect(renderToString(qweb, "main")).toBe(expected);
+  });
+
   test("recursive template, part 1", () => {
     qweb.addTemplates(`
         <templates>


### PR DESCRIPTION
Have a t-call having a t-raw="0"
that call is made to a template of the same form
i.e. itself as a t-call t-raw="0" structure

Before this commit, there was recursion crash
This was because the caller to which a t-raw="0" referred to
was incorrect. The caller here is the node which makes the t-call.
In particular, the caller was always set to last caller of the context

After this commit, there is no crash and this imbrication
of t-call and t-raw="0" is well rendered.
To sum up, we count the recursive calls to t-raw="0" and fetch
the caller in the context accordingly

closes #510