### PR TITLE
[FIX] qweb, extensions: t-foreach needs to hold on scope

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -323,6 +323,7 @@ QWeb.addDirective({
     ctx.addLine(`scope.${name}_index = ${loopVar}`);
     ctx.addLine(`scope.${name} = _${keysID}[${loopVar}]`);
     ctx.addLine(`scope.${name}_value = _${valuesID}[${loopVar}]`);
+    ctx = ctx.startBlockScope();
     const nodeCopy = <Element>node.cloneNode(true);
     let shouldWarn =
       !nodeCopy.hasAttribute("t-key") &&

--- a/src/qweb/expression_parser.ts
+++ b/src/qweb/expression_parser.ts
@@ -234,9 +234,10 @@ export function tokenize(expr: string): Token[] {
  * the arrow operator, then we add the current (or some previous tokens) token to
  * the list of variables so it does not get replaced by a lookup in the context
  */
-export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): string {
+export function compileExpr(expr: string, scope: { [key: string]: QWebVar }, compiledScopeName?: string): string {
   scope = Object.create(scope);
   const tokens = tokenize(expr);
+  compiledScopeName = compiledScopeName === undefined ? `scope` : compiledScopeName;
   for (let i = 0; i < tokens.length; i++) {
     let token = tokens[i];
     let prevToken = tokens[i - 1];
@@ -273,7 +274,7 @@ export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): st
         token.value = scope[token.value].expr!;
       } else {
         token.originalValue = token.value;
-        token.value = `scope['${token.value}']`;
+        token.value = `${compiledScopeName}['${token.value}']`;
       }
     }
   }

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -65,50 +65,52 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
         scope.section_index = i1
         scope.section = _3[i1]
         scope.section_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        let _6 = scope['section'].blips;
-        if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
-        let _7 = _8 = _6;
-        if (!(_6 instanceof Array)) {
-            _7 = Object.keys(_6);
-            _8 = Object.values(_6);
+        let _7 = subScope_6['section'].blips;
+        if (!_7) { throw new Error('QWeb error: Invalid loop expression')}
+        let _8 = _9 = _7;
+        if (!(_7 instanceof Array)) {
+            _8 = Object.keys(_7);
+            _9 = Object.values(_7);
         }
-        let _length7 = _7.length;
-        let _origScope9 = scope;
+        let _length8 = _8.length;
+        let _origScope10 = scope;
         scope = Object.assign(Object.create(context), scope);
-        for (let i2 = 0; i2 < _length7; i2++) {
+        for (let i2 = 0; i2 < _length8; i2++) {
             scope.blip_first = i2 === 0
-            scope.blip_last = i2 === _length7 - 1
+            scope.blip_last = i2 === _length8 - 1
             scope.blip_index = i2
-            scope.blip = _7[i2]
-            scope.blip_value = _8[i2]
+            scope.blip = _8[i2]
+            scope.blip_value = _9[i2]
+            const subScope_11 = Object.assign(Object.create(context), scope);
             let key2 = i2;
             // Component 'Child'
-            let k11 = \`__11__\${key1}__\${key2}__\`;
-            let w10 = k11 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k11]] : false;
-            let props10 = {blip:scope['blip']};
-            if (w10 && w10.__owl__.currentFiber && !w10.__owl__.vnode) {
-                w10.destroy();
-                w10 = false;
+            let k13 = \`__13__\${key1}__\${key2}__\`;
+            let w12 = k13 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k13]] : false;
+            let props12 = {blip:subScope_11['blip']};
+            if (w12 && w12.__owl__.currentFiber && !w12.__owl__.vnode) {
+                w12.destroy();
+                w12 = false;
             }
-            if (w10) {
-                w10.__updateProps(props10, extra.fiber, undefined);
-                let pvnode = w10.__owl__.pvnode;
+            if (w12) {
+                w12.__updateProps(props12, extra.fiber, undefined);
+                let pvnode = w12.__owl__.pvnode;
                 c1.push(pvnode);
             } else {
-                let componentKey10 = \`Child\`;
-                let W10 = context.constructor.components[componentKey10] || QWeb.components[componentKey10]|| scope['Child'];
-                if (!W10) {throw new Error('Cannot find the definition of component \\"' + componentKey10 + '\\"')}
-                w10 = new W10(parent, props10);
-                parent.__owl__.cmap[k11] = w10.__owl__.id;
-                let fiber = w10.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-                let pvnode = h('dummy', {key: k11, hook: {remove() {},destroy(vn) {w10.destroy();}}});
+                let componentKey12 = \`Child\`;
+                let W12 = context.constructor.components[componentKey12] || QWeb.components[componentKey12]|| subScope_11['Child'];
+                if (!W12) {throw new Error('Cannot find the definition of component \\"' + componentKey12 + '\\"')}
+                w12 = new W12(parent, props12);
+                parent.__owl__.cmap[k13] = w12.__owl__.id;
+                let fiber = w12.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+                let pvnode = h('dummy', {key: k13, hook: {remove() {},destroy(vn) {w12.destroy();}}});
                 c1.push(pvnode);
-                w10.__owl__.pvnode = pvnode;
+                w12.__owl__.pvnode = pvnode;
             }
-            w10.__owl__.parentLastFiberId = extra.fiber.id;
+            w12.__owl__.parentLastFiberId = extra.fiber.id;
         }
-        scope = _origScope9;
+        scope = _origScope10;
     }
     scope = _origScope5;
     return vn1;
@@ -439,33 +441,34 @@ exports[`composition sub components with some state rendered in a loop 1`] = `
         scope.number_index = i1
         scope.number = _3[i1]
         scope.number_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let key1 = scope['number'];
+            let key1 = subScope_6['number'];
             // Component 'ChildWidget'
-            let k7 = \`__7__\${key1}__\`;
-            let w6 = k7 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k7]] : false;
-            let props6 = {};
-            if (w6 && w6.__owl__.currentFiber && !w6.__owl__.vnode) {
-                w6.destroy();
-                w6 = false;
+            let k8 = \`__8__\${key1}__\`;
+            let w7 = k8 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k8]] : false;
+            let props7 = {};
+            if (w7 && w7.__owl__.currentFiber && !w7.__owl__.vnode) {
+                w7.destroy();
+                w7 = false;
             }
-            if (w6) {
-                w6.__updateProps(props6, extra.fiber, undefined);
-                let pvnode = w6.__owl__.pvnode;
+            if (w7) {
+                w7.__updateProps(props7, extra.fiber, undefined);
+                let pvnode = w7.__owl__.pvnode;
                 c1.push(pvnode);
             } else {
-                let componentKey6 = \`ChildWidget\`;
-                let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| scope['ChildWidget'];
-                if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
-                w6 = new W6(parent, props6);
-                parent.__owl__.cmap[k7] = w6.__owl__.id;
-                let fiber = w6.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-                let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
+                let componentKey7 = \`ChildWidget\`;
+                let W7 = context.constructor.components[componentKey7] || QWeb.components[componentKey7]|| subScope_6['ChildWidget'];
+                if (!W7) {throw new Error('Cannot find the definition of component \\"' + componentKey7 + '\\"')}
+                w7 = new W7(parent, props7);
+                parent.__owl__.cmap[k8] = w7.__owl__.id;
+                let fiber = w7.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+                let pvnode = h('dummy', {key: k8, hook: {remove() {},destroy(vn) {w7.destroy();}}});
                 c1.push(pvnode);
-                w6.__owl__.pvnode = pvnode;
+                w7.__owl__.pvnode = pvnode;
             }
-            w6.__owl__.parentLastFiberId = extra.fiber.id;
+            w7.__owl__.parentLastFiberId = extra.fiber.id;
         }
     }
     scope = _origScope5;
@@ -583,6 +586,106 @@ exports[`dynamic t-props basic use 1`] = `
         w2.__owl__.pvnode = pvnode;
     }
     w2.__owl__.parentLastFiberId = extra.fiber.id;
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-on expression in t-foreach 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.assign(Object.create(context), scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['val'];
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('div', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['val_index'];
+        if (_8 != null) {
+            c7.push({text: _8});
+        }
+        c7.push({text: \`: \`});
+        let _9 = subScope_6['val']+'';
+        if (_9 != null) {
+            c7.push({text: _9});
+        }
+        let c10 = [], p10 = {key:\`\${key1}_10\`,on:{}};
+        let vn10 = h('button', p10, c10);
+        c7.push(vn10);
+        p10.on['click'] = function (e) {if (!context.__owl__.isMounted){return}subScope_6['otherState'].vals.push(subScope_6['val'])};
+        c10.push({text: \`Expr\`});
+    }
+    scope = _origScope5;
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-on method call in t-foreach 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.assign(Object.create(context), scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['val'];
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('div', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['val_index'];
+        if (_8 != null) {
+            c7.push({text: _8});
+        }
+        c7.push({text: \`: \`});
+        let _9 = subScope_6['val']+'';
+        if (_9 != null) {
+            c7.push({text: _9});
+        }
+        let c10 = [], p10 = {key:\`\${key1}_10\`,on:{}};
+        let vn10 = h('button', p10, c10);
+        c7.push(vn10);
+        let args11 = [subScope_6['val']];
+        p10.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['addVal'](...args11, e);};
+        c10.push({text: \`meth call\`});
+    }
+    scope = _origScope5;
     return vn1;
 }"
 `;
@@ -1100,34 +1203,35 @@ exports[`random stuff/miscellaneous t-on with handler bound to dynamic argument 
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let key1 = scope['item'];
+            let key1 = subScope_6['item'];
             // Component 'Child'
-            let k7 = \`__7__\${key1}__\`;
-            let args8 = [scope['item']];
-            let w6 = k7 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k7]] : false;
-            let props6 = {};
-            if (w6 && w6.__owl__.currentFiber && !w6.__owl__.vnode) {
-                w6.destroy();
-                w6 = false;
+            let k8 = \`__8__\${key1}__\`;
+            let args9 = [subScope_6['item']];
+            let w7 = k8 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k8]] : false;
+            let props7 = {};
+            if (w7 && w7.__owl__.currentFiber && !w7.__owl__.vnode) {
+                w7.destroy();
+                w7 = false;
             }
-            if (w6) {
-                w6.__updateProps(props6, extra.fiber, undefined);
-                let pvnode = w6.__owl__.pvnode;
+            if (w7) {
+                w7.__updateProps(props7, extra.fiber, undefined);
+                let pvnode = w7.__owl__.pvnode;
                 c1.push(pvnode);
             } else {
-                let componentKey6 = \`Child\`;
-                let W6 = context.constructor.components[componentKey6] || QWeb.components[componentKey6]|| scope['Child'];
-                if (!W6) {throw new Error('Cannot find the definition of component \\"' + componentKey6 + '\\"')}
-                w6 = new W6(parent, props6);
-                parent.__owl__.cmap[k7] = w6.__owl__.id;
-                let fiber = w6.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onEv'](...args8, e);});}};});
-                let pvnode = h('dummy', {key: k7, hook: {remove() {},destroy(vn) {w6.destroy();}}});
+                let componentKey7 = \`Child\`;
+                let W7 = context.constructor.components[componentKey7] || QWeb.components[componentKey7]|| subScope_6['Child'];
+                if (!W7) {throw new Error('Cannot find the definition of component \\"' + componentKey7 + '\\"')}
+                w7 = new W7(parent, props7);
+                parent.__owl__.cmap[k8] = w7.__owl__.id;
+                let fiber = w7.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onEv'](...args9, e);});}};});
+                let pvnode = h('dummy', {key: k8, hook: {remove() {},destroy(vn) {w7.destroy();}}});
                 c1.push(pvnode);
-                w6.__owl__.pvnode = pvnode;
+                w7.__owl__.pvnode = pvnode;
             }
-            w6.__owl__.parentLastFiberId = extra.fiber.id;
+            w7.__owl__.parentLastFiberId = extra.fiber.id;
         }
     }
     scope = _origScope5;
@@ -1349,16 +1453,17 @@ exports[`t-model directive in a t-foreach 1`] = `
         scope.thing_index = i1
         scope.thing = _3[i1]
         scope.thing_value = _4[i1]
-        let key1 = scope['thing'].id;
-        let _6 = 'checkbox';
-        let c7 = [], p7 = {key:\`\${key1}_7\`,attrs:{type: _6},on:{}};
-        let vn7 = h('input', p7, c7);
-        c1.push(vn7);
-        let expr7 = scope['thing'];
-        let k8 = \`__8__\${key1}__\`;
-        p7.props = {checked: expr7.f};
-        extra.handlers[k8] = extra.handlers[k8] || ((ev) => {expr7.f = ev.target.checked});
-        p7.on['input'] = extra.handlers[k8];
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['thing'].id;
+        let _7 = 'checkbox';
+        let c8 = [], p8 = {key:\`\${key1}_8\`,attrs:{type: _7},on:{}};
+        let vn8 = h('input', p8, c8);
+        c1.push(vn8);
+        let expr8 = subScope_6['thing'];
+        let k9 = \`__9__\${key1}__\`;
+        p8.props = {checked: expr8.f};
+        extra.handlers[k9] = extra.handlers[k9] || ((ev) => {expr8.f = ev.target.checked});
+        p8.on['input'] = extra.handlers[k9];
     }
     scope = _origScope5;
     return vn1;

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -229,14 +229,14 @@ exports[`t-slot directive slots are rendered with proper context, part 2 1`] = `
     // Template name: \\"Link\\"
     let scope = Object.create(context);
     let h = this.h;
-    let _11 = scope['props'].to;
-    let c12 = [], p12 = {key:12,attrs:{href: _11}};
-    let vn12 = h('a', p12, c12);
-    const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot13) {
-        slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
+    let _12 = scope['props'].to;
+    let c13 = [], p13 = {key:13,attrs:{href: _12}};
+    let vn13 = h('a', p13, c13);
+    const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot14) {
+        slot14.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || context}));
     }
-    return vn12;
+    return vn13;
 }"
 `;
 
@@ -270,35 +270,36 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
         scope.user_index = i1
         scope.user = _4[i1]
         scope.user_value = _5[i1]
-        let key1 = scope['user'].id;
-        let c7 = [], p7 = {key:\`\${key1}_7\`};
-        let vn7 = h('li', p7, c7);
-        c2.push(vn7);
+        const subScope_7 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_7['user'].id;
+        let c8 = [], p8 = {key:\`\${key1}_8\`};
+        let vn8 = h('li', p8, c8);
+        c2.push(vn8);
         // Component 'Link'
-        let k9 = \`__9__\${key1}__\`;
-        let w8 = k9 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k9]] : false;
-        let props8 = {to:'/user/'+scope['user'].id};
-        if (w8 && w8.__owl__.currentFiber && !w8.__owl__.vnode) {
-            w8.destroy();
-            w8 = false;
+        let k10 = \`__10__\${key1}__\`;
+        let w9 = k10 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k10]] : false;
+        let props9 = {to:'/user/'+subScope_7['user'].id};
+        if (w9 && w9.__owl__.currentFiber && !w9.__owl__.vnode) {
+            w9.destroy();
+            w9 = false;
         }
-        if (w8) {
-            w8.__updateProps(props8, extra.fiber, Object.assign(Object.create(context), scope));
-            let pvnode = w8.__owl__.pvnode;
-            c7.push(pvnode);
+        if (w9) {
+            w9.__updateProps(props9, extra.fiber, Object.assign(Object.create(context), scope));
+            let pvnode = w9.__owl__.pvnode;
+            c8.push(pvnode);
         } else {
-            let componentKey8 = \`Link\`;
-            let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| scope['Link'];
-            if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
-            w8 = new W8(parent, props8);
-            parent.__owl__.cmap[k9] = w8.__owl__.id;
-            w8.__owl__.slotId = 1;
-            let fiber = w8.__prepare(extra.fiber, Object.assign(Object.create(context), scope), () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-            let pvnode = h('dummy', {key: k9, hook: {remove() {},destroy(vn) {w8.destroy();}}});
-            c7.push(pvnode);
-            w8.__owl__.pvnode = pvnode;
+            let componentKey9 = \`Link\`;
+            let W9 = context.constructor.components[componentKey9] || QWeb.components[componentKey9]|| subScope_7['Link'];
+            if (!W9) {throw new Error('Cannot find the definition of component \\"' + componentKey9 + '\\"')}
+            w9 = new W9(parent, props9);
+            parent.__owl__.cmap[k10] = w9.__owl__.id;
+            w9.__owl__.slotId = 1;
+            let fiber = w9.__prepare(extra.fiber, Object.assign(Object.create(context), scope), () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+            let pvnode = h('dummy', {key: k10, hook: {remove() {},destroy(vn) {w9.destroy();}}});
+            c8.push(pvnode);
+            w9.__owl__.pvnode = pvnode;
         }
-        w8.__owl__.parentLastFiberId = extra.fiber.id;
+        w9.__owl__.parentLastFiberId = extra.fiber.id;
     }
     scope = _origScope6;
     return vn1;
@@ -311,11 +312,11 @@ exports[`t-slot directive slots are rendered with proper context, part 2 3`] = `
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
     let h = this.h;
-    let c7 = extra.parentNode;
-    c7.push({text: \`User \`});
-    let _10 = scope['user'].name;
-    if (_10 != null) {
-        c7.push({text: _10});
+    let c8 = extra.parentNode;
+    c8.push({text: \`User \`});
+    let _11 = scope['user'].name;
+    if (_11 != null) {
+        c8.push({text: _11});
     }
 }"
 `;
@@ -326,14 +327,14 @@ exports[`t-slot directive slots are rendered with proper context, part 3 1`] = `
     // Template name: \\"Link\\"
     let scope = Object.create(context);
     let h = this.h;
-    let _10 = scope['props'].to;
-    let c11 = [], p11 = {key:11,attrs:{href: _10}};
-    let vn11 = h('a', p11, c11);
-    const slot12 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot12) {
-        slot12.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c11, parent: extra.parent || context}));
+    let _11 = scope['props'].to;
+    let c12 = [], p12 = {key:12,attrs:{href: _11}};
+    let vn12 = h('a', p12, c12);
+    const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot13) {
+        slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
     }
-    return vn11;
+    return vn12;
 }"
 `;
 
@@ -367,36 +368,37 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
         scope.user_index = i1
         scope.user = _4[i1]
         scope.user_value = _5[i1]
-        let key1 = scope['user'].id;
-        let c7 = [], p7 = {key:\`\${key1}_7\`};
-        let vn7 = h('li', p7, c7);
-        c2.push(vn7);
-        scope.userdescr = 'User '+scope['user'].name;
+        const subScope_7 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_7['user'].id;
+        let c8 = [], p8 = {key:\`\${key1}_8\`};
+        let vn8 = h('li', p8, c8);
+        c2.push(vn8);
+        scope.userdescr = 'User '+subScope_7['user'].name;
         // Component 'Link'
-        let k9 = \`__9__\${key1}__\`;
-        let w8 = k9 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k9]] : false;
-        let props8 = {to:'/user/'+scope['user'].id};
-        if (w8 && w8.__owl__.currentFiber && !w8.__owl__.vnode) {
-            w8.destroy();
-            w8 = false;
+        let k10 = \`__10__\${key1}__\`;
+        let w9 = k10 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k10]] : false;
+        let props9 = {to:'/user/'+subScope_7['user'].id};
+        if (w9 && w9.__owl__.currentFiber && !w9.__owl__.vnode) {
+            w9.destroy();
+            w9 = false;
         }
-        if (w8) {
-            w8.__updateProps(props8, extra.fiber, Object.assign(Object.create(context), scope));
-            let pvnode = w8.__owl__.pvnode;
-            c7.push(pvnode);
+        if (w9) {
+            w9.__updateProps(props9, extra.fiber, Object.assign(Object.create(context), scope));
+            let pvnode = w9.__owl__.pvnode;
+            c8.push(pvnode);
         } else {
-            let componentKey8 = \`Link\`;
-            let W8 = context.constructor.components[componentKey8] || QWeb.components[componentKey8]|| scope['Link'];
-            if (!W8) {throw new Error('Cannot find the definition of component \\"' + componentKey8 + '\\"')}
-            w8 = new W8(parent, props8);
-            parent.__owl__.cmap[k9] = w8.__owl__.id;
-            w8.__owl__.slotId = 1;
-            let fiber = w8.__prepare(extra.fiber, Object.assign(Object.create(context), scope), () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-            let pvnode = h('dummy', {key: k9, hook: {remove() {},destroy(vn) {w8.destroy();}}});
-            c7.push(pvnode);
-            w8.__owl__.pvnode = pvnode;
+            let componentKey9 = \`Link\`;
+            let W9 = context.constructor.components[componentKey9] || QWeb.components[componentKey9]|| subScope_7['Link'];
+            if (!W9) {throw new Error('Cannot find the definition of component \\"' + componentKey9 + '\\"')}
+            w9 = new W9(parent, props9);
+            parent.__owl__.cmap[k10] = w9.__owl__.id;
+            w9.__owl__.slotId = 1;
+            let fiber = w9.__prepare(extra.fiber, Object.assign(Object.create(context), scope), () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+            let pvnode = h('dummy', {key: k10, hook: {remove() {},destroy(vn) {w9.destroy();}}});
+            c8.push(pvnode);
+            w9.__owl__.pvnode = pvnode;
         }
-        w8.__owl__.parentLastFiberId = extra.fiber.id;
+        w9.__owl__.parentLastFiberId = extra.fiber.id;
     }
     scope = _origScope6;
     return vn1;
@@ -409,9 +411,9 @@ exports[`t-slot directive slots are rendered with proper context, part 3 3`] = `
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
     let h = this.h;
-    let c7 = extra.parentNode;
+    let c8 = extra.parentNode;
     if (scope.userdescr != null) {
-        c7.push({text: scope.userdescr});
+        c8.push({text: scope.userdescr});
     }
 }"
 `;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -428,10 +428,11 @@ exports[`foreach does not pollute the rendering context 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        let _6 = scope['item'];
-        if (_6 != null) {
-            c1.push({text: _6});
+        let _7 = subScope_6['item'];
+        if (_7 != null) {
+            c1.push({text: _7});
         }
     }
     scope = _origScope5;
@@ -463,13 +464,14 @@ exports[`foreach iterate on items (on a element node) 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
-        let key1 = scope['item'];
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('span', p6, c6);
-        c1.push(vn6);
-        let _7 = scope['item'];
-        if (_7 != null) {
-            c6.push({text: _7});
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['item'];
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('span', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['item'];
+        if (_8 != null) {
+            c7.push({text: _8});
         }
     }
     scope = _origScope5;
@@ -501,21 +503,22 @@ exports[`foreach iterate on items 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         c1.push({text: \` [\`});
-        let _6 = scope['item_index'];
-        if (_6 != null) {
-            c1.push({text: _6});
-        }
-        c1.push({text: \`: \`});
-        let _7 = scope['item'];
+        let _7 = subScope_6['item_index'];
         if (_7 != null) {
             c1.push({text: _7});
         }
-        c1.push({text: \` \`});
-        let _8 = scope['item_value'];
+        c1.push({text: \`: \`});
+        let _8 = subScope_6['item'];
         if (_8 != null) {
             c1.push({text: _8});
+        }
+        c1.push({text: \` \`});
+        let _9 = subScope_6['item_value'];
+        if (_9 != null) {
+            c1.push({text: _9});
         }
         c1.push({text: \`] \`});
     }
@@ -548,21 +551,22 @@ exports[`foreach iterate, dict param 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         c1.push({text: \` [\`});
-        let _6 = scope['item_index'];
-        if (_6 != null) {
-            c1.push({text: _6});
-        }
-        c1.push({text: \`: \`});
-        let _7 = scope['item'];
+        let _7 = subScope_6['item_index'];
         if (_7 != null) {
             c1.push({text: _7});
         }
-        c1.push({text: \` \`});
-        let _8 = scope['item_value'];
+        c1.push({text: \`: \`});
+        let _8 = subScope_6['item'];
         if (_8 != null) {
             c1.push({text: _8});
+        }
+        c1.push({text: \` \`});
+        let _9 = subScope_6['item_value'];
+        if (_9 != null) {
+            c1.push({text: _9});
         }
         c1.push({text: \`] \`});
     }
@@ -595,18 +599,19 @@ exports[`foreach iterate, position 1`] = `
         scope.elem_index = i1
         scope.elem = _3[i1]
         scope.elem_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         c1.push({text: \` -\`});
-        if (scope['elem_first']) {
+        if (subScope_6['elem_first']) {
             c1.push({text: \` first\`});
         }
-        if (scope['elem_last']) {
+        if (subScope_6['elem_last']) {
             c1.push({text: \` last\`});
         }
         c1.push({text: \` (\`});
-        let _6 = scope['elem_index'];
-        if (_6 != null) {
-            c1.push({text: _6});
+        let _7 = subScope_6['elem_index'];
+        if (_7 != null) {
+            c1.push({text: _7});
         }
         c1.push({text: \`) \`});
     }
@@ -639,36 +644,38 @@ exports[`foreach t-foreach in t-forach 1`] = `
         scope.number_index = i1
         scope.number = _3[i1]
         scope.number_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        let _6 = scope['letters'];
-        if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
-        let _7 = _8 = _6;
-        if (!(_6 instanceof Array)) {
-            _7 = Object.keys(_6);
-            _8 = Object.values(_6);
+        let _7 = subScope_6['letters'];
+        if (!_7) { throw new Error('QWeb error: Invalid loop expression')}
+        let _8 = _9 = _7;
+        if (!(_7 instanceof Array)) {
+            _8 = Object.keys(_7);
+            _9 = Object.values(_7);
         }
-        let _length7 = _7.length;
-        let _origScope9 = scope;
+        let _length8 = _8.length;
+        let _origScope10 = scope;
         scope = Object.assign(Object.create(context), scope);
-        for (let i2 = 0; i2 < _length7; i2++) {
+        for (let i2 = 0; i2 < _length8; i2++) {
             scope.letter_first = i2 === 0
-            scope.letter_last = i2 === _length7 - 1
+            scope.letter_last = i2 === _length8 - 1
             scope.letter_index = i2
-            scope.letter = _7[i2]
-            scope.letter_value = _8[i2]
+            scope.letter = _8[i2]
+            scope.letter_value = _9[i2]
+            const subScope_11 = Object.assign(Object.create(context), scope);
             let key2 = i2;
             c1.push({text: \` [\`});
-            let _10 = scope['number'];
-            if (_10 != null) {
-                c1.push({text: _10});
+            let _12 = subScope_11['number'];
+            if (_12 != null) {
+                c1.push({text: _12});
             }
-            let _11 = scope['letter'];
-            if (_11 != null) {
-                c1.push({text: _11});
+            let _13 = subScope_11['letter'];
+            if (_13 != null) {
+                c1.push({text: _13});
             }
             c1.push({text: \`] \`});
         }
-        scope = _origScope9;
+        scope = _origScope10;
     }
     scope = _origScope5;
     return vn1;
@@ -699,13 +706,14 @@ exports[`foreach warn if no key in some case 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('span', p6, c6);
-        c1.push(vn6);
-        let _7 = scope['item'];
-        if (_7 != null) {
-            c6.push({text: _7});
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('span', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['item'];
+        if (_8 != null) {
+            c7.push({text: _8});
         }
     }
     scope = _origScope5;
@@ -764,41 +772,42 @@ exports[`misc global 1`] = `
         scope.value_index = i1
         scope.value = _3[i1]
         scope.value_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('span', p6, c6);
-        c1.push(vn6);
-        let _7 = scope['value'];
-        if (_7 != null) {
-            c6.push({text: _7});
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('span', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['value'];
+        if (_8 != null) {
+            c7.push({text: _8});
         }
         {
-            let _origScope10 = scope;
+            let _origScope11 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 {
-                    let _origScope13 = scope;
+                    let _origScope14 = scope;
                     scope = Object.assign(Object.create(context), scope);
                     {
                         let c__0 = [];
                         scope.foo = 'aaa';
                         scope[utils.zero] = c__0;
                     }
-                    let k14 = \`__14__\${key1}__\`;
-                    this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k14}));
-                    scope = _origScope13;
+                    let k15 = \`__15__\${key1}__\`;
+                    this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k15}));
+                    scope = _origScope14;
                 }
-                let k15 = \`__15__\${key1}__\`;
-                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k15}));
-                scope.foo = 'bbb';
                 let k16 = \`__16__\${key1}__\`;
                 this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k16}));
+                scope.foo = 'bbb';
+                let k17 = \`__17__\${key1}__\`;
+                this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k17}));
                 scope[utils.zero] = c__0;
             }
-            let k17 = \`__17__\${key1}__\`;
-            this.subTemplates['_callee-asc'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k17}));
-            scope = _origScope10;
+            let k18 = \`__18__\${key1}__\`;
+            this.subTemplates['_callee-asc'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k18}));
+            scope = _origScope11;
         }
     }
     scope = _origScope5;
@@ -1237,7 +1246,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope11 = scope;
+        let _origScope12 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1245,7 +1254,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope11;
+        scope = _origScope12;
     }
     return vn1;
 }"
@@ -1286,18 +1295,19 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
         scope.subtree_index = i1
         scope.subtree = _6[i1]
         scope.subtree_value = _7[i1]
+        const subScope_9 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let _origScope9 = scope;
+            let _origScope10 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
-                scope.node = scope['subtree'];
+                scope.node = subScope_9['subtree'];
                 scope[utils.zero] = c__0;
             }
-            let k10 = \`__10__\${key0}__\${key1}__\`;
-            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k10}));
-            scope = _origScope9;
+            let k11 = \`__11__\${key0}__\${key1}__\`;
+            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k11}));
+            scope = _origScope10;
         }
     }
     scope = _origScope8;
@@ -1314,7 +1324,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     {
-        let _origScope11 = scope;
+        let _origScope12 = scope;
         scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
@@ -1322,7 +1332,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
-        scope = _origScope11;
+        scope = _origScope12;
     }
     return vn1;
 }"
@@ -1363,18 +1373,19 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
         scope.subtree_index = i1
         scope.subtree = _6[i1]
         scope.subtree_value = _7[i1]
+        const subScope_9 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let _origScope9 = scope;
+            let _origScope10 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
-                scope.node = scope['subtree'];
+                scope.node = subScope_9['subtree'];
                 scope[utils.zero] = c__0;
             }
-            let k10 = \`__10__\${key0}__\${key1}__\`;
-            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k10}));
-            scope = _origScope9;
+            let k11 = \`__11__\${key0}__\${key1}__\`;
+            this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k11}));
+            scope = _origScope10;
         }
     }
     scope = _origScope8;
@@ -1463,19 +1474,20 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         scope.v_index = i1
         scope.v = _3[i1]
         scope.v_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
-        scope.val = scope['v'].val;
+        scope.val = subScope_6['v'].val;
         {
-            let _origScope8 = scope;
+            let _origScope9 = scope;
             scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 scope.val3 = scope.val*3;
                 scope[utils.zero] = c__0;
             }
-            let k9 = \`__9__\${key1}__\`;
-            this.subTemplates['sub'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k9}));
-            scope = _origScope8;
+            let k10 = \`__10__\${key1}__\`;
+            this.subTemplates['sub'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k10}));
+            scope = _origScope9;
         }
     }
     scope = _origScope5;
@@ -2163,13 +2175,14 @@ exports[`t-key t-key directive in a list 1`] = `
         scope.beer_index = i1
         scope.beer = _3[i1]
         scope.beer_value = _4[i1]
-        let key1 = scope['beer'].id;
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('li', p6, c6);
-        c1.push(vn6);
-        let _7 = scope['beer'].name;
-        if (_7 != null) {
-            c6.push({text: _7});
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['beer'].id;
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('li', p7, c7);
+        c1.push(vn7);
+        let _8 = subScope_6['beer'].name;
+        if (_8 != null) {
+            c7.push({text: _8});
         }
     }
     scope = _origScope5;
@@ -2267,16 +2280,17 @@ exports[`t-on can bind handlers with loop variable as argument 1`] = `
         scope.action_index = i1
         scope.action = _3[i1]
         scope.action_value = _4[i1]
-        let key1 = scope['action_index'];
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('li', p6, c6);
-        c1.push(vn6);
-        let c7 = [], p7 = {key:\`\${key1}_7\`,on:{}};
-        let vn7 = h('a', p7, c7);
-        c6.push(vn7);
-        let args8 = [scope['action']];
-        p7.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['activate'](...args8, e);};
-        c7.push({text: \`link\`});
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['action_index'];
+        let c7 = [], p7 = {key:\`\${key1}_7\`};
+        let vn7 = h('li', p7, c7);
+        c1.push(vn7);
+        let c8 = [], p8 = {key:\`\${key1}_8\`,on:{}};
+        let vn8 = h('a', p8, c8);
+        c7.push(vn8);
+        let args9 = [subScope_6['action']];
+        p8.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['activate'](...args9, e);};
+        c8.push({text: \`link\`});
     }
     scope = _origScope5;
     return vn1;
@@ -2524,19 +2538,20 @@ exports[`t-on t-on with prevent modifier in t-foreach 1`] = `
         scope.project_index = i1
         scope.project = _3[i1]
         scope.project_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let key1 = scope['project'];
-            let _6 = '#';
-            let c7 = [], p7 = {key:\`\${key1}_7\`,attrs:{href: _6},on:{}};
-            let vn7 = h('a', p7, c7);
-            c1.push(vn7);
-            let args8 = [scope['project'].id];
-            p7.on['click'] = function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onEdit'](...args8, e);};
-            c7.push({text: \` Edit \`});
-            let _9 = scope['project'].name;
-            if (_9 != null) {
-                c7.push({text: _9});
+            let key1 = subScope_6['project'];
+            let _7 = '#';
+            let c8 = [], p8 = {key:\`\${key1}_8\`,attrs:{href: _7},on:{}};
+            let vn8 = h('a', p8, c8);
+            c1.push(vn8);
+            let args9 = [subScope_6['project'].id];
+            p8.on['click'] = function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onEdit'](...args9, e);};
+            c8.push({text: \` Edit \`});
+            let _10 = subScope_6['project'].name;
+            if (_10 != null) {
+                c8.push({text: _10});
             }
         }
     }
@@ -2770,24 +2785,25 @@ exports[`t-ref refs in a loop 1`] = `
         scope.item_index = i1
         scope.item = _3[i1]
         scope.item_value = _4[i1]
+        const subScope_6 = Object.assign(Object.create(context), scope);
         let key1 = i1;
         {
-            let key1 = scope['item'];
-            let c6 = [], p6 = {key:\`\${key1}_6\`};
-            let vn6 = h('div', p6, c6);
-            c1.push(vn6);
-            const ref7 = (scope['item']);
-            p6.hook = {
+            let key1 = subScope_6['item'];
+            let c7 = [], p7 = {key:\`\${key1}_7\`};
+            let vn7 = h('div', p7, c7);
+            c1.push(vn7);
+            const ref8 = (subScope_6['item']);
+            p7.hook = {
               create: (_, n) => {
-                context.__owl__.refs[ref7] = n.elm;
+                context.__owl__.refs[ref8] = n.elm;
               },
               destroy: () => {
-                delete context.__owl__.refs[ref7];
+                delete context.__owl__.refs[ref8];
               },
             };
-            let _8 = scope['item'];
-            if (_8 != null) {
-                c6.push({text: _8});
+            let _9 = subScope_6['item'];
+            if (_9 != null) {
+                c7.push({text: _9});
             }
         }
     }
@@ -3011,18 +3027,19 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
         scope.elem_index = i1
         scope.elem = _3[i1]
         scope.elem_value = _4[i1]
-        let key1 = scope['elem_index'];
-        let c6 = [], p6 = {key:\`\${key1}_6\`};
-        let vn6 = h('div', p6, c6);
-        c1.push(vn6);
+        const subScope_6 = Object.assign(Object.create(context), scope);
+        let key1 = subScope_6['elem_index'];
         let c7 = [], p7 = {key:\`\${key1}_7\`};
-        let vn7 = h('span', p7, c7);
-        c6.push(vn7);
-        c7.push({text: \`v\`});
+        let vn7 = h('div', p7, c7);
+        c1.push(vn7);
+        let c8 = [], p8 = {key:\`\${key1}_8\`};
+        let vn8 = h('span', p8, c8);
+        c7.push(vn8);
+        c8.push({text: \`v\`});
         if (scope.v != null) {
-            c7.push({text: scope.v});
+            c8.push({text: scope.v});
         }
-        scope.v = scope['elem'];
+        scope.v = subScope_6['elem'];
     }
     scope = _origScope5;
     return vn1;


### PR DESCRIPTION
Have a t-on within a t-foreach
the t-on has an expression

Before this commit, when triggering the t-on, the expression was falsely evaluated
In details, the expression took scope from outside the foreach loop
as we protect it to have similar results than an actual for loop

But, at triggering time, the scope protection had already been terminated
meaning the info of the iteration of the loop the handler has been built in
had already disappeared

This commit fixes that

closes #594