### PR TITLE
[FIX] qweb: properly display falsy values

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -39,11 +39,11 @@ function compileValueNode(value: any, node: Element, qweb: QWeb, ctx: Compilatio
   let exprID: string;
   if (typeof value === "string") {
     exprID = `_${ctx.generateID()}`;
-    ctx.addLine(`var ${exprID} = ${ctx.formatExpression(value)};`);
+    ctx.addLine(`let ${exprID} = ${ctx.formatExpression(value)};`);
   } else {
     exprID = `scope.${value.id}`;
   }
-  ctx.addIf(`${exprID} || ${exprID} === 0`);
+  ctx.addIf(`${exprID} != null`);
 
   if (ctx.escaping) {
     let protectID;
@@ -61,7 +61,7 @@ function compileValueNode(value: any, node: Element, qweb: QWeb, ctx: Compilatio
       let nodeID = ctx.generateID();
       ctx.rootContext.rootNode = nodeID;
       ctx.rootContext.parentTextNode = nodeID;
-      ctx.addLine(`var vn${nodeID} = {text: ${exprID}};`);
+      ctx.addLine(`let vn${nodeID} = {text: ${exprID}};`);
       if (ctx.rootContext.shouldDefineResult) {
         ctx.addLine(`result = vn${nodeID}`);
       }
@@ -140,7 +140,7 @@ QWeb.addDirective({
       const _parentNode = ctx.parentNode;
       ctx.parentNode = tempParentNodeID;
 
-      ctx.addLine(`const c${tempParentNodeID} = new utils.VDomArray();`);
+      ctx.addLine(`let c${tempParentNodeID} = new utils.VDomArray();`);
       const nodeCopy = node.cloneNode(true) as Element;
       for (let attr of ["t-set", "t-value", "t-if", "t-else", "t-elif"]) {
         nodeCopy.removeAttribute(attr);
@@ -301,16 +301,16 @@ QWeb.addDirective({
     const elems = node.getAttribute("t-foreach")!;
     const name = node.getAttribute("t-as")!;
     let arrayID = ctx.generateID();
-    ctx.addLine(`var _${arrayID} = ${ctx.formatExpression(elems)};`);
+    ctx.addLine(`let _${arrayID} = ${ctx.formatExpression(elems)};`);
     ctx.addLine(`if (!_${arrayID}) { throw new Error('QWeb error: Invalid loop expression')}`);
     let keysID = ctx.generateID();
     let valuesID = ctx.generateID();
-    ctx.addLine(`var _${keysID} = _${valuesID} = _${arrayID};`);
+    ctx.addLine(`let _${keysID} = _${valuesID} = _${arrayID};`);
     ctx.addIf(`!(_${arrayID} instanceof Array)`);
     ctx.addLine(`_${keysID} = Object.keys(_${arrayID});`);
     ctx.addLine(`_${valuesID} = Object.values(_${arrayID});`);
     ctx.closeIf();
-    ctx.addLine(`var _length${keysID} = _${keysID}.length;`);
+    ctx.addLine(`let _length${keysID} = _${keysID}.length;`);
     let varsID = ctx.startProtectScope();
     const loopVar = `i${ctx.loopNumber}`;
     ctx.addLine(`for (let ${loopVar} = 0; ${loopVar} < _length${keysID}; ${loopVar}++) {`);

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -31,7 +31,7 @@ export class CompilationContext {
   constructor(name?: string) {
     this.rootContext = this;
     this.templateName = name || "noname";
-    this.addLine("var h = this.h;");
+    this.addLine("let h = this.h;");
   }
 
   generateID(): number {
@@ -180,7 +180,7 @@ export class CompilationContext {
   startProtectScope(): number {
     const protectID = this.generateID();
     this.rootContext.shouldDefineScope = true;
-    this.addLine(`const _origScope${protectID} = scope;`);
+    this.addLine(`let _origScope${protectID} = scope;`);
     this.addLine(`scope = Object.assign(Object.create(context), scope);`);
     return protectID;
   }

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -466,7 +466,7 @@ export class QWeb extends EventBus {
         // this is an unusual situation: this text node is the result of the
         // template rendering.
         let nodeID = ctx.generateID();
-        ctx.addLine(`var vn${nodeID} = {text: \`${text}\`};`);
+        ctx.addLine(`let vn${nodeID} = {text: \`${text}\`};`);
         ctx.addLine(`result = vn${nodeID};`);
         ctx.rootContext.rootNode = nodeID;
         ctx.rootContext.parentTextNode = nodeID;
@@ -678,7 +678,7 @@ export class QWeb extends EventBus {
             ctx.addLine(`let ${classObj} = {${classDef}};`);
           }
         } else {
-          ctx.addLine(`var _${attID} = '${value}';`);
+          ctx.addLine(`let _${attID} = '${value}';`);
           if (!name.match(/^[a-zA-Z]+$/)) {
             // attribute contains 'non letters' => we want to quote it
             name = '"' + name + '"';
@@ -714,12 +714,12 @@ export class QWeb extends EventBus {
           const attValue = (<Element>node).getAttribute(attName);
           if (attValue) {
             const attValueID = ctx.generateID();
-            ctx.addLine(`var _${attValueID} = ${formattedValue};`);
+            ctx.addLine(`let _${attValueID} = ${formattedValue};`);
             formattedValue = `'${attValue}' + (_${attValueID} ? ' ' + _${attValueID} : '')`;
             const attrIndex = attrs.findIndex(att => att.startsWith(attName + ":"));
             attrs.splice(attrIndex, 1);
           }
-          ctx.addLine(`var _${attID} = ${formattedValue};`);
+          ctx.addLine(`let _${attID} = ${formattedValue};`);
           attrs.push(`${attName}: _${attID}`);
           handleBooleanProps(attName, attID);
         }
@@ -735,9 +735,9 @@ export class QWeb extends EventBus {
         const attID = ctx.generateID();
         let staticVal = (<Element>node).getAttribute(attName);
         if (staticVal) {
-          ctx.addLine(`var _${attID} = '${staticVal} ' + ${formattedExpr};`);
+          ctx.addLine(`let _${attID} = '${staticVal} ' + ${formattedExpr};`);
         } else {
-          ctx.addLine(`var _${attID} = ${formattedExpr};`);
+          ctx.addLine(`let _${attID} = ${formattedExpr};`);
         }
         attrs.push(`${attName}: _${attID}`);
       }
@@ -745,7 +745,7 @@ export class QWeb extends EventBus {
       // t-att= attributes
       if (name === "t-att") {
         let id = ctx.generateID();
-        ctx.addLine(`var _${id} = ${ctx.formatExpression(value!)};`);
+        ctx.addLine(`let _${id} = ${ctx.formatExpression(value!)};`);
         tattrs.push(id);
       }
     }
@@ -777,7 +777,7 @@ export class QWeb extends EventBus {
       ctx.addLine(`}`);
       ctx.closeIf();
     }
-    ctx.addLine(`var vn${nodeID} = h('${node.nodeName}', p${nodeID}, c${nodeID});`);
+    ctx.addLine(`let vn${nodeID} = h('${node.nodeName}', p${nodeID}, c${nodeID});`);
     if (ctx.parentNode) {
       ctx.addLine(`c${ctx.parentNode}.push(vn${nodeID});`);
     }

--- a/tests/__snapshots__/animations.test.ts.snap
+++ b/tests/__snapshots__/animations.test.ts.snap
@@ -8,9 +8,9 @@ exports[`animations t-transition combined with component 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -52,9 +52,9 @@ exports[`animations t-transition combined with t-component and t-if 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['state'].display) {
         // Component 'Child'
         let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -98,9 +98,9 @@ exports[`animations t-transition combined with t-component, remove and re-add be
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['state'].flag) {
         // Component 'Child'
         let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -141,9 +141,9 @@ exports[`animations t-transition with no delay/duration 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
+    let vn1 = h('span', p1, c1);
     p1.hook = {
       insert: vn => {
         utils.transitionInsert(vn, 'jupiler');
@@ -162,9 +162,9 @@ exports[`animations t-transition, on a simple node (insert) 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
+    let vn1 = h('span', p1, c1);
     p1.hook = {
       insert: vn => {
         utils.transitionInsert(vn, 'chimay');

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -8,18 +8,18 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['state'].s;
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].s;
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.section_first = i1 === 0
@@ -27,15 +27,15 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
         scope.section_index = i1
         scope.section = _3[i1]
         scope.section_value = _4[i1]
-        var _6 = scope['section'].blips;
+        let _6 = scope['section'].blips;
         if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
-        var _7 = _8 = _6;
+        let _7 = _8 = _6;
         if (!(_6 instanceof Array)) {
             _7 = Object.keys(_6);
             _8 = Object.values(_6);
         }
-        var _length7 = _7.length;
-        const _origScope9 = scope;
+        let _length7 = _7.length;
+        let _origScope9 = scope;
         scope = Object.assign(Object.create(context), scope);
         for (let i2 = 0; i2 < _length7; i2++) {
             scope.blip_first = i2 === 0
@@ -83,9 +83,9 @@ exports[`basic widget properties t-key on a component with t-if, and a sibling c
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (false) {
         const nodeKey2 = 'str';
         // Component 'Child'
@@ -148,9 +148,9 @@ exports[`class and style attributes with t-component dynamic t-att-style is prop
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     const _4 = scope['state'].style;
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -188,9 +188,9 @@ exports[`class and style attributes with t-component t-att-class is properly add
     let parent = context;
     context.__owl__.refs = context.__owl__.refs || {};
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     const ref4 = \`child\`;
     let _5 = {'a':true};
@@ -228,11 +228,11 @@ exports[`class and style attributes with t-component t-att-class is properly add
     // Template name: \\"Child\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _7 = {'c':true};
     Object.assign(_7, utils.toObj({d:scope['state'].d}))
     let c8 = [], p8 = {key:8,class:_7};
-    var vn8 = h('span', p8, c8);
+    let vn8 = h('span', p8, c8);
     return vn8;
 }"
 `;
@@ -246,9 +246,9 @@ exports[`class and style attributes with t-component t-att-class is properly add
     let parent = context;
     context.__owl__.refs = context.__owl__.refs || {};
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     const ref4 = \`child\`;
     let _5 = {'a':true};
@@ -286,11 +286,11 @@ exports[`class and style attributes with t-component t-att-class is properly add
     // Template name: \\"Child\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _7 = {'c':true};
     Object.assign(_7, utils.toObj(scope['state'].d?'d':''))
     let c8 = [], p8 = {key:8,class:_7};
-    var vn8 = h('span', p8, c8);
+    let vn8 = h('span', p8, c8);
     return vn8;
 }"
 `;
@@ -303,18 +303,18 @@ exports[`composition sub components with some state rendered in a loop 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['state'].numbers;
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].numbers;
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.number_first = i1 === 0
@@ -361,9 +361,9 @@ exports[`composition t-component with dynamic value 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component '{{state.widget}}'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -399,9 +399,9 @@ exports[`composition t-component with dynamic value 2 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Widget{{state.widget}}'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -437,9 +437,9 @@ exports[`dynamic t-props basic use 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = Object.assign({}, scope['some'].obj);
@@ -475,11 +475,11 @@ exports[`other directives with t-component t-on with getter as handler 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['state'].counter;
-    if (_2 || _2 === 0) {
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].counter;
+    if (_2 != null) {
         c1.push({text: _2});
     }
     // Component 'Child'
@@ -517,9 +517,9 @@ exports[`other directives with t-component t-on with handler bound to argument 1
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let args4 = [3];
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -556,9 +556,9 @@ exports[`other directives with t-component t-on with handler bound to empty obje
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let args4 = [{}];
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -595,9 +595,9 @@ exports[`other directives with t-component t-on with handler bound to empty obje
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let args4 = [{}];
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -634,9 +634,9 @@ exports[`other directives with t-component t-on with handler bound to object 1`]
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let args4 = [{val:3}];
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -673,11 +673,11 @@ exports[`other directives with t-component t-on with inline statement 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['state'].counter;
-    if (_2 || _2 === 0) {
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].counter;
+    if (_2 != null) {
         c1.push({text: _2});
     }
     // Component 'Child'
@@ -715,9 +715,9 @@ exports[`other directives with t-component t-on with no handler (only modifiers)
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'ComponentA'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -753,9 +753,9 @@ exports[`other directives with t-component t-on with prevent and self modifiers 
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -791,9 +791,9 @@ exports[`other directives with t-component t-on with self and prevent modifiers 
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -829,9 +829,9 @@ exports[`other directives with t-component t-on with self modifier 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -867,9 +867,9 @@ exports[`other directives with t-component t-on with stop and/or prevent modifie
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -902,9 +902,9 @@ exports[`random stuff/miscellaneous can inject values in tagged templates 1`] = 
 ) {
     // Template name: \\"__template__2\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     this.subTemplates['__template__1'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -918,9 +918,9 @@ exports[`random stuff/miscellaneous snapshotting compiled code 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     const nodeKey2 = 'somestring';
     // Component 'child'
     let k4 = \`__4__\` + nodeKey2;
@@ -958,18 +958,18 @@ exports[`random stuff/miscellaneous t-on with handler bound to dynamic argument 
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['items'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['items'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -1014,10 +1014,10 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
 ) {
     // Template name: \\"sub\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('p', p2, c2);
+    let vn2 = h('p', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
@@ -1031,10 +1031,10 @@ exports[`t-call handlers with arguments are properly bound through a t-call 1`] 
     // Template name: \\"sub\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('p', p2, c2);
+    let vn2 = h('p', p2, c2);
     c1.push(vn2);
     let args3 = [scope['a']];
     p2.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](...args3, e);};
@@ -1047,21 +1047,21 @@ exports[`t-model directive .lazy modifier 1`] = `
 ) {
     // Template name: \\"__template__1\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('input', p2, c2);
+    let vn2 = h('input', p2, c2);
     c1.push(vn2);
     let expr2 = scope['state'];
     p2.props = {value: expr2.text};
     extra.handlers['__3__'] = extra.handlers['__3__'] || ((ev) => {expr2.text = ev.target.value});
     p2.on['change'] = extra.handlers['__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
-    var _5 = scope['state'].text;
-    if (_5 || _5 === 0) {
+    let _5 = scope['state'].text;
+    if (_5 != null) {
         c4.push({text: _5});
     }
     return vn1;
@@ -1073,21 +1073,21 @@ exports[`t-model directive basic use, on an input 1`] = `
 ) {
     // Template name: \\"__template__1\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('input', p2, c2);
+    let vn2 = h('input', p2, c2);
     c1.push(vn2);
     let expr2 = scope['state'];
     p2.props = {value: expr2.text};
     extra.handlers['__3__'] = extra.handlers['__3__'] || ((ev) => {expr2.text = ev.target.value});
     p2.on['input'] = extra.handlers['__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
-    var _5 = scope['state'].text;
-    if (_5 || _5 === 0) {
+    let _5 = scope['state'].text;
+    if (_5 != null) {
         c4.push({text: _5});
     }
     return vn1;
@@ -1099,21 +1099,21 @@ exports[`t-model directive basic use, on another key in component 1`] = `
 ) {
     // Template name: \\"SomeComponent\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('input', p2, c2);
+    let vn2 = h('input', p2, c2);
     c1.push(vn2);
     let expr2 = scope['some'];
     p2.props = {value: expr2.text};
     extra.handlers['__3__'] = extra.handlers['__3__'] || ((ev) => {expr2.text = ev.target.value});
     p2.on['input'] = extra.handlers['__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
-    var _5 = scope['some'].text;
-    if (_5 || _5 === 0) {
+    let _5 = scope['some'].text;
+    if (_5 != null) {
         c4.push({text: _5});
     }
     return vn1;
@@ -1125,18 +1125,18 @@ exports[`t-model directive in a t-foreach 1`] = `
 ) {
     // Template name: \\"__template__1\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['state'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.thing_first = i1 === 0
@@ -1145,9 +1145,9 @@ exports[`t-model directive in a t-foreach 1`] = `
         scope.thing = _3[i1]
         scope.thing_value = _4[i1]
         const nodeKey6 = scope['thing'].id;
-        var _7 = 'checkbox';
+        let _7 = 'checkbox';
         let c8 = [], p8 = {key:nodeKey6,attrs:{type: _7},on:{}};
-        var vn8 = h('input', p8, c8);
+        let vn8 = h('input', p8, c8);
         c1.push(vn8);
         let expr8 = scope['thing'];
         let k9 = \`__9__\` + nodeKey6;
@@ -1165,11 +1165,11 @@ exports[`t-model directive on a select 1`] = `
 ) {
     // Template name: \\"SomeComponent\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('select', p2, c2);
+    let vn2 = h('select', p2, c2);
     c1.push(vn2);
     let expr2 = scope['state'];
     p2.props = {value: expr2.color};
@@ -1180,27 +1180,27 @@ exports[`t-model directive on a select 1`] = `
         n.elm.value=expr2.color;
       },
     };
-    var _4 = '';
+    let _4 = '';
     let c5 = [], p5 = {key:5,attrs:{value: _4}};
-    var vn5 = h('option', p5, c5);
+    let vn5 = h('option', p5, c5);
     c2.push(vn5);
     c5.push({text: \`Please select one\`});
-    var _6 = 'red';
+    let _6 = 'red';
     let c7 = [], p7 = {key:7,attrs:{value: _6}};
-    var vn7 = h('option', p7, c7);
+    let vn7 = h('option', p7, c7);
     c2.push(vn7);
     c7.push({text: \`Red\`});
-    var _8 = 'blue';
+    let _8 = 'blue';
     let c9 = [], p9 = {key:9,attrs:{value: _8}};
-    var vn9 = h('option', p9, c9);
+    let vn9 = h('option', p9, c9);
     c2.push(vn9);
     c9.push({text: \`Blue\`});
     let c10 = [], p10 = {key:10};
-    var vn10 = h('span', p10, c10);
+    let vn10 = h('span', p10, c10);
     c1.push(vn10);
     c10.push({text: \`Choice: \`});
-    var _11 = scope['state'].color;
-    if (_11 || _11 === 0) {
+    let _11 = scope['state'].color;
+    if (_11 != null) {
         c10.push({text: _11});
     }
     return vn1;
@@ -1212,21 +1212,21 @@ exports[`t-model directive on a sub state key 1`] = `
 ) {
     // Template name: \\"__template__1\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('input', p2, c2);
+    let vn2 = h('input', p2, c2);
     c1.push(vn2);
     let expr2 = scope['state'].something;
     p2.props = {value: expr2.text};
     extra.handlers['__3__'] = extra.handlers['__3__'] || ((ev) => {expr2.text = ev.target.value});
     p2.on['input'] = extra.handlers['__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
-    var _5 = scope['state'].something.text;
-    if (_5 || _5 === 0) {
+    let _5 = scope['state'].something.text;
+    if (_5 != null) {
         c4.push({text: _5});
     }
     return vn1;
@@ -1238,35 +1238,35 @@ exports[`t-model directive on an input type=radio 1`] = `
 ) {
     // Template name: \\"SomeComponent\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = 'radio';
-    var _3 = 'one';
-    var _4 = 'One';
+    let vn1 = h('div', p1, c1);
+    let _2 = 'radio';
+    let _3 = 'one';
+    let _4 = 'One';
     let c5 = [], p5 = {key:5,attrs:{type: _2,id: _3,value: _4},on:{}};
-    var vn5 = h('input', p5, c5);
+    let vn5 = h('input', p5, c5);
     c1.push(vn5);
     let expr5 = scope['state'];
     p5.props = {checked:expr5.choice === 'One'};
     extra.handlers['__6__'] = extra.handlers['__6__'] || ((ev) => {expr5.choice = ev.target.value});
     p5.on['click'] = extra.handlers['__6__'];
-    var _7 = 'radio';
-    var _8 = 'two';
-    var _9 = 'Two';
+    let _7 = 'radio';
+    let _8 = 'two';
+    let _9 = 'Two';
     let c10 = [], p10 = {key:10,attrs:{type: _7,id: _8,value: _9},on:{}};
-    var vn10 = h('input', p10, c10);
+    let vn10 = h('input', p10, c10);
     c1.push(vn10);
     let expr10 = scope['state'];
     p10.props = {checked:expr10.choice === 'Two'};
     extra.handlers['__11__'] = extra.handlers['__11__'] || ((ev) => {expr10.choice = ev.target.value});
     p10.on['click'] = extra.handlers['__11__'];
     let c12 = [], p12 = {key:12};
-    var vn12 = h('span', p12, c12);
+    let vn12 = h('span', p12, c12);
     c1.push(vn12);
     c12.push({text: \`Choice: \`});
-    var _13 = scope['state'].choice;
-    if (_13 || _13 === 0) {
+    let _13 = scope['state'].choice;
+    if (_13 != null) {
         c12.push({text: _13});
     }
     return vn1;
@@ -1278,19 +1278,19 @@ exports[`t-model directive on an input, type=checkbox 1`] = `
 ) {
     // Template name: \\"SomeComponent\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = 'checkbox';
+    let vn1 = h('div', p1, c1);
+    let _2 = 'checkbox';
     let c3 = [], p3 = {key:3,attrs:{type: _2},on:{}};
-    var vn3 = h('input', p3, c3);
+    let vn3 = h('input', p3, c3);
     c1.push(vn3);
     let expr3 = scope['state'];
     p3.props = {checked: expr3.flag};
     extra.handlers['__4__'] = extra.handlers['__4__'] || ((ev) => {expr3.flag = ev.target.checked});
     p3.on['input'] = extra.handlers['__4__'];
     let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
+    let vn5 = h('span', p5, c5);
     c1.push(vn5);
     if (scope['state'].flag) {
         c5.push({text: \`yes\`});
@@ -1311,7 +1311,7 @@ exports[`top level sub widgets basic use 1`] = `
     let parent = context;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     // Component 'Child'
     let w1 = '__2__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__2__']] : false;
     let vn3 = {};
@@ -1350,7 +1350,7 @@ exports[`top level sub widgets can select a sub widget  1`] = `
     let parent = context;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     if (scope['env'].flag) {
         // Component 'Child'
         let w1 = '__2__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__2__']] : false;

--- a/tests/component/__snapshots__/props_validation.test.ts.snap
+++ b/tests/component/__snapshots__/props_validation.test.ts.snap
@@ -8,9 +8,9 @@ exports[`props validation props are validated in dev mode (code snapshot) 1`] = 
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {message:1};

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -8,9 +8,9 @@ exports[`t-slot directive can define and call slots 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     // Component 'Dialog'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {};
@@ -43,18 +43,18 @@ exports[`t-slot directive can define and call slots 2`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"Dialog\\"
-    var h = this.h;
+    let h = this.h;
     let c6 = [], p6 = {key:6};
-    var vn6 = h('div', p6, c6);
+    let vn6 = h('div', p6, c6);
     let c7 = [], p7 = {key:7};
-    var vn7 = h('div', p7, c7);
+    let vn7 = h('div', p7, c7);
     c6.push(vn7);
     const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
     if (slot8) {
         slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || context}));
     }
     let c9 = [], p9 = {key:9};
-    var vn9 = h('div', p9, c9);
+    let vn9 = h('div', p9, c9);
     c6.push(vn9);
     const slot10 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
     if (slot10) {
@@ -68,10 +68,10 @@ exports[`t-slot directive can define and call slots 3`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_header_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
     c4.push({text: \`header\`});
 }"
@@ -81,10 +81,10 @@ exports[`t-slot directive can define and call slots 4`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_footer_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
+    let vn5 = h('span', p5, c5);
     c1.push(vn5);
     c5.push({text: \`footer\`});
 }"
@@ -94,10 +94,10 @@ exports[`t-slot directive content is the default slot 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_default_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
     c4.push({text: \`sts rocks\`});
 }"
@@ -107,9 +107,9 @@ exports[`t-slot directive dafault slots can define a default content 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"__template__1\\"
-    var h = this.h;
+    let h = this.h;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     const slot5 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot5) {
         slot5.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c4, parent: extra.parent || context}));
@@ -124,7 +124,7 @@ exports[`t-slot directive default slot work with text nodes 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_default_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     c1.push({text: \`sts rocks\`});
 }"
@@ -134,14 +134,14 @@ exports[`t-slot directive multiple roots are allowed in a default slot 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_default_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
     c4.push({text: \`sts\`});
     let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
+    let vn5 = h('span', p5, c5);
     c1.push(vn5);
     c5.push({text: \`rocks\`});
 }"
@@ -151,14 +151,14 @@ exports[`t-slot directive multiple roots are allowed in a named slot 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"slot_content_template\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c1.push(vn4);
     c4.push({text: \`sts\`});
     let c5 = [], p5 = {key:5};
-    var vn5 = h('span', p5, c5);
+    let vn5 = h('span', p5, c5);
     c1.push(vn5);
     c5.push({text: \`rocks\`});
 }"
@@ -168,9 +168,9 @@ exports[`t-slot directive named slots can define a default content 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"__template__1\\"
-    var h = this.h;
+    let h = this.h;
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     const slot5 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
     if (slot5) {
         slot5.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c4, parent: extra.parent || context}));
@@ -187,10 +187,10 @@ exports[`t-slot directive refs are properly bound in slots 1`] = `
     // Template name: \\"slot_footer_template\\"
     let utils = this.constructor.utils;
     context.__owl__.refs = context.__owl__.refs || {};
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c8 = [], p8 = {key:8,on:{}};
-    var vn8 = h('button', p8, c8);
+    let vn8 = h('button', p8, c8);
     c1.push(vn8);
     extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
     p8.on['click'] = extra.handlers['click__9__'];
@@ -212,10 +212,10 @@ exports[`t-slot directive slots are rendered with proper context 1`] = `
 ) {
     // Template name: \\"slot_footer_template\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c8 = [], p8 = {key:8,on:{}};
-    var vn8 = h('button', p8, c8);
+    let vn8 = h('button', p8, c8);
     c1.push(vn8);
     extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
     p8.on['click'] = extra.handlers['click__9__'];
@@ -228,10 +228,10 @@ exports[`t-slot directive slots are rendered with proper context, part 2 1`] = `
 ) {
     // Template name: \\"Link\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _12 = scope['props'].to;
+    let h = this.h;
+    let _12 = scope['props'].to;
     let c13 = [], p13 = {key:13,attrs:{href: _12}};
-    var vn13 = h('a', p13, c13);
+    let vn13 = h('a', p13, c13);
     const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot14) {
         slot14.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || context}));
@@ -248,21 +248,21 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('u', p2, c2);
+    let vn2 = h('u', p2, c2);
     c1.push(vn2);
-    var _3 = scope['state'].users;
+    let _3 = scope['state'].users;
     if (!_3) { throw new Error('QWeb error: Invalid loop expression')}
-    var _4 = _5 = _3;
+    let _4 = _5 = _3;
     if (!(_3 instanceof Array)) {
         _4 = Object.keys(_3);
         _5 = Object.values(_3);
     }
-    var _length4 = _4.length;
-    const _origScope6 = scope;
+    let _length4 = _4.length;
+    let _origScope6 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length4; i1++) {
         scope.user_first = i1 === 0
@@ -272,7 +272,7 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
         scope.user_value = _5[i1]
         const nodeKey7 = scope['user'].id;
         let c8 = [], p8 = {key:nodeKey7};
-        var vn8 = h('li', p8, c8);
+        let vn8 = h('li', p8, c8);
         c2.push(vn8);
         // Component 'Link'
         let k10 = \`__10__\` + nodeKey7;
@@ -310,11 +310,11 @@ exports[`t-slot directive slots are rendered with proper context, part 2 3`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c8 = extra.parentNode;
     c8.push({text: \`User \`});
-    var _11 = scope['user'].name;
-    if (_11 || _11 === 0) {
+    let _11 = scope['user'].name;
+    if (_11 != null) {
         c8.push({text: _11});
     }
 }"
@@ -325,10 +325,10 @@ exports[`t-slot directive slots are rendered with proper context, part 3 1`] = `
 ) {
     // Template name: \\"Link\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _11 = scope['props'].to;
+    let h = this.h;
+    let _11 = scope['props'].to;
     let c12 = [], p12 = {key:12,attrs:{href: _11}};
-    var vn12 = h('a', p12, c12);
+    let vn12 = h('a', p12, c12);
     const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot13) {
         slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
@@ -345,21 +345,21 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('u', p2, c2);
+    let vn2 = h('u', p2, c2);
     c1.push(vn2);
-    var _3 = scope['state'].users;
+    let _3 = scope['state'].users;
     if (!_3) { throw new Error('QWeb error: Invalid loop expression')}
-    var _4 = _5 = _3;
+    let _4 = _5 = _3;
     if (!(_3 instanceof Array)) {
         _4 = Object.keys(_3);
         _5 = Object.values(_3);
     }
-    var _length4 = _4.length;
-    const _origScope6 = scope;
+    let _length4 = _4.length;
+    let _origScope6 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length4; i1++) {
         scope.user_first = i1 === 0
@@ -369,7 +369,7 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
         scope.user_value = _5[i1]
         const nodeKey7 = scope['user'].id;
         let c8 = [], p8 = {key:nodeKey7};
-        var vn8 = h('li', p8, c8);
+        let vn8 = h('li', p8, c8);
         c2.push(vn8);
         scope.userdescr = 'User '+scope['user'].name;
         // Component 'Link'
@@ -408,9 +408,9 @@ exports[`t-slot directive slots are rendered with proper context, part 3 3`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c8 = extra.parentNode;
-    if (scope.userdescr || scope.userdescr === 0) {
+    if (scope.userdescr != null) {
         c8.push({text: scope.userdescr});
     }
 }"
@@ -424,9 +424,9 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
     let QWeb = this.constructor;
     let parent = context;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.userdescr = 'User '+scope['state'].user.name;
     // Component 'Link'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
@@ -461,9 +461,9 @@ exports[`t-slot directive slots are rendered with proper context, part 4 2`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
-    if (scope.userdescr || scope.userdescr === 0) {
+    if (scope.userdescr != null) {
         c1.push({text: scope.userdescr});
     }
 }"
@@ -475,7 +475,7 @@ exports[`t-slot directive template can just return a slot 1`] = `
     // Template name: \\"__template__2\\"
     let utils = this.constructor.utils;
     let result;
-    var h = this.h;
+    let h = this.h;
     const slot6 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
     if (slot6) {
         let children7= []

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -4520,7 +4520,7 @@ describe("component error handling (catchError)", () => {
     }
     const app = new App();
     await app.mount(fixture);
-    expect(fixture.innerHTML).toBe("<div><div><div>hey</div></div></div>");
+    expect(fixture.innerHTML).toBe("<div><div><div>heyfalse</div></div></div>");
     app.state.flag = true;
     await nextTick();
     expect(fixture.innerHTML).toBe("<div><div>Error handled</div></div>");
@@ -4555,7 +4555,7 @@ describe("component error handling (catchError)", () => {
     }
     const app = new App();
     await app.mount(fixture);
-    expect(fixture.innerHTML).toBe("<div><div>hey</div></div>");
+    expect(fixture.innerHTML).toBe("<div><div>heyfalse</div></div>");
     app.state.flag = true;
     await nextTick();
     expect(fixture.innerHTML).toBe("");

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -5,10 +5,10 @@ exports[`attributes class and t-attf-class with ternary operation 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = 'hello ' + (scope['value']?'world':'');
+    let h = this.h;
+    let _1 = 'hello ' + (scope['value']?'world':'');
     let c2 = [], p2 = {key:2,attrs:{class: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -18,10 +18,10 @@ exports[`attributes dynamic attribute falsy variable  1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = scope['value'];
+    let h = this.h;
+    let _1 = scope['value'];
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -31,10 +31,10 @@ exports[`attributes dynamic attribute with a dash 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = scope['id'];
+    let h = this.h;
+    let _1 = scope['id'];
     let c2 = [], p2 = {key:2,attrs:{\\"data-action-id\\": _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -44,10 +44,10 @@ exports[`attributes dynamic attributes 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = 'bar';
+    let h = this.h;
+    let _1 = 'bar';
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -58,10 +58,10 @@ exports[`attributes dynamic class attribute 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _1 = utils.toObj(scope['c']);
     let c2 = [], p2 = {key:2,class:_1};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -72,10 +72,10 @@ exports[`attributes dynamic empty class attribute 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _1 = utils.toObj(scope['c']);
     let c2 = [], p2 = {key:2,class:_1};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -85,10 +85,10 @@ exports[`attributes dynamic formatted attributes with a dash 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = \`Some text \${scope['id']}\`;
+    let h = this.h;
+    let _1 = \`Some text \${scope['id']}\`;
     let c2 = [], p2 = {key:2,attrs:{\\"aria-label\\": _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -98,10 +98,10 @@ exports[`attributes fixed variable 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = scope['value'];
+    let h = this.h;
+    let _1 = scope['value'];
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -111,10 +111,10 @@ exports[`attributes format expression 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = (scope['value']+37);
+    let h = this.h;
+    let _1 = (scope['value']+37);
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -124,10 +124,10 @@ exports[`attributes format expression, other format 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = (scope['value']+37);
+    let h = this.h;
+    let _1 = (scope['value']+37);
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -136,10 +136,10 @@ exports[`attributes format literal 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
-    var _1 = \`bar\`;
+    let h = this.h;
+    let _1 = \`bar\`;
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -149,10 +149,10 @@ exports[`attributes format multiple 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = \`a \${scope['value1']} is \${scope['value2']} of \${scope['value3']} ]\`;
+    let h = this.h;
+    let _1 = \`a \${scope['value1']} is \${scope['value2']} of \${scope['value3']} ]\`;
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -162,10 +162,10 @@ exports[`attributes format value 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = \`b\${scope['value']}r\`;
+    let h = this.h;
+    let _1 = \`b\${scope['value']}r\`;
     let c2 = [], p2 = {key:2,attrs:{foo: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -176,13 +176,13 @@ exports[`attributes from object variables set previously 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.o = {a:'b'};
     let _2 = utils.toObj(scope.o.a);
     let c3 = [], p3 = {key:3,class:_2};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c1.push(vn3);
     return vn1;
 }"
@@ -194,13 +194,13 @@ exports[`attributes from variables set previously 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.abc = 'def';
     let _2 = utils.toObj(scope.abc);
     let c3 = [], p3 = {key:3,class:_2};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c1.push(vn3);
     return vn1;
 }"
@@ -211,8 +211,8 @@ exports[`attributes object 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = scope['value'];
+    let h = this.h;
+    let _1 = scope['value'];
     let c2 = [], p2 = {key:2,attrs:{}};
     if (_1 instanceof Array) {
         p2.attrs[_1[0]] = _1[1];
@@ -221,7 +221,7 @@ exports[`attributes object 1`] = `
             p2.attrs[key] = _1[key];
         }
     }
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -230,12 +230,12 @@ exports[`attributes static attributes 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
-    var _1 = 'a';
-    var _2 = 'b';
-    var _3 = 'c';
+    let h = this.h;
+    let _1 = 'a';
+    let _2 = 'b';
+    let _3 = 'c';
     let c4 = [], p4 = {key:4,attrs:{foo: _1,bar: _2,baz: _3}};
-    var vn4 = h('div', p4, c4);
+    let vn4 = h('div', p4, c4);
     return vn4;
 }"
 `;
@@ -244,11 +244,11 @@ exports[`attributes static attributes on void elements 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
-    var _1 = '/test.jpg';
-    var _2 = 'Test';
+    let h = this.h;
+    let _1 = '/test.jpg';
+    let _2 = 'Test';
     let c3 = [], p3 = {key:3,attrs:{src: _1,alt: _2}};
-    var vn3 = h('img', p3, c3);
+    let vn3 = h('img', p3, c3);
     return vn3;
 }"
 `;
@@ -257,10 +257,10 @@ exports[`attributes static attributes with dashes 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
-    var _1 = 'Close';
+    let h = this.h;
+    let _1 = 'Close';
     let c2 = [], p2 = {key:2,attrs:{\\"aria-label\\": _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -271,11 +271,11 @@ exports[`attributes t-att-class and class should combine together 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _2 = {'hello':true};
     Object.assign(_2, utils.toObj(scope['value']))
     let c3 = [], p3 = {key:3,class:_2};
-    var vn3 = h('div', p3, c3);
+    let vn3 = h('div', p3, c3);
     return vn3;
 }"
 `;
@@ -286,11 +286,11 @@ exports[`attributes t-att-class with object 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _2 = {'static':true};
     Object.assign(_2, utils.toObj({a:scope['b'],c:scope['d'],e:scope['f']}))
     let c3 = [], p3 = {key:3,class:_2};
-    var vn3 = h('div', p3, c3);
+    let vn3 = h('div', p3, c3);
     return vn3;
 }"
 `;
@@ -299,10 +299,10 @@ exports[`attributes t-attf-class should combine with class 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
-    var _1 = 'hello ' + \`world\`;
+    let h = this.h;
+    let _1 = 'hello ' + \`world\`;
     let c2 = [], p2 = {key:2,attrs:{class: _1}};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -312,8 +312,8 @@ exports[`attributes tuple literal 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = ['foo','bar'];
+    let h = this.h;
+    let _1 = ['foo','bar'];
     let c2 = [], p2 = {key:2,attrs:{}};
     if (_1 instanceof Array) {
         p2.attrs[_1[0]] = _1[1];
@@ -322,7 +322,7 @@ exports[`attributes tuple literal 1`] = `
             p2.attrs[key] = _1[key];
         }
     }
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -332,8 +332,8 @@ exports[`attributes tuple variable 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = scope['value'];
+    let h = this.h;
+    let _1 = scope['value'];
     let c2 = [], p2 = {key:2,attrs:{}};
     if (_1 instanceof Array) {
         p2.attrs[_1[0]] = _1[1];
@@ -342,7 +342,7 @@ exports[`attributes tuple variable 1`] = `
             p2.attrs[key] = _1[key];
         }
     }
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     return vn2;
 }"
 `;
@@ -352,11 +352,11 @@ exports[`attributes various escapes 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = '<foo';
-    var _2 = scope['bar'];
-    var _3 = \`<\${scope['baz']}>\`;
-    var _4 = scope['qux'];
+    let h = this.h;
+    let _1 = '<foo';
+    let _2 = scope['bar'];
+    let _3 = \`<\${scope['baz']}>\`;
+    let _4 = scope['qux'];
     let c5 = [], p5 = {key:5,attrs:{foo: _1,bar: _2,baz: _3}};
     if (_4 instanceof Array) {
         p5.attrs[_4[0]] = _4[1];
@@ -365,7 +365,7 @@ exports[`attributes various escapes 1`] = `
             p5.attrs[key] = _4[key];
         }
     }
-    var vn5 = h('div', p5, c5);
+    let vn5 = h('div', p5, c5);
     return vn5;
 }"
 `;
@@ -375,14 +375,14 @@ exports[`debugging t-debug 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     debugger;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (true) {
         debugger;
         let c2 = [], p2 = {key:2};
-        var vn2 = h('span', p2, c2);
+        let vn2 = h('span', p2, c2);
         c1.push(vn2);
         c2.push({text: \`hey\`});
     }
@@ -395,9 +395,9 @@ exports[`debugging t-log 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.foo = 42;
     console.log(scope.foo+3)
     return vn1;
@@ -409,18 +409,18 @@ exports[`foreach does not pollute the rendering context 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = [1];
+    let vn1 = h('div', p1, c1);
+    let _2 = [1];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -428,8 +428,8 @@ exports[`foreach does not pollute the rendering context 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
-        var _6 = scope['item'];
-        if (_6 || _6 === 0) {
+        let _6 = scope['item'];
+        if (_6 != null) {
             c1.push({text: _6});
         }
     }
@@ -443,18 +443,18 @@ exports[`foreach iterate on items (on a element node) 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = [1,2];
+    let vn1 = h('div', p1, c1);
+    let _2 = [1,2];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -464,10 +464,10 @@ exports[`foreach iterate on items (on a element node) 1`] = `
         scope.item_value = _4[i1]
         const nodeKey6 = scope['item'];
         let c7 = [], p7 = {key:nodeKey6};
-        var vn7 = h('span', p7, c7);
+        let vn7 = h('span', p7, c7);
         c1.push(vn7);
-        var _8 = scope['item'];
-        if (_8 || _8 === 0) {
+        let _8 = scope['item'];
+        if (_8 != null) {
             c7.push({text: _8});
         }
     }
@@ -481,18 +481,18 @@ exports[`foreach iterate on items 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = [3,2,1];
+    let vn1 = h('div', p1, c1);
+    let _2 = [3,2,1];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -501,18 +501,18 @@ exports[`foreach iterate on items 1`] = `
         scope.item = _3[i1]
         scope.item_value = _4[i1]
         c1.push({text: \` [\`});
-        var _6 = scope['item_index'];
-        if (_6 || _6 === 0) {
+        let _6 = scope['item_index'];
+        if (_6 != null) {
             c1.push({text: _6});
         }
         c1.push({text: \`: \`});
-        var _7 = scope['item'];
-        if (_7 || _7 === 0) {
+        let _7 = scope['item'];
+        if (_7 != null) {
             c1.push({text: _7});
         }
         c1.push({text: \` \`});
-        var _8 = scope['item_value'];
-        if (_8 || _8 === 0) {
+        let _8 = scope['item_value'];
+        if (_8 != null) {
             c1.push({text: _8});
         }
         c1.push({text: \`] \`});
@@ -527,18 +527,18 @@ exports[`foreach iterate, dict param 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['value'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['value'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -547,18 +547,18 @@ exports[`foreach iterate, dict param 1`] = `
         scope.item = _3[i1]
         scope.item_value = _4[i1]
         c1.push({text: \` [\`});
-        var _6 = scope['item_index'];
-        if (_6 || _6 === 0) {
+        let _6 = scope['item_index'];
+        if (_6 != null) {
             c1.push({text: _6});
         }
         c1.push({text: \`: \`});
-        var _7 = scope['item'];
-        if (_7 || _7 === 0) {
+        let _7 = scope['item'];
+        if (_7 != null) {
             c1.push({text: _7});
         }
         c1.push({text: \` \`});
-        var _8 = scope['item_value'];
-        if (_8 || _8 === 0) {
+        let _8 = scope['item_value'];
+        if (_8 != null) {
             c1.push({text: _8});
         }
         c1.push({text: \`] \`});
@@ -573,18 +573,18 @@ exports[`foreach iterate, position 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = Array(5);
+    let vn1 = h('div', p1, c1);
+    let _2 = Array(5);
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.elem_first = i1 === 0
@@ -600,8 +600,8 @@ exports[`foreach iterate, position 1`] = `
             c1.push({text: \` last\`});
         }
         c1.push({text: \` (\`});
-        var _6 = scope['elem_index'];
-        if (_6 || _6 === 0) {
+        let _6 = scope['elem_index'];
+        if (_6 != null) {
             c1.push({text: _6});
         }
         c1.push({text: \`) \`});
@@ -616,18 +616,18 @@ exports[`foreach t-foreach in t-forach 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['numbers'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['numbers'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.number_first = i1 === 0
@@ -635,15 +635,15 @@ exports[`foreach t-foreach in t-forach 1`] = `
         scope.number_index = i1
         scope.number = _3[i1]
         scope.number_value = _4[i1]
-        var _6 = scope['letters'];
+        let _6 = scope['letters'];
         if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
-        var _7 = _8 = _6;
+        let _7 = _8 = _6;
         if (!(_6 instanceof Array)) {
             _7 = Object.keys(_6);
             _8 = Object.values(_6);
         }
-        var _length7 = _7.length;
-        const _origScope9 = scope;
+        let _length7 = _7.length;
+        let _origScope9 = scope;
         scope = Object.assign(Object.create(context), scope);
         for (let i2 = 0; i2 < _length7; i2++) {
             scope.letter_first = i2 === 0
@@ -652,12 +652,12 @@ exports[`foreach t-foreach in t-forach 1`] = `
             scope.letter = _7[i2]
             scope.letter_value = _8[i2]
             c1.push({text: \` [\`});
-            var _10 = scope['number'];
-            if (_10 || _10 === 0) {
+            let _10 = scope['number'];
+            if (_10 != null) {
                 c1.push({text: _10});
             }
-            var _11 = scope['letter'];
-            if (_11 || _11 === 0) {
+            let _11 = scope['letter'];
+            if (_11 != null) {
                 c1.push({text: _11});
             }
             c1.push({text: \`] \`});
@@ -674,18 +674,18 @@ exports[`foreach warn if no key in some case 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = [1,2];
+    let vn1 = h('div', p1, c1);
+    let _2 = [1,2];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -694,10 +694,10 @@ exports[`foreach warn if no key in some case 1`] = `
         scope.item = _3[i1]
         scope.item_value = _4[i1]
         let c6 = [], p6 = {key:6};
-        var vn6 = h('span', p6, c6);
+        let vn6 = h('span', p6, c6);
         c1.push(vn6);
-        var _7 = scope['item'];
-        if (_7 || _7 === 0) {
+        let _7 = scope['item'];
+        if (_7 != null) {
             c6.push({text: _7});
         }
     }
@@ -710,9 +710,9 @@ exports[`loading templates can initialize qweb with a string 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"hey\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \`jupiler\`});
     return vn1;
 }"
@@ -723,9 +723,9 @@ exports[`loading templates can load a few templates from a xml string 1`] = `
 ) {
     // Template name: \\"main\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('ul', p1, c1);
+    let vn1 = h('ul', p1, c1);
     this.subTemplates['items'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -737,18 +737,18 @@ exports[`misc global 1`] = `
     // Template name: \\"caller\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = [4,5,6];
+    let vn1 = h('div', p1, c1);
+    let _2 = [4,5,6];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.value_first = i1 === 0
@@ -757,19 +757,19 @@ exports[`misc global 1`] = `
         scope.value = _3[i1]
         scope.value_value = _4[i1]
         let c6 = [], p6 = {key:6};
-        var vn6 = h('span', p6, c6);
+        let vn6 = h('span', p6, c6);
         c1.push(vn6);
-        var _7 = scope['value'];
-        if (_7 || _7 === 0) {
+        let _7 = scope['value'];
+        if (_7 != null) {
             c6.push({text: _7});
         }
         {
-            const _origScope10 = scope;
+            let _origScope10 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 {
-                    const _origScope13 = scope;
+                    let _origScope13 = scope;
                     scope = Object.assign(Object.create(context), scope);
                     {
                         let c__0 = [];
@@ -799,17 +799,17 @@ exports[`properly support svg add proper namespace to g tags 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('g', p1, c1);
-    var _2 = '50';
-    var _3 = '50';
-    var _4 = '4';
-    var _5 = 'green';
-    var _6 = '1';
-    var _7 = 'yellow';
+    let vn1 = h('g', p1, c1);
+    let _2 = '50';
+    let _3 = '50';
+    let _4 = '4';
+    let _5 = 'green';
+    let _6 = '1';
+    let _7 = 'yellow';
     let c8 = [], p8 = {key:8,attrs:{cx: _2,cy: _3,r: _4,stroke: _5,\\"stroke-width\\": _6,fill: _7}};
-    var vn8 = h('circle', p8, c8);
+    let vn8 = h('circle', p8, c8);
     c1.push(vn8);
     c1.push({text: \` \`});
     utils.addNameSpace(vn1);
@@ -822,19 +822,19 @@ exports[`properly support svg add proper namespace to svg 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
-    var _1 = '100px';
-    var _2 = '90px';
+    let h = this.h;
+    let _1 = '100px';
+    let _2 = '90px';
     let c3 = [], p3 = {key:3,attrs:{width: _1,height: _2}};
-    var vn3 = h('svg', p3, c3);
-    var _4 = '50';
-    var _5 = '50';
-    var _6 = '4';
-    var _7 = 'green';
-    var _8 = '1';
-    var _9 = 'yellow';
+    let vn3 = h('svg', p3, c3);
+    let _4 = '50';
+    let _5 = '50';
+    let _6 = '4';
+    let _7 = 'green';
+    let _8 = '1';
+    let _9 = 'yellow';
     let c10 = [], p10 = {key:10,attrs:{cx: _4,cy: _5,r: _6,stroke: _7,\\"stroke-width\\": _8,fill: _9}};
-    var vn10 = h('circle', p10, c10);
+    let vn10 = h('circle', p10, c10);
     c3.push(vn10);
     c3.push({text: \` \`});
     utils.addNameSpace(vn3);
@@ -847,11 +847,11 @@ exports[`special cases for some boolean html attributes/properties input type= c
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
-    var _1 = 'checkbox';
-    var _2 = scope['flag'];
+    let h = this.h;
+    let _1 = 'checkbox';
+    let _2 = scope['flag'];
     let c3 = [], p3 = {key:3,attrs:{type: _1,checked: _2},props:{checked: _2}};
-    var vn3 = h('input', p3, c3);
+    let vn3 = h('input', p3, c3);
     return vn3;
 }"
 `;
@@ -860,38 +860,38 @@ exports[`special cases for some boolean html attributes/properties various boole
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = 'checkbox';
-    var _3 = 'checked';
+    let vn1 = h('div', p1, c1);
+    let _2 = 'checkbox';
+    let _3 = 'checked';
     let c4 = [], p4 = {key:4,attrs:{type: _2,checked: _3},props:{checked: _3}};
-    var vn4 = h('input', p4, c4);
+    let vn4 = h('input', p4, c4);
     c1.push(vn4);
-    var _5 = 'checked';
+    let _5 = 'checked';
     let c6 = [], p6 = {key:6,attrs:{checked: _5}};
-    var vn6 = h('input', p6, c6);
+    let vn6 = h('input', p6, c6);
     c1.push(vn6);
-    var _7 = 'checked';
+    let _7 = 'checked';
     let c8 = [], p8 = {key:8,attrs:{checked: _7}};
-    var vn8 = h('div', p8, c8);
+    let vn8 = h('div', p8, c8);
     c1.push(vn8);
-    var _9 = 'selected';
+    let _9 = 'selected';
     let c10 = [], p10 = {key:10,attrs:{selected: _9}};
-    var vn10 = h('div', p10, c10);
+    let vn10 = h('div', p10, c10);
     c1.push(vn10);
-    var _11 = 'selected';
-    var _12 = '1';
+    let _11 = 'selected';
+    let _12 = '1';
     let c13 = [], p13 = {key:13,attrs:{selected: _11,other: _12},props:{selected: _11}};
-    var vn13 = h('option', p13, c13);
+    let vn13 = h('option', p13, c13);
     c1.push(vn13);
-    var _14 = 'readonly';
+    let _14 = 'readonly';
     let c15 = [], p15 = {key:15,attrs:{readonly: _14},props:{readonly: _14}};
-    var vn15 = h('input', p15, c15);
+    let vn15 = h('input', p15, c15);
     c1.push(vn15);
-    var _16 = 'disabled';
+    let _16 = 'disabled';
     let c17 = [], p17 = {key:17,attrs:{disabled: _16},props:{disabled: _16}};
-    var vn17 = h('button', p17, c17);
+    let vn17 = h('button', p17, c17);
     c1.push(vn17);
     return vn1;
 }"
@@ -901,10 +901,10 @@ exports[`static templates div with a class attribute 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let _2 = {'abc':true};
     let c3 = [], p3 = {key:3,class:_2};
-    var vn3 = h('div', p3, c3);
+    let vn3 = h('div', p3, c3);
     c3.push({text: \`word\`});
     return vn3;
 }"
@@ -914,9 +914,9 @@ exports[`static templates div with a empty class attribute 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     c2.push({text: \`word\`});
     return vn2;
 }"
@@ -926,11 +926,11 @@ exports[`static templates div with a span child node 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`word\`});
     return vn1;
@@ -941,9 +941,9 @@ exports[`static templates div with a text node 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \`word\`});
     return vn1;
 }"
@@ -953,9 +953,9 @@ exports[`static templates empty div 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     return vn1;
 }"
 `;
@@ -964,9 +964,9 @@ exports[`static templates properly handle comments 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \`hello \`});
     c1.push(h('!', \` comment\`));
     c1.push({text: \`owl\`});
@@ -980,10 +980,10 @@ exports[`static templates simple dynamic value 1`] = `
     // Template name: \\"test\\"
     let scope = Object.create(context);
     let result;
-    var h = this.h;
-    var _1 = scope['text'];
-    if (_1 || _1 === 0) {
-        var vn2 = {text: _1};
+    let h = this.h;
+    let _1 = scope['text'];
+    if (_1 != null) {
+        let vn2 = {text: _1};
         result = vn2
     }
     return result;
@@ -995,8 +995,8 @@ exports[`static templates simple string 1`] = `
 ) {
     // Template name: \\"test\\"
     let result;
-    var h = this.h;
-    var vn1 = {text: \`hello vdom\`};
+    let h = this.h;
+    let vn1 = {text: \`hello vdom\`};
     result = vn1;
     return result;
 }"
@@ -1008,11 +1008,11 @@ exports[`static templates simple string, with some dynamic value 1`] = `
     // Template name: \\"test\\"
     let scope = Object.create(context);
     let result;
-    var h = this.h;
-    var vn1 = {text: \`hello \`};
+    let h = this.h;
+    let vn1 = {text: \`hello \`};
     result = vn1;
-    var _2 = scope['text'];
-    if (_2 || _2 === 0) {
+    let _2 = scope['text'];
+    if (_2 != null) {
         vn1.text += _2;
     }
     return result;
@@ -1024,9 +1024,9 @@ exports[`t-call (template calling basic caller 1`] = `
 ) {
     // Template name: \\"caller\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     this.subTemplates['_basic-callee'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -1036,10 +1036,10 @@ exports[`t-call (template calling basic caller 2`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"_basic-callee\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`ok\`});
 }"
@@ -1051,7 +1051,7 @@ exports[`t-call (template calling basic caller, no parent node 1`] = `
     // Template name: \\"caller\\"
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     result = []
     this.subTemplates['_basic-callee'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: result}));
     result = result[0]
@@ -1063,10 +1063,10 @@ exports[`t-call (template calling basic caller, no parent node 2`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"_basic-callee\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     c1.push(vn2);
     c2.push({text: \`ok\`});
 }"
@@ -1078,21 +1078,21 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
     // Template name: \\"main\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
-            var vn4 = h('span', p4, c4);
+            let vn4 = h('span', p4, c4);
             c__0.push(vn4);
             c4.push({text: \`hey\`});
             c__0.push({text: \` \`});
             let c5 = [], p5 = {key:5};
-            var vn5 = h('span', p5, c5);
+            let vn5 = h('span', p5, c5);
             c__0.push(vn5);
             c5.push({text: \`yay\`});
             scope[utils.zero] = c__0;
@@ -1110,10 +1110,10 @@ exports[`t-call (template calling call with several sub nodes on same line 2`] =
     // Template name: \\"SubTemplate\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     c1.push(vn2);
     c2.push(...scope[utils.zero]);
 }"
@@ -1125,21 +1125,21 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
     // Template name: \\"main\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope10 = scope;
+        let _origScope10 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c11 = [], p11 = {key:11};
-            var vn11 = h('span', p11, c11);
+            let vn11 = h('span', p11, c11);
             c__0.push(vn11);
             c11.push({text: \`hey\`});
             c__0.push({text: \` \`});
             let c12 = [], p12 = {key:12};
-            var vn12 = h('span', p12, c12);
+            let vn12 = h('span', p12, c12);
             c__0.push(vn12);
             c12.push({text: \`yay\`});
             scope[utils.zero] = c__0;
@@ -1156,9 +1156,9 @@ exports[`t-call (template calling inherit context 1`] = `
 ) {
     // Template name: \\"caller\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.foo = 1;
     this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
@@ -1170,11 +1170,11 @@ exports[`t-call (template calling recursive template, part 1 1`] = `
 ) {
     // Template name: \\"recursive\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`hey\`});
     if (false) {
@@ -1189,13 +1189,13 @@ exports[`t-call (template calling recursive template, part 1 2`] = `
 ) {
     // Template name: \\"recursive\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c3 = [], p3 = {key:3};
-    var vn3 = h('div', p3, c3);
+    let vn3 = h('div', p3, c3);
     c1.push(vn3);
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c3.push(vn4);
     c4.push({text: \`hey\`});
     if (false) {
@@ -1210,11 +1210,11 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     // Template name: \\"Parent\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope10 = scope;
+        let _origScope10 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1234,27 +1234,27 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
     // Template name: \\"nodeTemplate\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     c1.push(vn2);
     let c3 = [], p3 = {key:3};
-    var vn3 = h('p', p3, c3);
+    let vn3 = h('p', p3, c3);
     c2.push(vn3);
-    var _4 = scope['node'].val;
-    if (_4 || _4 === 0) {
+    let _4 = scope['node'].val;
+    if (_4 != null) {
         c3.push({text: _4});
     }
-    var _5 = scope['node'].children||[];
+    let _5 = scope['node'].children||[];
     if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    var _6 = _7 = _5;
+    let _6 = _7 = _5;
     if (!(_5 instanceof Array)) {
         _6 = Object.keys(_5);
         _7 = Object.values(_5);
     }
-    var _length6 = _6.length;
-    const _origScope8 = scope;
+    let _length6 = _6.length;
+    let _origScope8 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length6; i1++) {
         scope.subtree_first = i1 === 0
@@ -1263,7 +1263,7 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
         scope.subtree = _6[i1]
         scope.subtree_value = _7[i1]
         {
-            const _origScope9 = scope;
+            let _origScope9 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
@@ -1284,11 +1284,11 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     // Template name: \\"Parent\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope10 = scope;
+        let _origScope10 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1308,27 +1308,27 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
     // Template name: \\"nodeTemplate\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('div', p2, c2);
+    let vn2 = h('div', p2, c2);
     c1.push(vn2);
     let c3 = [], p3 = {key:3};
-    var vn3 = h('p', p3, c3);
+    let vn3 = h('p', p3, c3);
     c2.push(vn3);
-    var _4 = scope['node'].val;
-    if (_4 || _4 === 0) {
+    let _4 = scope['node'].val;
+    if (_4 != null) {
         c3.push({text: _4});
     }
-    var _5 = scope['node'].children||[];
+    let _5 = scope['node'].children||[];
     if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    var _6 = _7 = _5;
+    let _6 = _7 = _5;
     if (!(_5 instanceof Array)) {
         _6 = Object.keys(_5);
         _7 = Object.values(_5);
     }
-    var _length6 = _6.length;
-    const _origScope8 = scope;
+    let _length6 = _6.length;
+    let _origScope8 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length6; i1++) {
         scope.subtree_first = i1 === 0
@@ -1337,7 +1337,7 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
         scope.subtree = _6[i1]
         scope.subtree_value = _7[i1]
         {
-            const _origScope9 = scope;
+            let _origScope9 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
@@ -1358,11 +1358,11 @@ exports[`t-call (template calling scoped parameters 1`] = `
     // Template name: \\"caller\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope2 = scope;
+        let _origScope2 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1372,7 +1372,7 @@ exports[`t-call (template calling scoped parameters 1`] = `
         this.subTemplates['_basic-callee'].call(this, scope, Object.assign({}, extra, {parentNode: c1}));
         scope = _origScope2;
     }
-    if (scope.foo || scope.foo === 0) {
+    if (scope.foo != null) {
         c1.push({text: scope.foo});
     }
     return vn1;
@@ -1384,9 +1384,9 @@ exports[`t-call (template calling t-call with t-if 1`] = `
 ) {
     // Template name: \\"caller\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['flag']) {
         this.subTemplates['sub'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     }
@@ -1398,10 +1398,10 @@ exports[`t-call (template calling t-call with t-if 2`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"sub\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = extra.parentNode;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`ok\`});
 }"
@@ -1413,18 +1413,18 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
     // Template name: \\"main\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['list'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['list'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.v_first = i1 === 0
@@ -1434,7 +1434,7 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         scope.v_value = _4[i1]
         scope.val = scope['v'].val;
         {
-            const _origScope8 = scope;
+            let _origScope8 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
@@ -1455,9 +1455,9 @@ exports[`t-call (template calling t-call with t-set inside and outside. 2 1`] = 
 ) {
     // Template name: \\"wrapper\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('p', p1, c1);
+    let vn1 = h('p', p1, c1);
     scope.w = 'fromwrapper';
     this.subTemplates['main'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
@@ -1470,16 +1470,16 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     // Template name: \\"caller\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v1 = 'elif';
     if (scope.v1==='if') {
         this.subTemplates['callee1'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     }
     else if (scope.v1==='elif') {
         {
-            const _origScope5 = scope;
+            let _origScope5 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
@@ -1499,9 +1499,9 @@ exports[`t-call (template calling t-call, global templates 1`] = `
 ) {
     // Template name: \\"abcd\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     this.subTemplates['john'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -1514,9 +1514,9 @@ exports[`t-call (template calling with unused body 1`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1539,9 +1539,9 @@ exports[`t-call (template calling with unused setbody 1`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1564,9 +1564,9 @@ exports[`t-call (template calling with used body 1`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1588,11 +1588,11 @@ exports[`t-call (template calling with used set body 1`] = `
     // Template name: \\"caller\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
+    let vn1 = h('span', p1, c1);
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1606,16 +1606,63 @@ exports[`t-call (template calling with used set body 1`] = `
 }"
 `;
 
+exports[`t-esc div with falsy values 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"test\\"
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    let _3 = scope['v1'];
+    if (_3 != null) {
+        c2.push({text: _3});
+    }
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('p', p4, c4);
+    c1.push(vn4);
+    let _5 = scope['v2'];
+    if (_5 != null) {
+        c4.push({text: _5});
+    }
+    let c6 = [], p6 = {key:6};
+    let vn6 = h('p', p6, c6);
+    c1.push(vn6);
+    let _7 = scope['v3'];
+    if (_7 != null) {
+        c6.push({text: _7});
+    }
+    let c8 = [], p8 = {key:8};
+    let vn8 = h('p', p8, c8);
+    c1.push(vn8);
+    let _9 = scope['v4'];
+    if (_9 != null) {
+        c8.push({text: _9});
+    }
+    let c10 = [], p10 = {key:10};
+    let vn10 = h('p', p10, c10);
+    c1.push(vn10);
+    let _11 = scope['v5'];
+    if (_11 != null) {
+        c10.push({text: _11});
+    }
+    return vn1;
+}"
+`;
+
 exports[`t-esc escaping 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = scope['var'];
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
         c1.push({text: _2});
     }
     return vn1;
@@ -1627,11 +1674,11 @@ exports[`t-esc escaping on a node 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = 'ok';
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = 'ok';
+    if (_2 != null) {
         c1.push({text: _2});
     }
     return vn1;
@@ -1643,11 +1690,11 @@ exports[`t-esc escaping on a node with a body 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = 'ok';
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = 'ok';
+    if (_2 != null) {
         c1.push({text: _2});
     } else {
         c1.push({text: \`nope\`});
@@ -1661,11 +1708,11 @@ exports[`t-esc escaping on a node with a body, as a default 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = scope['var'];
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
         c1.push({text: _2});
     } else {
         c1.push({text: \`nope\`});
@@ -1679,11 +1726,11 @@ exports[`t-esc literal 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = 'ok';
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = 'ok';
+    if (_2 != null) {
         c1.push({text: _2});
     }
     return vn1;
@@ -1696,17 +1743,17 @@ exports[`t-esc t-esc is escaped 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    const c2 = new utils.VDomArray();
+    let vn1 = h('div', p1, c1);
+    let c2 = new utils.VDomArray();
     let c3 = [], p3 = {key:3};
-    var vn3 = h('p', p3, c3);
+    let vn3 = h('p', p3, c3);
     c2.push(vn3);
     c3.push({text: \`escaped\`});
     scope.var = c2
-    if (scope.var || scope.var === 0) {
-        const _origScope4 = scope;
+    if (scope.var != null) {
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.var = scope.var instanceof utils.VDomArray ? utils.vDomToString(scope.var) : scope.var;
         c1.push({text: scope.var});
@@ -1722,16 +1769,16 @@ exports[`t-esc t-esc=0 is escaped 1`] = `
     // Template name: \\"testCaller\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     {
-        const _origScope3 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
-            var vn4 = h('p', p4, c4);
+            let vn4 = h('p', p4, c4);
             c__0.push(vn4);
             c4.push({text: \`escaped\`});
             scope[utils.zero] = c__0;
@@ -1748,11 +1795,11 @@ exports[`t-esc variable 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = scope['var'];
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
         c1.push({text: _2});
     }
     return vn1;
@@ -1764,9 +1811,9 @@ exports[`t-if boolean value condition elif 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['color']=='black') {
         c1.push({text: \`black pearl\`});
     }
@@ -1788,11 +1835,11 @@ exports[`t-if boolean value condition else 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`begin\`});
     if (scope['condition']) {
@@ -1802,7 +1849,7 @@ exports[`t-if boolean value condition else 1`] = `
         c1.push({text: \`ok-else\`});
     }
     let c3 = [], p3 = {key:3};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c1.push(vn3);
     c3.push({text: \`end\`});
     return vn1;
@@ -1814,11 +1861,11 @@ exports[`t-if boolean value condition false else 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`begin\`});
     if (scope['condition']) {
@@ -1828,7 +1875,7 @@ exports[`t-if boolean value condition false else 1`] = `
         c1.push({text: \`fail-else\`});
     }
     let c3 = [], p3 = {key:3};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c1.push(vn3);
     c3.push({text: \`end\`});
     return vn1;
@@ -1840,9 +1887,9 @@ exports[`t-if boolean value condition missing 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
+    let vn1 = h('span', p1, c1);
     if (scope['condition']) {
         c1.push({text: \`fail\`});
     }
@@ -1855,9 +1902,9 @@ exports[`t-if boolean value false condition 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['condition']) {
         c1.push({text: \`ok\`});
     }
@@ -1870,9 +1917,9 @@ exports[`t-if boolean value true condition 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['condition']) {
         c1.push({text: \`ok\`});
     }
@@ -1885,9 +1932,9 @@ exports[`t-if can use some boolean operators in expressions 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['cond1']&&scope['cond2']) {
         c1.push({text: \`and\`});
     }
@@ -1921,15 +1968,15 @@ exports[`t-if t-esc with t-elif 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (false) {
         c1.push({text: \`abc\`});
     }
     else {
-        var _2 = 'x';
-        if (_2 || _2 === 0) {
+        let _2 = 'x';
+        if (_2 != null) {
             c1.push({text: _2});
         }
     }
@@ -1942,12 +1989,12 @@ exports[`t-if t-esc with t-if 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (true) {
-        var _2 = 'x';
-        if (_2 || _2 === 0) {
+        let _2 = 'x';
+        if (_2 != null) {
             c1.push({text: _2});
         }
     }
@@ -1960,20 +2007,20 @@ exports[`t-if t-set, then t-elif, part 3 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.y = false;
     scope.x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
-        var vn2 = h('span', p2, c2);
+        let vn2 = h('span', p2, c2);
         c1.push(vn2);
         c2.push({text: \`AAA\`});
     }
     else if (!scope.x) {
         let c3 = [], p3 = {key:3};
-        var vn3 = h('span', p3, c3);
+        let vn3 = h('span', p3, c3);
         c1.push(vn3);
         c3.push({text: \`BBB\`});
     }
@@ -1986,12 +2033,12 @@ exports[`t-if t-set, then t-if 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.title = 'test';
     if (scope.title) {
-        if (scope.title || scope.title === 0) {
+        if (scope.title != null) {
             c1.push({text: scope.title});
         }
     }
@@ -2004,14 +2051,14 @@ exports[`t-if t-set, then t-if, part 2 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.y = true;
     scope.x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
-        var vn2 = h('span', p2, c2);
+        let vn2 = h('span', p2, c2);
         c1.push(vn2);
         c2.push({text: \`COUCOU\`});
     }
@@ -2024,12 +2071,12 @@ exports[`t-key can use t-key directive on a node 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     const nodeKey1 = scope['beer'].id;
     let c2 = [], p2 = {key:nodeKey1};
-    var vn2 = h('div', p2, c2);
-    var _3 = scope['beer'].name;
-    if (_3 || _3 === 0) {
+    let vn2 = h('div', p2, c2);
+    let _3 = scope['beer'].name;
+    if (_3 != null) {
         c2.push({text: _3});
     }
     return vn2;
@@ -2041,18 +2088,18 @@ exports[`t-key t-key directive in a list 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('ul', p1, c1);
-    var _2 = scope['beers'];
+    let vn1 = h('ul', p1, c1);
+    let _2 = scope['beers'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.beer_first = i1 === 0
@@ -2062,10 +2109,10 @@ exports[`t-key t-key directive in a list 1`] = `
         scope.beer_value = _4[i1]
         const nodeKey6 = scope['beer'].id;
         let c7 = [], p7 = {key:nodeKey6};
-        var vn7 = h('li', p7, c7);
+        let vn7 = h('li', p7, c7);
         c1.push(vn7);
-        var _8 = scope['beer'].name;
-        if (_8 || _8 === 0) {
+        let _8 = scope['beer'].name;
+        if (_8 != null) {
             c7.push({text: _8});
         }
     }
@@ -2081,9 +2128,9 @@ exports[`t-on can bind event handler 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
     p1.on['click'] = extra.handlers['click__2__'];
     c1.push({text: \`Click\`});
@@ -2097,9 +2144,9 @@ exports[`t-on can bind handlers with arguments 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     let args2 = [5];
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](...args2, e);};
     c1.push({text: \`Click\`});
@@ -2113,9 +2160,9 @@ exports[`t-on can bind handlers with empty object (with non empty inner string) 
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     let args2 = [{}];
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](...args2, e);};
     c1.push({text: \`Click\`});
@@ -2129,9 +2176,9 @@ exports[`t-on can bind handlers with empty object 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     let args2 = [{}];
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](...args2, e);};
     c1.push({text: \`Click\`});
@@ -2145,18 +2192,18 @@ exports[`t-on can bind handlers with loop variable as argument 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('ul', p1, c1);
-    var _2 = ['someval'];
+    let vn1 = h('ul', p1, c1);
+    let _2 = ['someval'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.action_first = i1 === 0
@@ -2166,10 +2213,10 @@ exports[`t-on can bind handlers with loop variable as argument 1`] = `
         scope.action_value = _4[i1]
         const nodeKey6 = scope['action_index'];
         let c7 = [], p7 = {key:nodeKey6};
-        var vn7 = h('li', p7, c7);
+        let vn7 = h('li', p7, c7);
         c1.push(vn7);
         let c8 = [], p8 = {key:nodeKey6,on:{}};
-        var vn8 = h('a', p8, c8);
+        let vn8 = h('a', p8, c8);
         c7.push(vn8);
         let args9 = [scope['action']];
         p8.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['activate'](...args9, e);};
@@ -2186,9 +2233,9 @@ exports[`t-on can bind handlers with object arguments 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     let args2 = [{val:5}];
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](...args2, e);};
     c1.push({text: \`Click\`});
@@ -2201,9 +2248,9 @@ exports[`t-on can bind two event handlers 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleClick'](e);};
     p1.on['click'] = extra.handlers['click__2__'];
     extra.handlers['dblclick__3__'] = extra.handlers['dblclick__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleDblClick'](e);};
@@ -2218,9 +2265,9 @@ exports[`t-on handler is bound to proper owner 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
     p1.on['click'] = extra.handlers['click__2__'];
     c1.push({text: \`Click\`});
@@ -2234,16 +2281,16 @@ exports[`t-on t-on combined with t-esc 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
-    var _4 = scope['text'];
-    if (_4 || _4 === 0) {
+    let _4 = scope['text'];
+    if (_4 != null) {
         c2.push({text: _4});
     }
     return vn1;
@@ -2256,16 +2303,16 @@ exports[`t-on t-on combined with t-raw 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
-    var _4 = scope['html'];
-    if (_4 || _4 === 0) {
+    let _4 = scope['html'];
+    if (_4 != null) {
         c2.push(...utils.htmlToVDOM(_4));
     }
     return vn1;
@@ -2277,11 +2324,11 @@ exports[`t-on t-on with empty handler (only modifiers) 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     p2.on['click'] = function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();};
     c2.push({text: \`Button\`});
@@ -2294,9 +2341,9 @@ exports[`t-on t-on with inline statement (function call) 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].incrementCounter(2)};
     c1.push({text: \`Click\`});
     return vn1;
@@ -2308,9 +2355,9 @@ exports[`t-on t-on with inline statement 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].counter++};
     c1.push({text: \`Click\`});
     return vn1;
@@ -2322,9 +2369,9 @@ exports[`t-on t-on with inline statement, part 2 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].flag=!scope['state'].flag};
     c1.push({text: \`Toggle\`});
     return vn1;
@@ -2336,9 +2383,9 @@ exports[`t-on t-on with inline statement, part 3 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
-    var vn1 = h('button', p1, c1);
+    let vn1 = h('button', p1, c1);
     p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].n=scope['someFunction'](3)};
     c1.push({text: \`Toggle\`});
     return vn1;
@@ -2350,16 +2397,16 @@ exports[`t-on t-on with prevent and self modifiers (order matters) 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();if (e.target !== this.elm) {return}utils.getComponent(context)['onClick'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c2.push(vn4);
     c4.push({text: \`Button\`});
     return vn1;
@@ -2371,23 +2418,23 @@ exports[`t-on t-on with prevent and/or stop modifiers 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onClickPrevented'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
     c2.push({text: \`Button 1\`});
     let c4 = [], p4 = {key:4,on:{}};
-    var vn4 = h('button', p4, c4);
+    let vn4 = h('button', p4, c4);
     c1.push(vn4);
     extra.handlers['click__5__'] = extra.handlers['click__5__'] || function (e) {if (!context.__owl__.isMounted){return}e.stopPropagation();utils.getComponent(context)['onClickStopped'](e);};
     p4.on['click'] = extra.handlers['click__5__'];
     c4.push({text: \`Button 2\`});
     let c6 = [], p6 = {key:6,on:{}};
-    var vn6 = h('button', p6, c6);
+    let vn6 = h('button', p6, c6);
     c1.push(vn6);
     extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();e.stopPropagation();utils.getComponent(context)['onClickPreventedAndStopped'](e);};
     p6.on['click'] = extra.handlers['click__7__'];
@@ -2402,18 +2449,18 @@ exports[`t-on t-on with prevent modifier in t-foreach 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['projects'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['projects'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.project_first = i1 === 0
@@ -2422,15 +2469,15 @@ exports[`t-on t-on with prevent modifier in t-foreach 1`] = `
         scope.project = _3[i1]
         scope.project_value = _4[i1]
         const nodeKey6 = scope['project'];
-        var _7 = '#';
+        let _7 = '#';
         let c8 = [], p8 = {key:nodeKey6,attrs:{href: _7},on:{}};
-        var vn8 = h('a', p8, c8);
+        let vn8 = h('a', p8, c8);
         c1.push(vn8);
         let args9 = [scope['project'].id];
         p8.on['click'] = function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onEdit'](...args9, e);};
         c8.push({text: \` Edit \`});
-        var _10 = scope['project'].name;
-        if (_10 || _10 === 0) {
+        let _10 = scope['project'].name;
+        if (_10 != null) {
             c8.push({text: _10});
         }
     }
@@ -2444,16 +2491,16 @@ exports[`t-on t-on with self and prevent modifiers (order matters) 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}e.preventDefault();utils.getComponent(context)['onClick'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c2.push(vn4);
     c4.push({text: \`Button\`});
     return vn1;
@@ -2465,25 +2512,25 @@ exports[`t-on t-on with self modifier 1`] = `
 ) {
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2,on:{}};
-    var vn2 = h('button', p2, c2);
+    let vn2 = h('button', p2, c2);
     c1.push(vn2);
     extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
     p2.on['click'] = extra.handlers['click__3__'];
     let c4 = [], p4 = {key:4};
-    var vn4 = h('span', p4, c4);
+    let vn4 = h('span', p4, c4);
     c2.push(vn4);
     c4.push({text: \`Button\`});
     let c5 = [], p5 = {key:5,on:{}};
-    var vn5 = h('button', p5, c5);
+    let vn5 = h('button', p5, c5);
     c1.push(vn5);
     extra.handlers['click__6__'] = extra.handlers['click__6__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}utils.getComponent(context)['onClickSelf'](e);};
     p5.on['click'] = extra.handlers['click__6__'];
     let c7 = [], p7 = {key:7};
-    var vn7 = h('span', p7, c7);
+    let vn7 = h('span', p7, c7);
     c5.push(vn7);
     c7.push({text: \`Button\`});
     return vn1;
@@ -2495,9 +2542,9 @@ exports[`t-on t-on with t-call 1`] = `
 ) {
     // Template name: \\"main\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     this.subTemplates['sub'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -2508,9 +2555,9 @@ exports[`t-on t-on, with arguments and t-call 1`] = `
 ) {
     // Template name: \\"main\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     this.subTemplates['sub'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1}));
     return vn1;
 }"
@@ -2522,11 +2569,11 @@ exports[`t-raw literal 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = 'ok';
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = 'ok';
+    if (_2 != null) {
         c1.push(...utils.htmlToVDOM(_2));
     }
     return vn1;
@@ -2539,11 +2586,11 @@ exports[`t-raw not escaping 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['var'];
-    if (_2 || _2 === 0) {
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
         c1.push(...utils.htmlToVDOM(_2));
     }
     return vn1;
@@ -2556,15 +2603,15 @@ exports[`t-raw t-raw and another sibling node 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
+    let vn1 = h('span', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`hello\`});
-    var _3 = scope['var'];
-    if (_3 || _3 === 0) {
+    let _3 = scope['var'];
+    if (_3 != null) {
         c1.push(...utils.htmlToVDOM(_3));
     }
     return vn1;
@@ -2577,11 +2624,11 @@ exports[`t-raw variable 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('span', p1, c1);
-    var _2 = scope['var'];
-    if (_2 || _2 === 0) {
+    let vn1 = h('span', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
         c1.push(...utils.htmlToVDOM(_2));
     }
     return vn1;
@@ -2594,11 +2641,11 @@ exports[`t-ref can get a dynamic ref on a node 1`] = `
     // Template name: \\"test\\"
     context.__owl__.refs = context.__owl__.refs || {};
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     const ref3 = \`myspan\${scope['id']}\`;
     p2.hook = {
@@ -2618,11 +2665,11 @@ exports[`t-ref can get a ref on a node 1`] = `
 ) {
     // Template name: \\"test\\"
     context.__owl__.refs = context.__owl__.refs || {};
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     const ref3 = \`myspan\`;
     p2.hook = {
@@ -2643,18 +2690,18 @@ exports[`t-ref refs in a loop 1`] = `
     // Template name: \\"test\\"
     context.__owl__.refs = context.__owl__.refs || {};
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = scope['items'];
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['items'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
@@ -2664,7 +2711,7 @@ exports[`t-ref refs in a loop 1`] = `
         scope.item_value = _4[i1]
         const nodeKey6 = scope['item'];
         let c7 = [], p7 = {key:nodeKey6};
-        var vn7 = h('div', p7, c7);
+        let vn7 = h('div', p7, c7);
         c1.push(vn7);
         const ref8 = (scope['item']);
         p7.hook = {
@@ -2675,8 +2722,8 @@ exports[`t-ref refs in a loop 1`] = `
             delete context.__owl__.refs[ref8];
           },
         };
-        var _9 = scope['item'];
-        if (_9 || _9 === 0) {
+        let _9 = scope['item'];
+        if (_9 != null) {
             c7.push({text: _9});
         }
     }
@@ -2690,11 +2737,11 @@ exports[`t-set evaluate value expression 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.value = 1+2;
-    if (scope.value || scope.value === 0) {
+    if (scope.value != null) {
         c1.push({text: scope.value});
     }
     return vn1;
@@ -2706,11 +2753,11 @@ exports[`t-set evaluate value expression, part 2 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.value = scope['somevariable']+2;
-    if (scope.value || scope.value === 0) {
+    if (scope.value != null) {
         c1.push({text: scope.value});
     }
     return vn1;
@@ -2722,11 +2769,11 @@ exports[`t-set set from attribute literal 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.value = 'ok';
-    if (scope.value || scope.value === 0) {
+    if (scope.value != null) {
         c1.push({text: scope.value});
     }
     return vn1;
@@ -2738,11 +2785,11 @@ exports[`t-set set from attribute lookup 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.stuff = scope['value'];
-    if (scope.stuff || scope.stuff === 0) {
+    if (scope.stuff != null) {
         c1.push({text: scope.stuff});
     }
     return vn1;
@@ -2756,15 +2803,15 @@ exports[`t-set set from body literal 1`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
-    const c1 = new utils.VDomArray();
+    let h = this.h;
+    let c1 = new utils.VDomArray();
     c1.push({text: \`ok\`});
     scope.value = c1
-    if (scope.value || scope.value === 0) {
-        const _origScope2 = scope;
+    if (scope.value != null) {
+        let _origScope2 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
-        var vn3 = {text: scope.value};
+        let vn3 = {text: scope.value};
         result = vn3
         scope = _origScope2;
     }
@@ -2778,17 +2825,17 @@ exports[`t-set set from body lookup 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    const c2 = new utils.VDomArray();
-    var _3 = scope['value'];
-    if (_3 || _3 === 0) {
+    let vn1 = h('div', p1, c1);
+    let c2 = new utils.VDomArray();
+    let _3 = scope['value'];
+    if (_3 != null) {
         c2.push({text: _3});
     }
     scope.stuff = c2
-    if (scope.stuff || scope.stuff === 0) {
-        const _origScope4 = scope;
+    if (scope.stuff != null) {
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.stuff = scope.stuff instanceof utils.VDomArray ? utils.vDomToString(scope.stuff) : scope.stuff;
         c1.push({text: scope.stuff});
@@ -2803,10 +2850,10 @@ exports[`t-set set from empty body 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    if (scope.stuff || scope.stuff === 0) {
+    let vn1 = h('div', p1, c1);
+    if (scope.stuff != null) {
         c1.push({text: scope.stuff});
     }
     return vn1;
@@ -2818,9 +2865,9 @@ exports[`t-set t-set and t-if 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v = scope['value'];
     if (scope.v==='ok') {
         c1.push({text: \`grimbergen\`});
@@ -2835,20 +2882,20 @@ exports[`t-set t-set body is evaluated immediately 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v1 = 'before';
-    const c2 = new utils.VDomArray();
+    let c2 = new utils.VDomArray();
     let c3 = [], p3 = {key:3};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c2.push(vn3);
-    if (scope.v1 || scope.v1 === 0) {
+    if (scope.v1 != null) {
         c3.push({text: scope.v1});
     }
     scope.v2 = c2
     scope.v1 = 'after';
-    if (scope.v2 || scope.v2 === 0) {
+    if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
     }
@@ -2861,14 +2908,14 @@ exports[`t-set t-set evaluates an expression only once 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v = scope['value']+' artois';
-    if (scope.v || scope.v === 0) {
+    if (scope.v != null) {
         c1.push({text: scope.v});
     }
-    if (scope.v || scope.v === 0) {
+    if (scope.v != null) {
         c1.push({text: scope.v});
     }
     return vn1;
@@ -2880,19 +2927,19 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
 ) {
     // Template name: \\"test\\"
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v = 1;
-    var _2 = scope['list'];
+    let _2 = scope['list'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
-    var _3 = _4 = _2;
+    let _3 = _4 = _2;
     if (!(_2 instanceof Array)) {
         _3 = Object.keys(_2);
         _4 = Object.values(_2);
     }
-    var _length3 = _3.length;
-    const _origScope5 = scope;
+    let _length3 = _3.length;
+    let _origScope5 = scope;
     scope = Object.assign(Object.create(context), scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.elem_first = i1 === 0
@@ -2902,13 +2949,13 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
         scope.elem_value = _4[i1]
         const nodeKey6 = scope['elem_index'];
         let c7 = [], p7 = {key:nodeKey6};
-        var vn7 = h('div', p7, c7);
+        let vn7 = h('div', p7, c7);
         c1.push(vn7);
         let c8 = [], p8 = {key:nodeKey6};
-        var vn8 = h('span', p8, c8);
+        let vn8 = h('span', p8, c8);
         c7.push(vn8);
         c8.push({text: \`v\`});
-        if (scope.v || scope.v === 0) {
+        if (scope.v != null) {
             c8.push({text: scope.v});
         }
         scope.v = scope['elem'];
@@ -2924,25 +2971,25 @@ exports[`t-set t-set with t-value (falsy) and body 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v3 = false;
     scope.v1 = 'before';
     scope.v2 = scope.v3;
     if (!(scope.v2)) {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
-        var vn3 = h('span', p3, c3);
+        let vn3 = h('span', p3, c3);
         c2.push(vn3);
-        if (scope.v1 || scope.v1 === 0) {
+        if (scope.v1 != null) {
             c3.push({text: scope.v1});
         }
         scope.v2 = c2
     }
     scope.v1 = 'after';
     scope.v3 = true;
-    if (scope.v2 || scope.v2 === 0) {
+    if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
     }
@@ -2956,25 +3003,25 @@ exports[`t-set t-set with t-value (truthy) and body 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.v3 = 'Truthy';
     scope.v1 = 'before';
     scope.v2 = scope.v3;
     if (!(scope.v2)) {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
-        var vn3 = h('span', p3, c3);
+        let vn3 = h('span', p3, c3);
         c2.push(vn3);
-        if (scope.v1 || scope.v1 === 0) {
+        if (scope.v1 != null) {
             c3.push({text: scope.v1});
         }
         scope.v2 = c2
     }
     scope.v1 = 'after';
     scope.v3 = false;
-    if (scope.v2 || scope.v2 === 0) {
+    if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
     }
@@ -2988,19 +3035,19 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         c2.push({text: \`1\`});
         scope.ourvar = c2
     }
     else {
         scope.ourvar = 0;
     }
-    if (scope.ourvar || scope.ourvar === 0) {
-        const _origScope3 = scope;
+    if (scope.ourvar != null) {
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
@@ -3016,19 +3063,19 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 2`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         c2.push({text: \`1\`});
         scope.ourvar = c2
     }
     else {
         scope.ourvar = 0;
     }
-    if (scope.ourvar || scope.ourvar === 0) {
-        const _origScope3 = scope;
+    if (scope.ourvar != null) {
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
@@ -3044,19 +3091,19 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['flag']) {
         scope.ourvar = 1;
     }
     else {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         c2.push({text: \`0\`});
         scope.ourvar = c2
     }
-    if (scope.ourvar || scope.ourvar === 0) {
-        const _origScope3 = scope;
+    if (scope.ourvar != null) {
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
@@ -3072,19 +3119,19 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 2`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     if (scope['flag']) {
         scope.ourvar = 1;
     }
     else {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         c2.push({text: \`0\`});
         scope.ourvar = c2
     }
-    if (scope.ourvar || scope.ourvar === 0) {
-        const _origScope3 = scope;
+    if (scope.ourvar != null) {
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
@@ -3100,17 +3147,17 @@ exports[`t-set value priority 1`] = `
     // Template name: \\"test\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     scope.value = 1;
     if (!(scope.value)) {
-        const c2 = new utils.VDomArray();
+        let c2 = new utils.VDomArray();
         c2.push({text: \`2\`});
         scope.value = c2
     }
-    if (scope.value || scope.value === 0) {
-        const _origScope3 = scope;
+    if (scope.value != null) {
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
         c1.push({text: scope.value});
@@ -3124,9 +3171,9 @@ exports[`translation support can translate node content 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \`mot\`});
     return vn1;
 }"
@@ -3136,15 +3183,15 @@ exports[`translation support does not translate node content if disabled 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`mot\`});
     let c3 = [], p3 = {key:3};
-    var vn3 = h('span', p3, c3);
+    let vn3 = h('span', p3, c3);
     c1.push(vn3);
     c3.push({text: \`word\`});
     return vn1;
@@ -3155,32 +3202,32 @@ exports[`translation support some attributes are translated 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
-    var _2 = 'mot';
+    let vn1 = h('div', p1, c1);
+    let _2 = 'mot';
     let c3 = [], p3 = {key:3,attrs:{label: _2}};
-    var vn3 = h('p', p3, c3);
+    let vn3 = h('p', p3, c3);
     c1.push(vn3);
     c3.push({text: \`mot\`});
-    var _4 = 'mot';
+    let _4 = 'mot';
     let c5 = [], p5 = {key:5,attrs:{title: _4}};
-    var vn5 = h('p', p5, c5);
+    let vn5 = h('p', p5, c5);
     c1.push(vn5);
     c5.push({text: \`mot\`});
-    var _6 = 'mot';
+    let _6 = 'mot';
     let c7 = [], p7 = {key:7,attrs:{placeholder: _6}};
-    var vn7 = h('p', p7, c7);
+    let vn7 = h('p', p7, c7);
     c1.push(vn7);
     c7.push({text: \`mot\`});
-    var _8 = 'mot';
+    let _8 = 'mot';
     let c9 = [], p9 = {key:9,attrs:{alt: _8}};
-    var vn9 = h('p', p9, c9);
+    let vn9 = h('p', p9, c9);
     c1.push(vn9);
     c9.push({text: \`mot\`});
-    var _10 = 'word';
+    let _10 = 'word';
     let c11 = [], p11 = {key:11,attrs:{something: _10}};
-    var vn11 = h('p', p11, c11);
+    let vn11 = h('p', p11, c11);
     c1.push(vn11);
     c11.push({text: \`mot\`});
     return vn1;
@@ -3191,9 +3238,9 @@ exports[`whitespace handling consecutives whitespaces are condensed into a singl
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \` abc \`});
     return vn1;
 }"
@@ -3203,9 +3250,9 @@ exports[`whitespace handling nothing is done in pre tags 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('pre', p1, c1);
+    let vn1 = h('pre', p1, c1);
     c1.push({text: \`  \`});
     return vn1;
 }"
@@ -3215,9 +3262,9 @@ exports[`whitespace handling nothing is done in pre tags 2`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test2\\"
-    var h = this.h;
+    let h = this.h;
     let c2 = [], p2 = {key:2};
-    var vn2 = h('pre', p2, c2);
+    let vn2 = h('pre', p2, c2);
     c2.push({text: \`
         some text
       \`});
@@ -3229,9 +3276,9 @@ exports[`whitespace handling nothing is done in pre tags 3`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test3\\"
-    var h = this.h;
+    let h = this.h;
     let c3 = [], p3 = {key:3};
-    var vn3 = h('pre', p3, c3);
+    let vn3 = h('pre', p3, c3);
     c3.push({text: \`
         
       \`});
@@ -3243,9 +3290,9 @@ exports[`whitespace handling white space only text nodes are condensed into a si
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     c1.push({text: \` \`});
     return vn1;
 }"
@@ -3255,11 +3302,11 @@ exports[`whitespace handling whitespace only text nodes with newlines are remove
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    var h = this.h;
+    let h = this.h;
     let c1 = [], p1 = {key:1};
-    var vn1 = h('div', p1, c1);
+    let vn1 = h('div', p1, c1);
     let c2 = [], p2 = {key:2};
-    var vn2 = h('span', p2, c2);
+    let vn2 = h('span', p2, c2);
     c1.push(vn2);
     c2.push({text: \`abc\`});
     return vn1;

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -152,6 +152,26 @@ describe("t-esc", () => {
     const domRendered = renderToDOM(qweb, "testCaller") as HTMLElement;
     expect(domRendered.querySelector("span")!.textContent).toBe("<p>escaped</p>");
   });
+
+  test("div with falsy values", () => {
+    qweb.addTemplate("test", `
+      <div>
+        <p t-esc="v1"/>
+        <p t-esc="v2"/>
+        <p t-esc="v3"/>
+        <p t-esc="v4"/>
+        <p t-esc="v5"/>
+      </div>`);
+    const vals = {
+      v1: false,
+      v2: undefined,
+      v3: null,
+      v4: 0,
+      v5: ""
+    }
+    expect(renderToString(qweb, "test", vals)).toBe("<div><p>false</p><p></p><p></p><p>0</p><p></p></div>");
+  });
+
 });
 
 describe("t-raw", () => {

--- a/tests/router/__snapshots__/link.test.ts.snap
+++ b/tests/router/__snapshots__/link.test.ts.snap
@@ -6,11 +6,11 @@ exports[`Link component can render simple cases 1`] = `
     // Template name: \\"__template__1\\"
     let utils = this.constructor.utils;
     let scope = Object.create(context);
-    var h = this.h;
+    let h = this.h;
     let _4 = utils.toObj({'router-link-active':scope['isActive']});
-    var _5 = scope['href'];
+    let _5 = scope['href'];
     let c6 = [], p6 = {key:6,attrs:{href: _5},class:_4,on:{}};
-    var vn6 = h('a', p6, c6);
+    let vn6 = h('a', p6, c6);
     extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
     p6.on['click'] = extra.handlers['click__7__'];
     const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];

--- a/tests/router/__snapshots__/route_component.test.ts.snap
+++ b/tests/router/__snapshots__/route_component.test.ts.snap
@@ -9,7 +9,7 @@ exports[`RouteComponent can render simple cases 1`] = `
     let parent = context;
     let scope = Object.create(context);
     let result;
-    var h = this.h;
+    let h = this.h;
     if (scope['routeComponent']) {
         const nodeKey4 = scope['env'].router.currentRouteName;
         // Component 'routeComponent'


### PR DESCRIPTION
While it is not tested, nor documented, the reference QWeb
implementation display the `false` value as "false". So, we have to
adapt the Owl implementation to match that behaviour.

At the same time, this commit uses 'let' instead of 'var' in various places,
to make the compiled code more consistant.