### PR TITLE
[FIX] qweb: t-call properly transfer key to sub components

### DIFF
--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -383,7 +383,12 @@ export class QWeb extends EventBus {
     });
   }
 
-  _compile(name: string, elem: Element, parentContext?: CompilationContext): CompiledTemplate {
+  _compile(
+    name: string,
+    elem: Element,
+    parentContext?: CompilationContext,
+    defineKey?: boolean
+  ): CompiledTemplate {
     const isDebug = elem.attributes.hasOwnProperty("t-debug");
     const ctx = new CompilationContext(name);
     if (elem.tagName !== "t") {
@@ -396,6 +401,10 @@ export class QWeb extends EventBus {
       ctx.hasParentWidget = true;
       ctx.shouldDefineResult = false;
       ctx.addLine(`let c${ctx.parentNode} = extra.parentNode;`);
+      if (defineKey) {
+        ctx.currentKey = `key${ctx.generateID()}`;
+        ctx.addLine(`let ${ctx.currentKey} = extra.key || '';`);
+      }
     }
     this._compileNode(elem, ctx);
 

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -1017,12 +1017,14 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
     let utils = this.constructor.utils;
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2,on:{}};
-    let vn2 = h('p', p2, c2);
-    c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    c2.push({text: \`lucas\`});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2,on:{}};
+    let vn3 = h('p', p3, c3);
+    c1.push(vn3);
+    let k4 = \`click__4__\` + key2;
+    extra.handlers[k4] = extra.handlers[k4] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
+    p3.on['click'] = extra.handlers[k4];
+    c3.push({text: \`lucas\`});
 }"
 `;
 
@@ -1034,12 +1036,13 @@ exports[`t-call handlers with arguments are properly bound through a t-call 1`] 
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2,on:{}};
-    let vn2 = h('p', p2, c2);
-    c1.push(vn2);
-    let args3 = [scope['a']];
-    p2.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](...args3, e);};
-    c2.push({text: \`lucas\`});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2,on:{}};
+    let vn3 = h('p', p3, c3);
+    c1.push(vn3);
+    let args4 = [scope['a']];
+    p3.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](...args4, e);};
+    c3.push({text: \`lucas\`});
 }"
 `;
 
@@ -1053,29 +1056,31 @@ exports[`t-call parent is set within t-call 1`] = `
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
+    let key2 = extra.key || '';
     // Component 'Child'
-    let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
-    let props2 = {};
-    if (w2 && w2.__owl__.currentFiber && !w2.__owl__.vnode) {
-        w2.destroy();
-        w2 = false;
+    let k4 = \`__4__\` + key2;
+    let w3 = k4 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k4]] : false;
+    let props3 = {};
+    if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
+        w3.destroy();
+        w3 = false;
     }
-    if (w2) {
-        w2.__updateProps(props2, extra.fiber, undefined);
-        let pvnode = w2.__owl__.pvnode;
+    if (w3) {
+        w3.__updateProps(props3, extra.fiber, undefined);
+        let pvnode = w3.__owl__.pvnode;
         c1.push(pvnode);
     } else {
-        let componentKey2 = \`Child\`;
-        let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| scope['Child'];
-        if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
-        w2 = new W2(parent, props2);
-        parent.__owl__.cmap['__3__'] = w2.__owl__.id;
-        let fiber = w2.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-        let pvnode = h('dummy', {key: '__3__', hook: {remove() {},destroy(vn) {w2.destroy();}}});
+        let componentKey3 = \`Child\`;
+        let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| scope['Child'];
+        if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
+        w3 = new W3(parent, props3);
+        parent.__owl__.cmap[k4] = w3.__owl__.id;
+        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+        let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
         c1.push(pvnode);
-        w2.__owl__.pvnode = pvnode;
+        w3.__owl__.pvnode = pvnode;
     }
-    w2.__owl__.parentLastFiberId = extra.fiber.id;
+    w3.__owl__.parentLastFiberId = extra.fiber.id;
 }"
 `;
 
@@ -1089,29 +1094,31 @@ exports[`t-call parent is set within t-call with no parentNode 1`] = `
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
+    let key2 = extra.key || '';
     // Component 'Child'
-    let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
-    let props2 = {};
-    if (w2 && w2.__owl__.currentFiber && !w2.__owl__.vnode) {
-        w2.destroy();
-        w2 = false;
+    let k4 = \`__4__\` + key2;
+    let w3 = k4 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k4]] : false;
+    let props3 = {};
+    if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
+        w3.destroy();
+        w3 = false;
     }
-    if (w2) {
-        w2.__updateProps(props2, extra.fiber, undefined);
-        let pvnode = w2.__owl__.pvnode;
+    if (w3) {
+        w3.__updateProps(props3, extra.fiber, undefined);
+        let pvnode = w3.__owl__.pvnode;
         c1.push(pvnode);
     } else {
-        let componentKey2 = \`Child\`;
-        let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| scope['Child'];
-        if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
-        w2 = new W2(parent, props2);
-        parent.__owl__.cmap['__3__'] = w2.__owl__.id;
-        let fiber = w2.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-        let pvnode = h('dummy', {key: '__3__', hook: {remove() {},destroy(vn) {w2.destroy();}}});
+        let componentKey3 = \`Child\`;
+        let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| scope['Child'];
+        if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
+        w3 = new W3(parent, props3);
+        parent.__owl__.cmap[k4] = w3.__owl__.id;
+        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+        let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
         c1.push(pvnode);
-        w2.__owl__.pvnode = pvnode;
+        w3.__owl__.pvnode = pvnode;
     }
-    w2.__owl__.parentLastFiberId = extra.fiber.id;
+    w3.__owl__.parentLastFiberId = extra.fiber.id;
 }"
 `;
 

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -5599,6 +5599,26 @@ describe("t-call", () => {
     expect(env.qweb.subTemplates["sub"].toString()).toMatchSnapshot();
   });
 
+  test("t-call in t-foreach and children component", async () => {
+    env.qweb.addTemplate("sub", `<Child val="val"/>`);
+    class Child extends Component<any, any> {
+      static template = xml`<span><t t-esc="props.val"/></span>`;
+    }
+    class Parent extends Component<any, any> {
+      static components = { Child };
+      static template = xml`
+        <div>
+          <t t-foreach="['a', 'b', 'c']" t-as="val" t-key="val">
+            <t t-call="sub"/>
+          </t>
+        </div>`;
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><span>a</span><span>b</span><span>c</span></div>");
+  });
+
   test("parent is set within t-call with no parentNode", async () => {
     env.qweb.addTemplate("sub", `<Child/>`);
     let child;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -765,28 +765,32 @@ exports[`misc global 1`] = `
             c6.push({text: _7});
         }
         {
-            let _origScope10 = scope;
+            let _origScope11 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 {
-                    let _origScope13 = scope;
+                    let _origScope15 = scope;
                     scope = Object.assign(Object.create(context), scope);
                     {
                         let c__0 = [];
                         scope.foo = 'aaa';
                         scope[utils.zero] = c__0;
                     }
-                    this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context)}));
-                    scope = _origScope13;
+                    let k16 = \`__16__\${i1}__\`;
+                    this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k16}));
+                    scope = _origScope15;
                 }
-                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context)}));
+                let k17 = \`__17__\${i1}__\`;
+                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k17}));
                 scope.foo = 'bbb';
-                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context)}));
+                let k18 = \`__18__\${i1}__\`;
+                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k18}));
                 scope[utils.zero] = c__0;
             }
-            this.subTemplates['_callee-asc'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-            scope = _origScope10;
+            let k19 = \`__19__\${i1}__\`;
+            this.subTemplates['_callee-asc'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k19}));
+            scope = _origScope11;
         }
     }
     scope = _origScope5;
@@ -1040,10 +1044,11 @@ exports[`t-call (template calling basic caller 2`] = `
     // Template name: \\"_basic-callee\\"
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('span', p2, c2);
-    c1.push(vn2);
-    c2.push({text: \`ok\`});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('span', p3, c3);
+    c1.push(vn3);
+    c3.push({text: \`ok\`});
 }"
 `;
 
@@ -1068,10 +1073,11 @@ exports[`t-call (template calling basic caller, no parent node 2`] = `
     // Template name: \\"_basic-callee\\"
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
-    c2.push({text: \`ok\`});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('div', p3, c3);
+    c1.push(vn3);
+    c3.push({text: \`ok\`});
 }"
 `;
 
@@ -1085,23 +1091,23 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
-            let c4 = [], p4 = {key:4};
-            let vn4 = h('span', p4, c4);
-            c__0.push(vn4);
-            c4.push({text: \`hey\`});
-            c__0.push({text: \` \`});
             let c5 = [], p5 = {key:5};
             let vn5 = h('span', p5, c5);
             c__0.push(vn5);
-            c5.push({text: \`yay\`});
+            c5.push({text: \`hey\`});
+            c__0.push({text: \` \`});
+            let c6 = [], p6 = {key:6};
+            let vn6 = h('span', p6, c6);
+            c__0.push(vn6);
+            c6.push({text: \`yay\`});
             scope[utils.zero] = c__0;
         }
         this.subTemplates['SubTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return vn1;
 }"
@@ -1115,10 +1121,11 @@ exports[`t-call (template calling call with several sub nodes on same line 2`] =
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
-    c2.push(...scope[utils.zero]);
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('div', p3, c3);
+    c1.push(vn3);
+    c3.push(...scope[utils.zero]);
 }"
 `;
 
@@ -1132,23 +1139,23 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope10 = scope;
+        let _origScope13 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
-            let c11 = [], p11 = {key:11};
-            let vn11 = h('span', p11, c11);
-            c__0.push(vn11);
-            c11.push({text: \`hey\`});
+            let c14 = [], p14 = {key:14};
+            let vn14 = h('span', p14, c14);
+            c__0.push(vn14);
+            c14.push({text: \`hey\`});
             c__0.push({text: \` \`});
-            let c12 = [], p12 = {key:12};
-            let vn12 = h('span', p12, c12);
-            c__0.push(vn12);
-            c12.push({text: \`yay\`});
+            let c15 = [], p15 = {key:15};
+            let vn15 = h('span', p15, c15);
+            c__0.push(vn15);
+            c15.push({text: \`yay\`});
             scope[utils.zero] = c__0;
         }
         this.subTemplates['SubTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope10;
+        scope = _origScope13;
     }
     return vn1;
 }"
@@ -1197,15 +1204,16 @@ exports[`t-call (template calling recursive template, part 1 2`] = `
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
-    let c3 = [], p3 = {key:3};
-    let vn3 = h('div', p3, c3);
-    c1.push(vn3);
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c3.push(vn4);
-    c4.push({text: \`hey\`});
+    let key3 = extra.key || '';
+    let c4 = [], p4 = {key:key3};
+    let vn4 = h('div', p4, c4);
+    c1.push(vn4);
+    let c5 = [], p5 = {key:key3};
+    let vn5 = h('span', p5, c5);
+    c4.push(vn5);
+    c5.push({text: \`hey\`});
     if (false) {
-        this.subTemplates['recursive'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context)}));
+        this.subTemplates['recursive'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c4, parent: utils.getComponent(context)}));
     }
 }"
 `;
@@ -1220,7 +1228,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope10 = scope;
+        let _origScope12 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1228,7 +1236,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope10;
+        scope = _origScope12;
     }
     return vn1;
 }"
@@ -1242,45 +1250,47 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
-    let c3 = [], p3 = {key:3};
-    let vn3 = h('p', p3, c3);
-    c2.push(vn3);
-    let _4 = scope['node'].val;
-    if (_4 != null) {
-        c3.push({text: _4});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('div', p3, c3);
+    c1.push(vn3);
+    let c4 = [], p4 = {key:key2};
+    let vn4 = h('p', p4, c4);
+    c3.push(vn4);
+    let _5 = scope['node'].val;
+    if (_5 != null) {
+        c4.push({text: _5});
     }
-    let _5 = scope['node'].children||[];
-    if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    let _6 = _7 = _5;
-    if (!(_5 instanceof Array)) {
-        _6 = Object.keys(_5);
-        _7 = Object.values(_5);
+    let _6 = scope['node'].children||[];
+    if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
+    let _7 = _8 = _6;
+    if (!(_6 instanceof Array)) {
+        _7 = Object.keys(_6);
+        _8 = Object.values(_6);
     }
-    let _length6 = _6.length;
-    let _origScope8 = scope;
+    let _length7 = _7.length;
+    let _origScope9 = scope;
     scope = Object.assign(Object.create(context), scope);
-    for (let i1 = 0; i1 < _length6; i1++) {
+    for (let i1 = 0; i1 < _length7; i1++) {
         scope.subtree_first = i1 === 0
-        scope.subtree_last = i1 === _length6 - 1
+        scope.subtree_last = i1 === _length7 - 1
         scope.subtree_index = i1
-        scope.subtree = _6[i1]
-        scope.subtree_value = _7[i1]
+        scope.subtree = _7[i1]
+        scope.subtree_value = _8[i1]
         {
-            let _origScope9 = scope;
+            let _origScope10 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 scope.node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
-            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context)}));
-            scope = _origScope9;
+            let k11 = \`__11__\` + key2;
+            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k11}));
+            scope = _origScope10;
         }
     }
-    scope = _origScope8;
+    scope = _origScope9;
 }"
 `;
 
@@ -1294,7 +1304,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope10 = scope;
+        let _origScope12 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1302,7 +1312,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope10;
+        scope = _origScope12;
     }
     return vn1;
 }"
@@ -1316,45 +1326,47 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
     let scope = Object.create(context);
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
-    let c3 = [], p3 = {key:3};
-    let vn3 = h('p', p3, c3);
-    c2.push(vn3);
-    let _4 = scope['node'].val;
-    if (_4 != null) {
-        c3.push({text: _4});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('div', p3, c3);
+    c1.push(vn3);
+    let c4 = [], p4 = {key:key2};
+    let vn4 = h('p', p4, c4);
+    c3.push(vn4);
+    let _5 = scope['node'].val;
+    if (_5 != null) {
+        c4.push({text: _5});
     }
-    let _5 = scope['node'].children||[];
-    if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    let _6 = _7 = _5;
-    if (!(_5 instanceof Array)) {
-        _6 = Object.keys(_5);
-        _7 = Object.values(_5);
+    let _6 = scope['node'].children||[];
+    if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
+    let _7 = _8 = _6;
+    if (!(_6 instanceof Array)) {
+        _7 = Object.keys(_6);
+        _8 = Object.values(_6);
     }
-    let _length6 = _6.length;
-    let _origScope8 = scope;
+    let _length7 = _7.length;
+    let _origScope9 = scope;
     scope = Object.assign(Object.create(context), scope);
-    for (let i1 = 0; i1 < _length6; i1++) {
+    for (let i1 = 0; i1 < _length7; i1++) {
         scope.subtree_first = i1 === 0
-        scope.subtree_last = i1 === _length6 - 1
+        scope.subtree_last = i1 === _length7 - 1
         scope.subtree_index = i1
-        scope.subtree = _6[i1]
-        scope.subtree_value = _7[i1]
+        scope.subtree = _7[i1]
+        scope.subtree_value = _8[i1]
         {
-            let _origScope9 = scope;
+            let _origScope10 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 scope.node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
-            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context)}));
-            scope = _origScope9;
+            let k11 = \`__11__\` + key2;
+            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k11}));
+            scope = _origScope10;
         }
     }
-    scope = _origScope8;
+    scope = _origScope9;
 }"
 `;
 
@@ -1368,7 +1380,7 @@ exports[`t-call (template calling scoped parameters 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope2 = scope;
+        let _origScope3 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1376,7 +1388,7 @@ exports[`t-call (template calling scoped parameters 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['_basic-callee'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope2;
+        scope = _origScope3;
     }
     if (scope.foo != null) {
         c1.push({text: scope.foo});
@@ -1407,10 +1419,11 @@ exports[`t-call (template calling t-call with t-if 2`] = `
     // Template name: \\"sub\\"
     let h = this.h;
     let c1 = extra.parentNode;
-    let c2 = [], p2 = {key:2};
-    let vn2 = h('span', p2, c2);
-    c1.push(vn2);
-    c2.push({text: \`ok\`});
+    let key2 = extra.key || '';
+    let c3 = [], p3 = {key:key2};
+    let vn3 = h('span', p3, c3);
+    c1.push(vn3);
+    c3.push({text: \`ok\`});
 }"
 `;
 
@@ -1441,15 +1454,16 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         scope.v_value = _4[i1]
         scope.val = scope['v'].val;
         {
-            let _origScope8 = scope;
+            let _origScope9 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 scope.val3 = scope.val*3;
                 scope[utils.zero] = c__0;
             }
-            this.subTemplates['sub'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-            scope = _origScope8;
+            let k10 = \`__10__\${i1}__\`;
+            this.subTemplates['sub'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k10}));
+            scope = _origScope9;
         }
     }
     scope = _origScope5;
@@ -1487,7 +1501,7 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     }
     else if (scope.v1==='elif') {
         {
-            let _origScope5 = scope;
+            let _origScope7 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
@@ -1495,7 +1509,7 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
                 scope[utils.zero] = c__0;
             }
             this.subTemplates['callee2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-            scope = _origScope5;
+            scope = _origScope7;
         }
     }
     return vn1;
@@ -1525,7 +1539,7 @@ exports[`t-call (template calling with unused body 1`] = `
     let result;
     let h = this.h;
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1535,7 +1549,7 @@ exports[`t-call (template calling with unused body 1`] = `
         result = []
         this.subTemplates['_basic-callee'].call(this, scope, Object.assign({}, extra, {parentNode: result, parent: utils.getComponent(context)}));
         result = result[0]
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return result;
 }"
@@ -1550,7 +1564,7 @@ exports[`t-call (template calling with unused setbody 1`] = `
     let result;
     let h = this.h;
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1560,7 +1574,7 @@ exports[`t-call (template calling with unused setbody 1`] = `
         result = []
         this.subTemplates['_basic-callee'].call(this, scope, Object.assign({}, extra, {parentNode: result, parent: utils.getComponent(context)}));
         result = result[0]
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return result;
 }"
@@ -1575,7 +1589,7 @@ exports[`t-call (template calling with used body 1`] = `
     let result;
     let h = this.h;
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1585,7 +1599,7 @@ exports[`t-call (template calling with used body 1`] = `
         result = []
         this.subTemplates['_callee-printsbody'].call(this, scope, Object.assign({}, extra, {parentNode: result, parent: utils.getComponent(context)}));
         result = result[0]
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return result;
 }"
@@ -1601,7 +1615,7 @@ exports[`t-call (template calling with used set body 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('span', p1, c1);
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1609,7 +1623,7 @@ exports[`t-call (template calling with used set body 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return vn1;
 }"
@@ -1798,18 +1812,18 @@ exports[`t-esc t-esc=0 is escaped 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
-            let c4 = [], p4 = {key:4};
-            let vn4 = h('p', p4, c4);
-            c__0.push(vn4);
-            c4.push({text: \`escaped\`});
+            let c5 = [], p5 = {key:5};
+            let vn5 = h('p', p5, c5);
+            c__0.push(vn5);
+            c5.push({text: \`escaped\`});
             scope[utils.zero] = c__0;
         }
         this.subTemplates['test'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope3;
+        scope = _origScope4;
     }
     return vn1;
 }"


### PR DESCRIPTION
Since t-call is now a function call, we need to properly handle the
internal key used to find previous components.  If a t-call is inside a
t-foreach, then we need to transfer the key to the sub template.
Otherwise, each component in the subtemplate will be associated to the
same key, which means that it will lead to big issues: components are
destroyed and reused...

closes #581