### PR TITLE
[FIX] qweb: conditional t-call with body

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -242,7 +242,9 @@ QWeb.addDirective({
       ctx.indent();
       protectID = ctx.startProtectScope();
       const nodeCopy = node.cloneNode(true) as Element;
-      nodeCopy.removeAttribute("t-call");
+      for (let attr of ["t-if", "t-else", "t-elif", "t-call"]) {
+        nodeCopy.removeAttribute(attr);
+      }
       const parentNode = ctx.parentNode;
       ctx.parentNode = "__0";
       // this local scope is intended to trap c__0

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -1464,6 +1464,36 @@ exports[`t-call (template calling t-call with t-set inside and outside. 2 1`] = 
 }"
 `;
 
+exports[`t-call (template calling t-call, conditional and t-set in t-call body 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"caller\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    var h = this.h;
+    let c1 = [], p1 = {key:1};
+    var vn1 = h('div', p1, c1);
+    scope.v1 = 'elif';
+    if (scope.v1==='if') {
+        this.subTemplates['callee1'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
+    }
+    else if (scope.v1==='elif') {
+        {
+            const _origScope5 = scope;
+            scope = Object.assign(Object.create(context), scope);
+            {
+                let c__0 = [];
+                scope.v = 'success';
+                scope[utils.zero] = c__0;
+            }
+            this.subTemplates['callee2'].call(this, scope, Object.assign({}, extra, {parentNode: c1}));
+            scope = _origScope5;
+        }
+    }
+    return vn1;
+}"
+`;
+
 exports[`t-call (template calling t-call, global templates 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -882,6 +882,22 @@ describe("t-call (template calling", () => {
     expect(trim(renderToString(qweb, "abcd"))).toBe(expected);
   });
 
+  test("t-call, conditional and t-set in t-call body", () => {
+    QWeb.registerTemplate("callee1", '<div>callee1</div>');
+    QWeb.registerTemplate("callee2", '<div>callee2 <t t-esc="v"/></div>');
+    QWeb.registerTemplate("caller",
+      `<div>
+        <t t-set="v1" t-value="'elif'"/>
+        <t t-if="v1 === 'if'" t-call="callee1" />
+        <t t-elif="v1 === 'elif'" t-call="callee2" >
+          <t t-set="v" t-value="'success'" />
+        </t>
+       </div>`
+    );
+    const rendered = renderToString(qweb, "caller");
+    expect(rendered).toBe(`<div><div>callee2 success</div></div>`);
+  });
+
   test("t-call with t-set inside and outside", () => {
     qweb.addTemplates(`
       <templates>


### PR DESCRIPTION
When a t-call has a condition and a body
the t-if's and its flavors should be ignored when compiling the body of a t-call