### PR TITLE
[FIX] qweb: properly handle empty class attribute

### DIFF
--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -650,13 +650,14 @@ export class QWeb extends EventBus {
       if (!name.startsWith("t-") && !(<Element>node).getAttribute("t-attf-" + name)) {
         const attID = ctx.generateID();
         if (name === "class") {
-          let classDef = value
-            .trim()
-            .split(/\s+/)
-            .map(a => `'${a}':true`)
-            .join(",");
-          classObj = `_${ctx.generateID()}`;
-          ctx.addLine(`let ${classObj} = {${classDef}};`);
+          if (value = value.trim()) {
+            let classDef = value
+              .split(/\s+/)
+              .map(a => `'${a}':true`)
+              .join(",");
+            classObj = `_${ctx.generateID()}`;
+            ctx.addLine(`let ${classObj} = {${classDef}};`);
+          }
         } else {
           ctx.addLine(`var _${attID} = '${value}';`);
           if (!name.match(/^[a-zA-Z]+$/)) {

--- a/src/vdom/modules.ts
+++ b/src/vdom/modules.ts
@@ -219,7 +219,7 @@ function updateClass(oldVnode: VNode, vnode: VNode): void {
   elm = vnode.elm as Element;
 
   for (name in oldClass) {
-    if (!klass[name]) {
+    if (name && !klass[name]) {
       elm.classList.remove(name);
     }
   }

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -1614,6 +1614,19 @@ describe("class and style attributes with t-component", () => {
     expect(fixture.innerHTML).toBe(`<div><div class="c a b"></div></div>`);
   });
 
+  test("empty class attribute is not added on widget root el", async () => {
+    class Child extends Component<any, any> {
+      static template = xml`<span/>`;
+    }
+    class Parent extends Component<any, any> {
+      static template = xml`<div><Child class=""/></div>`;
+      static components = { Child };
+    }
+    const widget = new Parent();
+    await widget.mount(fixture);
+    expect(fixture.innerHTML).toBe(`<div><span></span></div>`);
+  });
+
   test("t-att-class is properly added/removed on widget root el", async () => {
     class Child extends Widget {
       static template = xml`<div class="c"/>`;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -44,6 +44,30 @@ exports[`attributes dynamic attributes 1`] = `
 }"
 `;
 
+exports[`attributes dynamic class attribute 1`] = `
+"function anonymous(context,extra
+) {
+    let utils = this.constructor.utils;
+    var h = this.h;
+    let _1 = utils.toObj(context['c']);
+    let c2 = [], p2 = {key:2,class:_1};
+    var vn2 = h('div', p2, c2);
+    return vn2;
+}"
+`;
+
+exports[`attributes dynamic empty class attribute 1`] = `
+"function anonymous(context,extra
+) {
+    let utils = this.constructor.utils;
+    var h = this.h;
+    let _1 = utils.toObj(context['c']);
+    let c2 = [], p2 = {key:2,class:_1};
+    var vn2 = h('div', p2, c2);
+    return vn2;
+}"
+`;
+
 exports[`attributes dynamic formatted attributes with a dash 1`] = `
 "function anonymous(context,extra
 ) {
@@ -784,6 +808,29 @@ exports[`special cases for some boolean html attributes/properties various boole
     var vn17 = h('button', p17, c17);
     c1.push(vn17);
     return vn1;
+}"
+`;
+
+exports[`static templates div with a class attribute 1`] = `
+"function anonymous(context,extra
+) {
+    var h = this.h;
+    let _2 = {'abc':true};
+    let c3 = [], p3 = {key:3,class:_2};
+    var vn3 = h('div', p3, c3);
+    c3.push({text: \`word\`});
+    return vn3;
+}"
+`;
+
+exports[`static templates div with a empty class attribute 1`] = `
+"function anonymous(context,extra
+) {
+    var h = this.h;
+    let c2 = [], p2 = {key:2};
+    var vn2 = h('div', p2, c2);
+    c2.push({text: \`word\`});
+    return vn2;
 }"
 `;
 

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -46,6 +46,16 @@ describe("static templates", () => {
     expect(renderToString(qweb, "test")).toBe("<div>word</div>");
   });
 
+  test("div with a class attribute", () => {
+    qweb.addTemplate("test", `<div class="abc">word</div>`);
+    expect(renderToString(qweb, "test")).toBe(`<div class="abc">word</div>`);
+  });
+
+  test("div with a empty class attribute", () => {
+    qweb.addTemplate("test", `<div class="">word</div>`);
+    expect(renderToString(qweb, "test")).toBe(`<div>word</div>`);
+  });
+
   test("div with a span child node", () => {
     qweb.addTemplate("test", "<div><span>word</span></div>");
     expect(renderToString(qweb, "test")).toBe("<div><span>word</span></div>");
@@ -430,6 +440,18 @@ describe("attributes", () => {
     qweb.addTemplate("test", `<div t-att-foo="'bar'"/>`);
     const result = renderToString(qweb, "test");
     expect(result).toBe(`<div foo="bar"></div>`);
+  });
+
+  test("dynamic class attribute", () => {
+    qweb.addTemplate("test", `<div t-att-class="c"/>`);
+    const result = renderToString(qweb, "test", { c: "abc" });
+    expect(result).toBe(`<div class="abc"></div>`);
+  });
+
+  test("dynamic empty class attribute", () => {
+    qweb.addTemplate("test", `<div t-att-class="c"/>`);
+    const result = renderToString(qweb, "test", { c: "" });
+    expect(result).toBe(`<div></div>`);
   });
 
   test("dynamic attribute with a dash", () => {


### PR DESCRIPTION
The classList.add method actually crashes when given an empty string (or
a string with just white spaces).

closes #530