### PR TITLE
[FIX] styles: fix rule selector generation

### DIFF
--- a/tests/component/styles.test.ts
+++ b/tests/component/styles.test.ts
@@ -1,4 +1,5 @@
 import { Component, Env } from "../../src/component/component";
+import { processSheet } from "../../src/component/styles";
 import { xml, css } from "../../src/tags";
 import { makeTestFixture, makeTestEnv } from "../helpers";
 
@@ -127,6 +128,18 @@ describe("styles and component", () => {
 }
 .app {
   display: block;
+}`);
+  });
+
+  test("properly handle rules with commas", async () => {
+    const sheet = processSheet(`.parent-a, .parent-b {
+      .child-a, .child-b {
+        color: red;
+      }
+    }`);
+    
+    expect(sheet).toBe(`.parent-a .child-a, .parent-a .child-b, .parent-b .child-a, .parent-b .child-b {
+  color: red;
 }`);
   });
 });


### PR DESCRIPTION
This PR fixes the css selector generation for nested rules

Before this fix, a selector like:

```css
.parent {
  .child-a, .child-b {
    color: red;
  }
}
```

was generated as:

```css
.parent .child-a, .child-b {
  color: red;
}
```

Now it generates:

```css
.parent .child-a, .parent .child-b {
  color: red;
}
```

#592 