### PR TITLE
[FIX] slot: nested t-slot multiple levels

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -86,7 +86,6 @@ interface Internal<T extends Env, Props> {
   willUpdatePropsCB: Function | null;
   classObj: { [key: string]: boolean } | null;
   refs: { [key: string]: Component<T, any> | HTMLElement | undefined } | null;
-  contextualParentID: number;
 }
 
 export const portalSymbol = Symbol("portal"); // FIXME
@@ -201,7 +200,6 @@ export class Component<T extends Env, Props extends {}> {
       refs: null,
       scope: null,
       vars: null,
-      contextualParentID: id,
     };
   }
 

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -86,6 +86,7 @@ interface Internal<T extends Env, Props> {
   willUpdatePropsCB: Function | null;
   classObj: { [key: string]: boolean } | null;
   refs: { [key: string]: Component<T, any> | HTMLElement | undefined } | null;
+  contextualParentID: number;
 }
 
 export const portalSymbol = Symbol("portal"); // FIXME
@@ -199,7 +200,8 @@ export class Component<T extends Env, Props extends {}> {
       classObj: null,
       refs: null,
       scope: null,
-      vars: null
+      vars: null,
+      contextualParentID: id,
     };
   }
 

--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -405,6 +405,9 @@ QWeb.addDirective({
       `if (!W${componentID}) {throw new Error('Cannot find the definition of component "' + componentKey${componentID} + '"')}`
     );
     ctx.addLine(`w${componentID} = new W${componentID}(parent, props${componentID});`);
+    if (ctx.currentComponent) {
+      ctx.addLine(`w${componentID}.__owl__.contextualParentID = ${ctx.currentComponent.__owl__.id};`);
+    }
     if (transition) {
       ctx.addLine(`const __patch${componentID} = w${componentID}.__patch;`);
       ctx.addLine(

--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -405,9 +405,6 @@ QWeb.addDirective({
       `if (!W${componentID}) {throw new Error('Cannot find the definition of component "' + componentKey${componentID} + '"')}`
     );
     ctx.addLine(`w${componentID} = new W${componentID}(parent, props${componentID});`);
-    if (ctx.currentComponent) {
-      ctx.addLine(`w${componentID}.__owl__.contextualParentID = ${ctx.currentComponent.__owl__.id};`);
-    }
     if (transition) {
       ctx.addLine(`const __patch${componentID} = w${componentID}.__patch;`);
       ctx.addLine(
@@ -428,7 +425,10 @@ QWeb.addDirective({
           const key = slotNode.getAttribute("t-set")!;
           slotNode.removeAttribute("t-set");
           const slotFn = qweb._compile(`slot_${key}_template`, slotNode, ctx);
-          QWeb.slots[`${slotId}_${key}`] = slotFn;
+          QWeb.slots[`${slotId}_${key}`] = function ctxSlotFn(context, extra) {
+            context = ctx.currentComponent ? ctx.currentComponent : context;
+            return slotFn.call(this, context, extra);
+          };
         }
       }
       if (clone.childNodes.length) {
@@ -437,7 +437,10 @@ QWeb.addDirective({
           t.appendChild(child);
         }
         const slotFn = qweb._compile(`slot_default_template`, t, ctx);
-        QWeb.slots[`${slotId}_default`] = slotFn;
+        QWeb.slots[`${slotId}_default`] = function ctxSlotFn(context, extra) {
+          context = ctx.currentComponent ? ctx.currentComponent : context;
+          return slotFn.call(this, context, extra);
+        };
       }
     }
 

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -18,7 +18,6 @@ export class CompilationContext {
   caller: Element | undefined;
   shouldDefineOwner: boolean = false;
   shouldDefineParent: boolean = false;
-  shouldDefineContextualParent: boolean = false;
   shouldDefineQWeb: boolean = false;
   shouldDefineUtils: boolean = false;
   shouldDefineRefs: boolean = false;
@@ -91,15 +90,6 @@ export class CompilationContext {
     }
     if (this.shouldDefineRefs) {
       this.code.unshift("    context.__owl__.refs = context.__owl__.refs || {};");
-    }
-    if (this.shouldDefineContextualParent) {
-      this.code.unshift(`
-    const contextualParentID = context.__owl__.contextualParentID;
-    let ctxParent = context;
-    while (ctxParent.__owl__.id !== contextualParentID) {
-      ctxParent = ctxParent.__owl__.parent;
-    }`
-      );
     }
     if (this.shouldDefineOwner) {
       // this is necessary to prevent some directives (t-forach for ex) to

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -18,6 +18,7 @@ export class CompilationContext {
   caller: Element | undefined;
   shouldDefineOwner: boolean = false;
   shouldDefineParent: boolean = false;
+  shouldDefineContextualParent: boolean = false;
   shouldDefineQWeb: boolean = false;
   shouldDefineUtils: boolean = false;
   shouldDefineRefs: boolean = false;
@@ -34,6 +35,7 @@ export class CompilationContext {
   templates: { [key: string]: boolean } = {};
   callingLevel: number = 0;
   inliningLevel: number = 0;
+  currentComponent: any = null;
 
   constructor(name?: string) {
     this.rootContext = this;
@@ -89,6 +91,15 @@ export class CompilationContext {
     }
     if (this.shouldDefineRefs) {
       this.code.unshift("    context.__owl__.refs = context.__owl__.refs || {};");
+    }
+    if (this.shouldDefineContextualParent) {
+      this.code.unshift(`
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }`
+      );
     }
     if (this.shouldDefineOwner) {
       // this is necessary to prevent some directives (t-forach for ex) to

--- a/src/qweb/extensions.ts
+++ b/src/qweb/extensions.ts
@@ -198,7 +198,6 @@ QWeb.addDirective({
   atNodeEncounter({ ctx, value }): boolean {
     const slotKey = ctx.generateID();
     ctx.rootContext.shouldDefineOwner = true;
-    ctx.rootContext.shouldDefineContextualParent = true;
     ctx.addLine(
       `const slot${slotKey} = this.constructor.slots[context.__owl__.slotId + '_' + '${value}'];`
     );
@@ -215,7 +214,7 @@ QWeb.addDirective({
     // parent fiber instead.
     const vars = ctx.allowMultipleRoots ? "extra.fiber.parent.vars" : "extra.fiber.vars";
     ctx.addLine(
-      `slot${slotKey}.call(this, ctxParent, Object.assign({}, extra, {parentNode: ${parentNode}, parent: extra.parent || owner, vars: ${vars}}));`
+      `slot${slotKey}.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: ${parentNode}, parent: extra.parent || owner, vars: ${vars}}));`
     );
     if (!ctx.parentNode) {
       ctx.addLine(`utils.defineProxy(result, ${parentNode}[0]);`);

--- a/src/qweb/extensions.ts
+++ b/src/qweb/extensions.ts
@@ -198,6 +198,7 @@ QWeb.addDirective({
   atNodeEncounter({ ctx, value }): boolean {
     const slotKey = ctx.generateID();
     ctx.rootContext.shouldDefineOwner = true;
+    ctx.rootContext.shouldDefineContextualParent = true;
     ctx.addLine(
       `const slot${slotKey} = this.constructor.slots[context.__owl__.slotId + '_' + '${value}'];`
     );
@@ -214,7 +215,7 @@ QWeb.addDirective({
     // parent fiber instead.
     const vars = ctx.allowMultipleRoots ? "extra.fiber.parent.vars" : "extra.fiber.vars";
     ctx.addLine(
-      `slot${slotKey}.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: ${parentNode}, parent: extra.parent || owner, vars: ${vars}}));`
+      `slot${slotKey}.call(this, ctxParent, Object.assign({}, extra, {parentNode: ${parentNode}, parent: extra.parent || owner, vars: ${vars}}));`
     );
     if (!ctx.parentNode) {
       ctx.addLine(`utils.defineProxy(result, ${parentNode}[0]);`);

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -260,7 +260,7 @@ export class QWeb extends EventBus {
     const template = {
       elem,
       fn: function(this: QWeb, context, extra) {
-        const compiledFunction = this._compile(name, elem);
+        const compiledFunction = this._compile(name, elem, undefined, context);
         template.fn = compiledFunction;
         return compiledFunction.call(this, context, extra);
       }
@@ -353,9 +353,11 @@ export class QWeb extends EventBus {
     });
   }
 
-  _compile(name: string, elem: Element, parentContext?: CompilationContext): CompiledTemplate {
+  _compile(name: string, elem: Element, parentContext?: CompilationContext, currentComponent?: any): CompiledTemplate {
     const isDebug = elem.attributes.hasOwnProperty("t-debug");
     const ctx = new CompilationContext(name);
+    ctx.currentComponent = currentComponent;
+
     if (elem.tagName !== "t") {
       ctx.shouldDefineResult = false;
     }
@@ -366,6 +368,7 @@ export class QWeb extends EventBus {
       ctx.allowMultipleRoots = true;
       ctx.hasParentWidget = true;
       ctx.shouldDefineResult = false;
+      ctx.currentComponent = currentComponent || parentContext.currentComponent;
       ctx.addLine(`let c${ctx.parentNode} = extra.parentNode;`);
 
       for (let v in parentContext.variables) {

--- a/tests/__snapshots__/animations.test.ts.snap
+++ b/tests/__snapshots__/animations.test.ts.snap
@@ -27,6 +27,7 @@ exports[`animations t-transition combined with component 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 3;
         const __patch2 = w2.__patch;
         w2.__patch = fiber => {__patch2.call(w2, fiber); if(!w2.__owl__.transitionInserted){w2.__owl__.transitionInserted = true;utils.transitionInsert(w2.__owl__.vnode, 'chimay');}};
         parent.__owl__.cmap[k3] = w2.__owl__.id;
@@ -72,6 +73,7 @@ exports[`animations t-transition combined with t-component and t-if 1`] = `
             let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
             if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
             w2 = new W2(parent, props2);
+            w2.__owl__.contextualParentID = 5;
             const __patch2 = w2.__patch;
             w2.__patch = fiber => {__patch2.call(w2, fiber); if(!w2.__owl__.transitionInserted){w2.__owl__.transitionInserted = true;utils.transitionInsert(w2.__owl__.vnode, 'chimay');}};
             parent.__owl__.cmap[k3] = w2.__owl__.id;
@@ -118,6 +120,7 @@ exports[`animations t-transition combined with t-component, remove and re-add be
             let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
             if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
             w2 = new W2(parent, props2);
+            w2.__owl__.contextualParentID = 8;
             const __patch2 = w2.__patch;
             w2.__patch = fiber => {__patch2.call(w2, fiber); if(!w2.__owl__.transitionInserted){w2.__owl__.transitionInserted = true;utils.transitionInsert(w2.__owl__.vnode, 'chimay');}};
             parent.__owl__.cmap[k3] = w2.__owl__.id;

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -56,7 +56,6 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
                 let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| context['Child'];
                 if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
                 w8 = new W8(parent, props8);
-                w8.__owl__.contextualParentID = 20;
                 parent.__owl__.cmap[k9] = w8.__owl__.id;
                 let fiber = w8.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
                 let pvnode = h('dummy', {key: k9, hook: {remove() {},destroy(vn) {w8.destroy();}}});
@@ -99,7 +98,6 @@ exports[`basic widget properties t-key on a component with t-if, and a sibling c
             let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
             if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
             w3 = new W3(parent, props3);
-            w3.__owl__.contextualParentID = 27;
             parent.__owl__.cmap[k4] = w3.__owl__.id;
             let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -125,7 +123,6 @@ exports[`basic widget properties t-key on a component with t-if, and a sibling c
         let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['Child'];
         if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
         w6 = new W6(parent, props6);
-        w6.__owl__.contextualParentID = 27;
         parent.__owl__.cmap[k7] = w6.__owl__.id;
         let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -165,7 +162,6 @@ exports[`class and style attributes with t-component dynamic t-att-style is prop
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 160;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.style = _5;}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -208,7 +204,6 @@ exports[`class and style attributes with t-component t-att-class is properly add
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 153;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){}};});
         let pvnode = h('dummy', {key: k3, hook: {insert(vn) {context.__owl__.refs[ref5] = w2;},remove() {},destroy(vn) {w2.destroy();delete context.__owl__.refs[ref5];}}});
@@ -265,7 +260,6 @@ exports[`class and style attributes with t-component t-att-class is properly add
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 155;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){}};});
         let pvnode = h('dummy', {key: k3, hook: {insert(vn) {context.__owl__.refs[ref5] = w2;},remove() {},destroy(vn) {w2.destroy();delete context.__owl__.refs[ref5];}}});
@@ -334,7 +328,6 @@ exports[`composition sub components with some state rendered in a loop 1`] = `
             let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['ChildWidget'];
             if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
             w6 = new W6(parent, props6);
-            w6.__owl__.contextualParentID = 114;
             parent.__owl__.cmap[k7] = w6.__owl__.id;
             let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -374,7 +367,6 @@ exports[`composition t-component with dynamic value 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 127;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -413,7 +405,6 @@ exports[`composition t-component with dynamic value 2 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 129;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -452,7 +443,6 @@ exports[`dynamic t-props basic use 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 449;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -495,7 +485,6 @@ exports[`other directives with t-component t-on with getter as handler 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
-        w3.__owl__.contextualParentID = 187;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['handler'];if (fn) { fn.call(owner, e); } else { owner.handler; }});}};});
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -534,7 +523,6 @@ exports[`other directives with t-component t-on with handler bound to argument 1
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 168;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, 3, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -573,7 +561,6 @@ exports[`other directives with t-component t-on with handler bound to empty obje
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 174;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -612,7 +599,6 @@ exports[`other directives with t-component t-on with handler bound to empty obje
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 172;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -651,7 +637,6 @@ exports[`other directives with t-component t-on with handler bound to object 1`]
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 170;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {val:3}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -694,7 +679,6 @@ exports[`other directives with t-component t-on with inline statement 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
-        w3.__owl__.contextualParentID = 189;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['state.counter++'];if (fn) { fn.call(owner, e); } else { owner.state.counter++; }});}};});
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -733,7 +717,6 @@ exports[`other directives with t-component t-on with no handler (only modifiers)
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['ComponentA'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 191;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -772,7 +755,6 @@ exports[`other directives with t-component t-on with prevent and self modifiers 
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 184;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}e.preventDefault();if (e.target !== vn.elm) {return}const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -811,7 +793,6 @@ exports[`other directives with t-component t-on with self and prevent modifiers 
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 181;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}if (e.target !== vn.elm) {return}e.preventDefault();const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -850,7 +831,6 @@ exports[`other directives with t-component t-on with self modifier 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 178;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev-1', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv1'];if (fn) { fn.call(owner, e); } else { owner.onEv1; }});vn.elm.addEventListener('ev-2', function (e) {if(!owner.__owl__.isMounted){return}if (e.target !== vn.elm) {return}const fn = owner['onEv2'];if (fn) { fn.call(owner, e); } else { owner.onEv2; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -889,7 +869,6 @@ exports[`other directives with t-component t-on with stop and/or prevent modifie
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 176;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev-1', function (e) {if(!owner.__owl__.isMounted){return}e.stopPropagation();const fn = owner['onEv1'];if (fn) { fn.call(owner, e); } else { owner.onEv1; }});vn.elm.addEventListener('ev-2', function (e) {if(!owner.__owl__.isMounted){return}e.preventDefault();const fn = owner['onEv2'];if (fn) { fn.call(owner, e); } else { owner.onEv2; }});vn.elm.addEventListener('ev-3', function (e) {if(!owner.__owl__.isMounted){return}e.stopPropagation();e.preventDefault();const fn = owner['onEv3'];if (fn) { fn.call(owner, e); } else { owner.onEv3; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -946,7 +925,6 @@ exports[`random stuff/miscellaneous snapshotting compiled code 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
-        w3.__owl__.contextualParentID = 225;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -1002,7 +980,6 @@ exports[`random stuff/miscellaneous t-on with handler bound to dynamic argument 
             let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['Child'];
             if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
             w6 = new W6(parent, props6);
-            w6.__owl__.contextualParentID = 218;
             parent.__owl__.cmap[k7] = w6.__owl__.id;
             let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, arg9, e); } else { owner.onEv; }});}};});
             let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -1292,7 +1269,6 @@ exports[`t-slot directive can define and call slots 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Dialog'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
-        w2.__owl__.contextualParentID = 310;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         w2.__owl__.slotId = 1;
         let fiber = w2.__prepare(extra.fiber, {}, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1309,12 +1285,6 @@ exports[`t-slot directive can define and call slots 2`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
-
-    const contextualParentID = context.__owl__.contextualParentID;
-    let ctxParent = context;
-    while (ctxParent.__owl__.id !== contextualParentID) {
-      ctxParent = ctxParent.__owl__.parent;
-    }
     var h = this.h;
     let c7 = [], p7 = {key:7};
     var vn7 = h('div', p7, c7);
@@ -1323,161 +1293,86 @@ exports[`t-slot directive can define and call slots 2`] = `
     c7.push(vn8);
     const slot9 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
     if (slot9) {
-        slot9.call(this, ctxParent, Object.assign({}, extra, {parentNode: c8, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot9.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c8, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     let c10 = [], p10 = {key:10};
     var vn10 = h('div', p10, c10);
     c7.push(vn10);
     const slot11 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
     if (slot11) {
-        slot11.call(this, ctxParent, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot11.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn7;
 }"
 `;
 
 exports[`t-slot directive can define and call slots 3`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`header\`});
-}"
+"function ctxSlotFn(context, extra) {
+                        context = ctx.currentComponent ? ctx.currentComponent : context;
+                        return slotFn.call(this, context, extra);
+                    }"
 `;
 
 exports[`t-slot directive can define and call slots 4`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c6 = [], p6 = {key:6};
-    var vn6 = h('span', p6, c6);
-    c1.push(vn6);
-    c6.push({text: \`footer\`});
-}"
+"function ctxSlotFn(context, extra) {
+                        context = ctx.currentComponent ? ctx.currentComponent : context;
+                        return slotFn.call(this, context, extra);
+                    }"
 `;
 
 exports[`t-slot directive content is the default slot 1`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`sts rocks\`});
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive default slot work with text nodes 1`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    c1.push({text: \`sts rocks\`});
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive multiple roots are allowed in a default slot 1`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`sts\`});
-    let c6 = [], p6 = {key:6};
-    var vn6 = h('span', p6, c6);
-    c1.push(vn6);
-    c6.push({text: \`rocks\`});
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive multiple roots are allowed in a named slot 1`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`sts\`});
-    let c6 = [], p6 = {key:6};
-    var vn6 = h('span', p6, c6);
-    c1.push(vn6);
-    c6.push({text: \`rocks\`});
-}"
+"function ctxSlotFn(context, extra) {
+                        context = ctx.currentComponent ? ctx.currentComponent : context;
+                        return slotFn.call(this, context, extra);
+                    }"
 `;
 
 exports[`t-slot directive refs are properly bound in slots 1`] = `
-"function anonymous(context,extra
-) {
-    let owner = context;
-    context.__owl__.refs = context.__owl__.refs || {};
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c9 = [], p9 = {key:9,on:{}};
-    var vn9 = h('button', p9, c9);
-    c1.push(vn9);
-    extra.handlers['click' + 9] = extra.handlers['click' + 9] || function (e) {if (!context.__owl__.isMounted){return}const fn = context['doSomething'];if (fn) { fn.call(owner, e); } else { context.doSomething; }};
-    p9.on['click'] = extra.handlers['click' + 9];
-    const ref10 = \`myButton\`;
-    p9.hook = {
-      create: (_, n) => {
-        context.__owl__.refs[ref10] = n.elm;
-      },
-      destroy: () => {
-        delete context.__owl__.refs[ref10];
-      },
-    };
-    c9.push({text: \`do something\`});
-}"
+"function ctxSlotFn(context, extra) {
+                        context = ctx.currentComponent ? ctx.currentComponent : context;
+                        return slotFn.call(this, context, extra);
+                    }"
 `;
 
 exports[`t-slot directive slots are rendered with proper context 1`] = `
-"function anonymous(context,extra
-) {
-    let owner = context;
-    var h = this.h;
-    let c1 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    let c9 = [], p9 = {key:9,on:{}};
-    var vn9 = h('button', p9, c9);
-    c1.push(vn9);
-    extra.handlers['click' + 9] = extra.handlers['click' + 9] || function (e) {if (!context.__owl__.isMounted){return}const fn = context['doSomething'];if (fn) { fn.call(owner, e); } else { context.doSomething; }};
-    p9.on['click'] = extra.handlers['click' + 9];
-    c9.push({text: \`do something\`});
-}"
+"function ctxSlotFn(context, extra) {
+                        context = ctx.currentComponent ? ctx.currentComponent : context;
+                        return slotFn.call(this, context, extra);
+                    }"
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 2 1`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
-
-    const contextualParentID = context.__owl__.contextualParentID;
-    let ctxParent = context;
-    while (ctxParent.__owl__.id !== contextualParentID) {
-      ctxParent = ctxParent.__owl__.parent;
-    }
     var h = this.h;
     var _12 = context['props'].to;
     let c13 = [], p13 = {key:13,attrs:{href: _12}};
     var vn13 = h('a', p13, c13);
     const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot14) {
-        slot14.call(this, ctxParent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot14.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn13;
 }"
@@ -1538,7 +1433,6 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
             let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| context['Link'];
             if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
             w8 = new W8(parent, props8);
-            w8.__owl__.contextualParentID = 314;
             parent.__owl__.cmap[k9] = w8.__owl__.id;
             w8.__owl__.slotId = 1;
             let fiber = w8.__prepare(extra.fiber, Object.assign({}, scope), undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1553,36 +1447,23 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 2 3`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c7 = extra.parentNode;
-    Object.assign(context, extra.fiber.scope);
-    c7.push({text: \`User \`});
-    var _11 = context['user'].name;
-    if (_11 || _11 === 0) {
-        c7.push({text: _11});
-    }
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 3 1`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
-
-    const contextualParentID = context.__owl__.contextualParentID;
-    let ctxParent = context;
-    while (ctxParent.__owl__.id !== contextualParentID) {
-      ctxParent = ctxParent.__owl__.parent;
-    }
     var h = this.h;
     var _12 = context['props'].to;
     let c13 = [], p13 = {key:13,attrs:{href: _12}};
     var vn13 = h('a', p13, c13);
     const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot14) {
-        slot14.call(this, ctxParent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot14.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn13;
 }"
@@ -1644,7 +1525,6 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
             let W9 = context.constructor.components[componentKey9] || QWeb.components[componentKey9]|| context['Link'];
             if (!W9) {throw new Error('Cannot find the definition of component \\"' + componentKey9 + '\\"')}
             w9 = new W9(parent, props9);
-            w9.__owl__.contextualParentID = 317;
             parent.__owl__.cmap[k10] = w9.__owl__.id;
             w9.__owl__.slotId = 1;
             let fiber = w9.__prepare(extra.fiber, Object.assign({}, scope), {_8}, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1659,16 +1539,10 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 3 3`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c7 = extra.parentNode;
-    let _8 = extra.vars._8;
-    Object.assign(context, extra.fiber.scope);
-    if (_8 || _8 === 0) {
-        c7.push({text: _8});
-    }
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
@@ -1699,7 +1573,6 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Link'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
-        w3.__owl__.contextualParentID = 320;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         w3.__owl__.slotId = 1;
         let fiber = w3.__prepare(extra.fiber, {}, {_2}, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1713,16 +1586,10 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
 `;
 
 exports[`t-slot directive slots are rendered with proper context, part 4 2`] = `
-"function anonymous(context,extra
-) {
-    var h = this.h;
-    let c1 = extra.parentNode;
-    let _2 = extra.vars._2;
-    Object.assign(context, extra.fiber.scope);
-    if (_2 || _2 === 0) {
-        c1.push({text: _2});
-    }
-}"
+"function ctxSlotFn(context, extra) {
+                    context = ctx.currentComponent ? ctx.currentComponent : context;
+                    return slotFn.call(this, context, extra);
+                }"
 `;
 
 exports[`t-slot directive template can just return a slot 1`] = `
@@ -1730,19 +1597,13 @@ exports[`t-slot directive template can just return a slot 1`] = `
 ) {
     let utils = this.constructor.utils;
     let owner = context;
-
-    const contextualParentID = context.__owl__.contextualParentID;
-    let ctxParent = context;
-    while (ctxParent.__owl__.id !== contextualParentID) {
-      ctxParent = ctxParent.__owl__.parent;
-    }
     let result;
     var h = this.h;
     const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot8) {
         let children9= []
         result = {}
-        slot8.call(this, ctxParent, Object.assign({}, extra, {parentNode: children9, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot8.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: children9, parent: extra.parent || owner, vars: extra.fiber.vars}));
         utils.defineProxy(result, children9[0]);
     }
     return result;
@@ -1777,7 +1638,6 @@ exports[`top level sub widgets basic use 1`] = `
         let W1 = context.constructor.components[componentKey1] || QWeb.components[componentKey1]|| context['Child'];
         if (!W1) {throw new Error('Cannot find the definition of component \\"' + componentKey1 + '\\"')}
         w1 = new W1(parent, props1);
-        w1.__owl__.contextualParentID = 416;
         parent.__owl__.cmap[k2] = w1.__owl__.id;
         let fiber = w1.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k2, hook: {remove() {},destroy(vn) {w1.destroy();}}});
@@ -1818,7 +1678,6 @@ exports[`top level sub widgets can select a sub widget  1`] = `
             let W1 = context.constructor.components[componentKey1] || QWeb.components[componentKey1]|| context['Child'];
             if (!W1) {throw new Error('Cannot find the definition of component \\"' + componentKey1 + '\\"')}
             w1 = new W1(parent, props1);
-            w1.__owl__.contextualParentID = 420;
             parent.__owl__.cmap[k2] = w1.__owl__.id;
             let fiber = w1.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k2, hook: {remove() {},destroy(vn) {w1.destroy();}}});
@@ -1847,7 +1706,6 @@ exports[`top level sub widgets can select a sub widget  1`] = `
             let W5 = context.constructor.components[componentKey5] || QWeb.components[componentKey5]|| context['OtherChild'];
             if (!W5) {throw new Error('Cannot find the definition of component \\"' + componentKey5 + '\\"')}
             w5 = new W5(parent, props5);
-            w5.__owl__.contextualParentID = 420;
             parent.__owl__.cmap[k6] = w5.__owl__.id;
             let fiber = w5.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k6, hook: {remove() {},destroy(vn) {w5.destroy();}}});

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -56,6 +56,7 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
                 let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| context['Child'];
                 if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
                 w8 = new W8(parent, props8);
+                w8.__owl__.contextualParentID = 20;
                 parent.__owl__.cmap[k9] = w8.__owl__.id;
                 let fiber = w8.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
                 let pvnode = h('dummy', {key: k9, hook: {remove() {},destroy(vn) {w8.destroy();}}});
@@ -98,6 +99,7 @@ exports[`basic widget properties t-key on a component with t-if, and a sibling c
             let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
             if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
             w3 = new W3(parent, props3);
+            w3.__owl__.contextualParentID = 27;
             parent.__owl__.cmap[k4] = w3.__owl__.id;
             let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -123,6 +125,7 @@ exports[`basic widget properties t-key on a component with t-if, and a sibling c
         let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['Child'];
         if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
         w6 = new W6(parent, props6);
+        w6.__owl__.contextualParentID = 27;
         parent.__owl__.cmap[k7] = w6.__owl__.id;
         let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -162,6 +165,7 @@ exports[`class and style attributes with t-component dynamic t-att-style is prop
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 160;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.style = _5;}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -204,6 +208,7 @@ exports[`class and style attributes with t-component t-att-class is properly add
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 153;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){}};});
         let pvnode = h('dummy', {key: k3, hook: {insert(vn) {context.__owl__.refs[ref5] = w2;},remove() {},destroy(vn) {w2.destroy();delete context.__owl__.refs[ref5];}}});
@@ -260,6 +265,7 @@ exports[`class and style attributes with t-component t-att-class is properly add
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 155;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){}};});
         let pvnode = h('dummy', {key: k3, hook: {insert(vn) {context.__owl__.refs[ref5] = w2;},remove() {},destroy(vn) {w2.destroy();delete context.__owl__.refs[ref5];}}});
@@ -328,6 +334,7 @@ exports[`composition sub components with some state rendered in a loop 1`] = `
             let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['ChildWidget'];
             if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
             w6 = new W6(parent, props6);
+            w6.__owl__.contextualParentID = 114;
             parent.__owl__.cmap[k7] = w6.__owl__.id;
             let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -367,6 +374,7 @@ exports[`composition t-component with dynamic value 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 127;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -405,6 +413,7 @@ exports[`composition t-component with dynamic value 2 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 129;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -443,6 +452,7 @@ exports[`dynamic t-props basic use 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 449;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -485,6 +495,7 @@ exports[`other directives with t-component t-on with getter as handler 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
+        w3.__owl__.contextualParentID = 187;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['handler'];if (fn) { fn.call(owner, e); } else { owner.handler; }});}};});
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -523,6 +534,7 @@ exports[`other directives with t-component t-on with handler bound to argument 1
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 168;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, 3, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -561,6 +573,7 @@ exports[`other directives with t-component t-on with handler bound to empty obje
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 174;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -599,6 +612,7 @@ exports[`other directives with t-component t-on with handler bound to empty obje
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 172;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -637,6 +651,7 @@ exports[`other directives with t-component t-on with handler bound to object 1`]
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 170;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, {val:3}, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -679,6 +694,7 @@ exports[`other directives with t-component t-on with inline statement 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
+        w3.__owl__.contextualParentID = 189;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['state.counter++'];if (fn) { fn.call(owner, e); } else { owner.state.counter++; }});}};});
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -717,6 +733,7 @@ exports[`other directives with t-component t-on with no handler (only modifiers)
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['ComponentA'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 191;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -755,6 +772,7 @@ exports[`other directives with t-component t-on with prevent and self modifiers 
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 184;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}e.preventDefault();if (e.target !== vn.elm) {return}const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -793,6 +811,7 @@ exports[`other directives with t-component t-on with self and prevent modifiers 
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 181;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}if (e.target !== vn.elm) {return}e.preventDefault();const fn = owner['onEv'];if (fn) { fn.call(owner, e); } else { owner.onEv; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -831,6 +850,7 @@ exports[`other directives with t-component t-on with self modifier 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 178;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev-1', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv1'];if (fn) { fn.call(owner, e); } else { owner.onEv1; }});vn.elm.addEventListener('ev-2', function (e) {if(!owner.__owl__.isMounted){return}if (e.target !== vn.elm) {return}const fn = owner['onEv2'];if (fn) { fn.call(owner, e); } else { owner.onEv2; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -869,6 +889,7 @@ exports[`other directives with t-component t-on with stop and/or prevent modifie
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 176;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev-1', function (e) {if(!owner.__owl__.isMounted){return}e.stopPropagation();const fn = owner['onEv1'];if (fn) { fn.call(owner, e); } else { owner.onEv1; }});vn.elm.addEventListener('ev-2', function (e) {if(!owner.__owl__.isMounted){return}e.preventDefault();const fn = owner['onEv2'];if (fn) { fn.call(owner, e); } else { owner.onEv2; }});vn.elm.addEventListener('ev-3', function (e) {if(!owner.__owl__.isMounted){return}e.stopPropagation();e.preventDefault();const fn = owner['onEv3'];if (fn) { fn.call(owner, e); } else { owner.onEv3; }});}};});
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
@@ -925,6 +946,7 @@ exports[`random stuff/miscellaneous snapshotting compiled code 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['child'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
+        w3.__owl__.contextualParentID = 225;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         let fiber = w3.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
@@ -980,6 +1002,7 @@ exports[`random stuff/miscellaneous t-on with handler bound to dynamic argument 
             let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['Child'];
             if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
             w6 = new W6(parent, props6);
+            w6.__owl__.contextualParentID = 218;
             parent.__owl__.cmap[k7] = w6.__owl__.id;
             let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if(!owner.__owl__.isMounted){return}const fn = owner['onEv'];if (fn) { fn.call(owner, arg9, e); } else { owner.onEv; }});}};});
             let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
@@ -1269,6 +1292,7 @@ exports[`t-slot directive can define and call slots 1`] = `
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Dialog'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 310;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         w2.__owl__.slotId = 1;
         let fiber = w2.__prepare(extra.fiber, {}, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1285,6 +1309,12 @@ exports[`t-slot directive can define and call slots 2`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
+
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }
     var h = this.h;
     let c7 = [], p7 = {key:7};
     var vn7 = h('div', p7, c7);
@@ -1293,14 +1323,14 @@ exports[`t-slot directive can define and call slots 2`] = `
     c7.push(vn8);
     const slot9 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
     if (slot9) {
-        slot9.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c8, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot9.call(this, ctxParent, Object.assign({}, extra, {parentNode: c8, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     let c10 = [], p10 = {key:10};
     var vn10 = h('div', p10, c10);
     c7.push(vn10);
     const slot11 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
     if (slot11) {
-        slot11.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot11.call(this, ctxParent, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn7;
 }"
@@ -1435,13 +1465,19 @@ exports[`t-slot directive slots are rendered with proper context, part 2 1`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
+
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }
     var h = this.h;
     var _12 = context['props'].to;
     let c13 = [], p13 = {key:13,attrs:{href: _12}};
     var vn13 = h('a', p13, c13);
     const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot14) {
-        slot14.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot14.call(this, ctxParent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn13;
 }"
@@ -1502,6 +1538,7 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
             let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| context['Link'];
             if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
             w8 = new W8(parent, props8);
+            w8.__owl__.contextualParentID = 314;
             parent.__owl__.cmap[k9] = w8.__owl__.id;
             w8.__owl__.slotId = 1;
             let fiber = w8.__prepare(extra.fiber, Object.assign({}, scope), undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1533,13 +1570,19 @@ exports[`t-slot directive slots are rendered with proper context, part 3 1`] = `
 "function anonymous(context,extra
 ) {
     let owner = context;
+
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }
     var h = this.h;
     var _12 = context['props'].to;
     let c13 = [], p13 = {key:13,attrs:{href: _12}};
     var vn13 = h('a', p13, c13);
     const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot14) {
-        slot14.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot14.call(this, ctxParent, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn13;
 }"
@@ -1601,6 +1644,7 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
             let W9 = context.constructor.components[componentKey9] || QWeb.components[componentKey9]|| context['Link'];
             if (!W9) {throw new Error('Cannot find the definition of component \\"' + componentKey9 + '\\"')}
             w9 = new W9(parent, props9);
+            w9.__owl__.contextualParentID = 317;
             parent.__owl__.cmap[k10] = w9.__owl__.id;
             w9.__owl__.slotId = 1;
             let fiber = w9.__prepare(extra.fiber, Object.assign({}, scope), {_8}, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1655,6 +1699,7 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
         let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| context['Link'];
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
+        w3.__owl__.contextualParentID = 320;
         parent.__owl__.cmap[k4] = w3.__owl__.id;
         w3.__owl__.slotId = 1;
         let fiber = w3.__prepare(extra.fiber, {}, {_2}, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
@@ -1685,13 +1730,19 @@ exports[`t-slot directive template can just return a slot 1`] = `
 ) {
     let utils = this.constructor.utils;
     let owner = context;
+
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }
     let result;
     var h = this.h;
     const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot8) {
         let children9= []
         result = {}
-        slot8.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: children9, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot8.call(this, ctxParent, Object.assign({}, extra, {parentNode: children9, parent: extra.parent || owner, vars: extra.fiber.vars}));
         utils.defineProxy(result, children9[0]);
     }
     return result;
@@ -1726,6 +1777,7 @@ exports[`top level sub widgets basic use 1`] = `
         let W1 = context.constructor.components[componentKey1] || QWeb.components[componentKey1]|| context['Child'];
         if (!W1) {throw new Error('Cannot find the definition of component \\"' + componentKey1 + '\\"')}
         w1 = new W1(parent, props1);
+        w1.__owl__.contextualParentID = 416;
         parent.__owl__.cmap[k2] = w1.__owl__.id;
         let fiber = w1.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k2, hook: {remove() {},destroy(vn) {w1.destroy();}}});
@@ -1766,6 +1818,7 @@ exports[`top level sub widgets can select a sub widget  1`] = `
             let W1 = context.constructor.components[componentKey1] || QWeb.components[componentKey1]|| context['Child'];
             if (!W1) {throw new Error('Cannot find the definition of component \\"' + componentKey1 + '\\"')}
             w1 = new W1(parent, props1);
+            w1.__owl__.contextualParentID = 420;
             parent.__owl__.cmap[k2] = w1.__owl__.id;
             let fiber = w1.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k2, hook: {remove() {},destroy(vn) {w1.destroy();}}});
@@ -1794,6 +1847,7 @@ exports[`top level sub widgets can select a sub widget  1`] = `
             let W5 = context.constructor.components[componentKey5] || QWeb.components[componentKey5]|| context['OtherChild'];
             if (!W5) {throw new Error('Cannot find the definition of component \\"' + componentKey5 + '\\"')}
             w5 = new W5(parent, props5);
+            w5.__owl__.contextualParentID = 420;
             parent.__owl__.cmap[k6] = w5.__owl__.id;
             let fiber = w5.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k6, hook: {remove() {},destroy(vn) {w5.destroy();}}});

--- a/tests/component/__snapshots__/props_validation.test.ts.snap
+++ b/tests/component/__snapshots__/props_validation.test.ts.snap
@@ -27,6 +27,7 @@ exports[`props validation props are validated in dev mode (code snapshot) 1`] = 
         let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| context['Child'];
         if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
         w2 = new W2(parent, props2);
+        w2.__owl__.contextualParentID = 86;
         parent.__owl__.cmap[k3] = w2.__owl__.id;
         let fiber = w2.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
         let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});

--- a/tests/router/__snapshots__/link.test.ts.snap
+++ b/tests/router/__snapshots__/link.test.ts.snap
@@ -5,6 +5,12 @@ exports[`Link component can render simple cases 1`] = `
 ) {
     let utils = this.constructor.utils;
     let owner = context;
+
+    const contextualParentID = context.__owl__.contextualParentID;
+    let ctxParent = context;
+    while (ctxParent.__owl__.id !== contextualParentID) {
+      ctxParent = ctxParent.__owl__.parent;
+    }
     var h = this.h;
     let _5 = utils.toObj({'router-link-active':context['isActive']});
     var _6 = context['href'];
@@ -14,7 +20,7 @@ exports[`Link component can render simple cases 1`] = `
     p7.on['click'] = extra.handlers['click' + 7];
     const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot8) {
-        slot8.call(this, context.__owl__.parent, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || owner, vars: extra.fiber.vars}));
+        slot8.call(this, ctxParent, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || owner, vars: extra.fiber.vars}));
     }
     return vn7;
 }"

--- a/tests/router/__snapshots__/route_component.test.ts.snap
+++ b/tests/router/__snapshots__/route_component.test.ts.snap
@@ -30,6 +30,7 @@ exports[`RouteComponent can render simple cases 1`] = `
             let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| context['routeComponent'];
             if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
             w6 = new W6(parent, props6);
+            w6.__owl__.contextualParentID = 2;
             parent.__owl__.cmap[k7] = w6.__owl__.id;
             let fiber = w6.__prepare(extra.fiber, undefined, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
             let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});


### PR DESCRIPTION
When a Component was nested in a slot within another directly
that is, in the same template, its rendering context was wrongly
its *parent*, whereas it should be the component which we *are* rendering
the template of.

A similar issue happened when a t-slot was nested within a slot, itself
having a t-slot.
In that case though, the crash in a browser was a memory error

This commit fixes both issues by introducing the concept of contextualParent
which is the Component of which we are compiling the template

At runtime (after compile time) this contextualParent is irrelevant
it doesn't take any part in the life cycle of any component

closes #545