### PR TITLE
 [FIX] qweb: variables set outside foreach must be altered by inloop t-set

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/owl/index.js",
   "types": "dist/owl/index.d.ts",
   "prepublish": "npm run build",
-  "files": ["dist/owl/"],
+  "files": [
+    "dist/owl/"
+  ],
   "engines": {
     "node": ">=10.15.3"
   },

--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -136,7 +136,7 @@ QWeb.addDirective({
     if (hasBody) {
       ctx.rootContext.shouldDefineUtils = true;
       if (value) {
-        ctx.addIf(`!(scope.${qwebvar.id})`);
+        ctx.addIf(`!(${qwebvar.expr})`);
       }
       const tempParentNodeID = ctx.generateID();
       const _parentNode = ctx.parentNode;
@@ -149,7 +149,7 @@ QWeb.addDirective({
       }
       qweb._compileNode(nodeCopy, ctx);
 
-      ctx.addLine(`scope.${qwebvar.id} = c${tempParentNodeID}`);
+      ctx.addLine(`${qwebvar.expr} = c${tempParentNodeID}`);
       qwebvar.value = `c${tempParentNodeID}`;
       qwebvar.hasBody = true;
 

--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -314,7 +314,7 @@ QWeb.addDirective({
     ctx.addLine(`_${valuesID} = Object.values(_${arrayID});`);
     ctx.closeIf();
     ctx.addLine(`let _length${keysID} = _${keysID}.length;`);
-    let varsID = ctx.startProtectScope();
+    let varsID = ctx.startProtectScope(true);
     const loopVar = `i${ctx.loopNumber}`;
     ctx.addLine(`for (let ${loopVar} = 0; ${loopVar} < _length${keysID}; ${loopVar}++) {`);
     ctx.indent();

--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -118,7 +118,6 @@ QWeb.addDirective({
   priority: 60,
   atNodeEncounter({ node, qweb, ctx }): boolean {
     ctx.rootContext.shouldDefineScope = true;
-    ctx.rootContext.shouldDefineUtils = true;
     const hasBody = node.hasChildNodes();
     const variable = node.getAttribute("t-set")!;
     let value = node.getAttribute("t-value")!;
@@ -129,7 +128,12 @@ QWeb.addDirective({
     
     if (value) {
       const formattedValue = ctx.formatExpression(value);
-      ctx.addLine(`utils.getScope(scope, '${variable}').${variable} = ${formattedValue};`);
+      let scopeExpr = `scope`;
+      if (ctx.protectedScopeSet.size) {
+        ctx.rootContext.shouldDefineUtils = true;
+        scopeExpr = `utils.getScope(scope, '${variable}')`;
+      }
+      ctx.addLine(`${scopeExpr}.${variable} = ${formattedValue};`);
       qwebvar.value = formattedValue;
     }
 

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -173,11 +173,12 @@ export class CompilationContext {
     let r = s.replace(/\{\{.*?\}\}/g, s => "${" + this.formatExpression(s.slice(2, -2)) + "}");
     return "`" + r + "`";
   }
-  startProtectScope(): number {
+  startProtectScope(codeBlock?: boolean): number {
     const protectID = this.generateID();
     this.rootContext.shouldDefineScope = true;
+    const scopeExpr = codeBlock ? `Object.create(scope);` : `Object.assign(Object.create(context), scope);`;
     this.addLine(`let _origScope${protectID} = scope;`);
-    this.addLine(`scope = Object.create(scope);`);
+    this.addLine(`scope = ${scopeExpr}`);
     return protectID;
   }
   stopProtectScope(protectID: number) {

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -177,7 +177,7 @@ export class CompilationContext {
     const protectID = this.generateID();
     this.rootContext.shouldDefineScope = true;
     this.addLine(`let _origScope${protectID} = scope;`);
-    this.addLine(`scope = Object.assign(Object.create(context), scope);`);
+    this.addLine(`scope = Object.create(scope);`);
     return protectID;
   }
   stopProtectScope(protectID: number) {

--- a/src/qweb/compilation_context.ts
+++ b/src/qweb/compilation_context.ts
@@ -17,6 +17,7 @@ export class CompilationContext {
   rootContext: CompilationContext;
   shouldDefineParent: boolean = false;
   shouldDefineScope: boolean = false;
+  protectedScopeSet: Set<number> = new Set();
   shouldDefineQWeb: boolean = false;
   shouldDefineUtils: boolean = false;
   shouldDefineRefs: boolean = false;
@@ -175,6 +176,7 @@ export class CompilationContext {
   }
   startProtectScope(codeBlock?: boolean): number {
     const protectID = this.generateID();
+    this.rootContext.protectedScopeSet.add(protectID);
     this.rootContext.shouldDefineScope = true;
     const scopeExpr = codeBlock ? `Object.create(scope);` : `Object.assign(Object.create(context), scope);`;
     this.addLine(`let _origScope${protectID} = scope;`);
@@ -182,6 +184,7 @@ export class CompilationContext {
     return protectID;
   }
   stopProtectScope(protectID: number) {
+    this.rootContext.protectedScopeSet.delete(protectID);
     this.addLine(`scope = _origScope${protectID};`);
   }
 }

--- a/src/qweb/expression_parser.ts
+++ b/src/qweb/expression_parser.ts
@@ -66,6 +66,7 @@ interface Token {
   value: string;
   originalValue?: string;
   size?: number;
+  varName?: string;
 }
 
 const STATIC_TOKEN_MAP: { [key: string]: TKind } = {
@@ -234,7 +235,7 @@ export function tokenize(expr: string): Token[] {
  * the arrow operator, then we add the current (or some previous tokens) token to
  * the list of variables so it does not get replaced by a lookup in the context
  */
-export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): string {
+export function compileExprToArray(expr: string, scope: { [key: string]: QWebVar }): Token[] {
   scope = Object.create(scope);
   const tokens = tokenize(expr);
   for (let i = 0; i < tokens.length; i++) {
@@ -269,6 +270,7 @@ export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): st
     }
 
     if (isVar) {
+      token.varName = token.value;
       if (token.value in scope && "id" in scope[token.value]) {
         token.value = scope[token.value].expr!;
       } else {
@@ -277,5 +279,13 @@ export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): st
       }
     }
   }
+  return tokens;
+}
+
+export function compileExpr(expr: string, scope: { [key: string]: QWebVar }): string {
+  return tokenArrayToString(compileExprToArray(expr, scope));
+}
+
+export function tokenArrayToString(tokens: Token[]) {
   return tokens.map(t => t.value).join("");
 }

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -129,6 +129,9 @@ const UTILS: Utils = {
     while (obj && !obj.hasOwnProperty(str)) {
       obj = obj.__proto__;
     }
+    if (obj && str !== "__owl__" && obj.hasOwnProperty("__owl__")) {
+      return obj0;
+    }
     return obj || obj0;
   }
 };

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -122,10 +122,7 @@ const UTILS: Utils = {
       .join("");
   },
   getComponent(obj) {
-    while (obj && !obj.hasOwnProperty("__owl__")) {
-      obj = obj.__proto__;
-    }
-    return obj;
+    return this.getScope(obj, "__owl__");
   },
   getScope(obj, str: string) {
     const obj0 = obj;

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -126,6 +126,13 @@ const UTILS: Utils = {
       obj = obj.__proto__;
     }
     return obj;
+  },
+  getScope(obj, str: string) {
+    const obj0 = obj;
+    while (obj && !obj.hasOwnProperty(str)) {
+      obj = obj.__proto__;
+    }
+    return obj || obj0;
   }
 };
 

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -1017,6 +1017,33 @@ exports[`other directives with t-component t-on with stop and/or prevent modifie
 }"
 `;
 
+exports[`other directives with t-component t-set can't alter component 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    let _3 = scope['iter'];
+    if (_3 != null) {
+        c2.push({text: _3});
+    }
+    utils.getScope(scope, 'iter').iter = 5;
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('p', p4, c4);
+    c1.push(vn4);
+    if (scope.iter != null) {
+        c4.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
 exports[`other directives with t-component t-set outside modified in t-foreach 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -639,6 +639,160 @@ exports[`other directives with t-component slot setted value (with t-set) not ac
 }"
 `;
 
+exports[`other directives with t-component t-on expression in t-foreach 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.create(scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        let key1 = scope['val'];
+        let c6 = [], p6 = {key:\`\${key1}_6\`};
+        let vn6 = h('div', p6, c6);
+        c1.push(vn6);
+        let _7 = scope['val_index'];
+        if (_7 != null) {
+            c6.push({text: _7});
+        }
+        c6.push({text: \`: \`});
+        let _8 = scope['val']+'';
+        if (_8 != null) {
+            c6.push({text: _8});
+        }
+        let c9 = [], p9 = {key:\`\${key1}_9\`,on:{}};
+        let vn9 = h('button', p9, c9);
+        c6.push(vn9);
+        const otherState_10 = scope['otherState'];
+        const val_10 = scope['val'];
+        p9.on['click'] = function (e) {if (!context.__owl__.isMounted){return}otherState_10.vals.push(val_10)};
+        c9.push({text: \`Expr\`});
+    }
+    scope = _origScope5;
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-on expression in t-foreach with t-set 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    scope.bossa = 'nova';
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.create(scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        let key1 = scope['val'];
+        let c6 = [], p6 = {key:\`\${key1}_6\`};
+        let vn6 = h('div', p6, c6);
+        c1.push(vn6);
+        utils.getScope(scope, 'bossa').bossa = scope.bossa+'_'+scope['val_index'];
+        let _7 = scope['val_index'];
+        if (_7 != null) {
+            c6.push({text: _7});
+        }
+        c6.push({text: \`: \`});
+        let _8 = scope['val']+'';
+        if (_8 != null) {
+            c6.push({text: _8});
+        }
+        let c9 = [], p9 = {key:\`\${key1}_9\`,on:{}};
+        let vn9 = h('button', p9, c9);
+        c6.push(vn9);
+        const otherState_10 = scope['otherState'];
+        const val_10 = scope['val'];
+        const bossa_10 = scope.bossa;
+        p9.on['click'] = function (e) {if (!context.__owl__.isMounted){return}otherState_10.vals.push(val_10+'_'+bossa_10)};
+        c9.push({text: \`Expr\`});
+    }
+    scope = _origScope5;
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-on method call in t-foreach 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.create(scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        let key1 = scope['val'];
+        let c6 = [], p6 = {key:\`\${key1}_6\`};
+        let vn6 = h('div', p6, c6);
+        c1.push(vn6);
+        let _7 = scope['val_index'];
+        if (_7 != null) {
+            c6.push({text: _7});
+        }
+        c6.push({text: \`: \`});
+        let _8 = scope['val']+'';
+        if (_8 != null) {
+            c6.push({text: _8});
+        }
+        let c9 = [], p9 = {key:\`\${key1}_9\`,on:{}};
+        let vn9 = h('button', p9, c9);
+        c6.push(vn9);
+        let args10 = [scope['val']];
+        p9.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['addVal'](...args10, e);};
+        c9.push({text: \`meth call\`});
+    }
+    scope = _origScope5;
+    return vn1;
+}"
+`;
+
 exports[`other directives with t-component t-on with getter as handler 1`] = `
 "function anonymous(context, extra
 ) {
@@ -853,6 +1007,7 @@ exports[`other directives with t-component t-on with inline statement 1`] = `
         c1.push({text: _2});
     }
     // Component 'Child'
+    const state_5 = scope['state'];
     let w3 = '__4__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__4__']] : false;
     let props3 = {};
     if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
@@ -869,7 +1024,7 @@ exports[`other directives with t-component t-on with inline statement 1`] = `
         if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
         w3 = new W3(parent, props3);
         parent.__owl__.cmap['__4__'] = w3.__owl__.id;
-        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if (!context.__owl__.isMounted){return}scope['state'].counter++});}};});
+        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; vnode.data.hook = {create(_, vn){vn.elm.addEventListener('ev', function (e) {if (!context.__owl__.isMounted){return}state_5.counter++});}};});
         let pvnode = h('dummy', {key: '__4__', hook: {remove() {},destroy(vn) {w3.destroy();}}});
         c1.push(pvnode);
         w3.__owl__.pvnode = pvnode;
@@ -1387,9 +1542,9 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
     let c2 = [], p2 = {key:\`\${key0}_2\`,on:{}};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
-    let k3 = \`click__3__\${key0}__\`;
-    extra.handlers[k3] = extra.handlers[k3] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
-    p2.on['click'] = extra.handlers[k3];
+    let k4 = \`click__4__\${key0}__\`;
+    extra.handlers[k4] = extra.handlers[k4] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
+    p2.on['click'] = extra.handlers[k4];
     c2.push({text: \`lucas\`});
 }"
 `;

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -598,7 +598,7 @@ exports[`other directives with t-component slot setted value (with t-set) not ac
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'iter').iter = 'source';
+    scope.iter = 'source';
     let c2 = [], p2 = {key:2};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
@@ -1073,7 +1073,6 @@ exports[`other directives with t-component t-set can't alter component 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"__template__1\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
@@ -1085,7 +1084,7 @@ exports[`other directives with t-component t-set can't alter component 1`] = `
     if (_3 != null) {
         c2.push({text: _3});
     }
-    utils.getScope(scope, 'iter').iter = 5;
+    scope.iter = 5;
     let c4 = [], p4 = {key:4};
     let vn4 = h('p', p4, c4);
     c1.push(vn4);
@@ -1105,7 +1104,7 @@ exports[`other directives with t-component t-set can't alter from within callee 
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'iter').iter = 'source';
+    scope.iter = 'source';
     let c2 = [], p2 = {key:2};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
@@ -1132,7 +1131,7 @@ exports[`other directives with t-component t-set can't alter in t-call body 1`] 
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'iter').iter = 'source';
+    scope.iter = 'source';
     let c2 = [], p2 = {key:2};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
@@ -1171,7 +1170,7 @@ exports[`other directives with t-component t-set not altered by child widget 1`]
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'iter').iter = 'source';
+    scope.iter = 'source';
     let c2 = [], p2 = {key:2};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
@@ -1220,7 +1219,7 @@ exports[`other directives with t-component t-set outside modified in t-foreach 1
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'iter').iter = 0;
+    scope.iter = 0;
     let _2 = scope['state'].values;
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
     let _3 = _4 = _2;

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -587,6 +587,58 @@ exports[`dynamic t-props basic use 1`] = `
 }"
 `;
 
+exports[`other directives with t-component slot setted value (with t-set) not accessible with t-esc 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__2\\"
+    let utils = this.constructor.utils;
+    let QWeb = this.constructor;
+    let parent = context;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    utils.getScope(scope, 'iter').iter = 'source';
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    if (scope.iter != null) {
+        c2.push({text: scope.iter});
+    }
+    // Component 'ChildWidget'
+    let w3 = '__4__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__4__']] : false;
+    let props3 = {};
+    if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
+        w3.destroy();
+        w3 = false;
+    }
+    if (w3) {
+        w3.__updateProps(props3, extra.fiber, Object.assign(Object.create(context), scope));
+        let pvnode = w3.__owl__.pvnode;
+        c1.push(pvnode);
+    } else {
+        let componentKey3 = \`ChildWidget\`;
+        let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| scope['ChildWidget'];
+        if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
+        w3 = new W3(parent, props3);
+        parent.__owl__.cmap['__4__'] = w3.__owl__.id;
+        w3.__owl__.slotId = 1;
+        let fiber = w3.__prepare(extra.fiber, Object.assign(Object.create(context), scope), () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+        let pvnode = h('dummy', {key: '__4__', hook: {remove() {},destroy(vn) {w3.destroy();}}});
+        c1.push(pvnode);
+        w3.__owl__.pvnode = pvnode;
+    }
+    w3.__owl__.parentLastFiberId = extra.fiber.id;
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('p', p5, c5);
+    c1.push(vn5);
+    if (scope.iter != null) {
+        c5.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
 exports[`other directives with t-component t-on with getter as handler 1`] = `
 "function anonymous(context, extra
 ) {
@@ -1039,6 +1091,121 @@ exports[`other directives with t-component t-set can't alter component 1`] = `
     c1.push(vn4);
     if (scope.iter != null) {
         c4.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-set can't alter from within callee 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    utils.getScope(scope, 'iter').iter = 'source';
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    if (scope.iter != null) {
+        c2.push({text: scope.iter});
+    }
+    this.subTemplates['ChildWidget'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('p', p4, c4);
+    c1.push(vn4);
+    if (scope.iter != null) {
+        c4.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-set can't alter in t-call body 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    utils.getScope(scope, 'iter').iter = 'source';
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    if (scope.iter != null) {
+        c2.push({text: scope.iter});
+    }
+    {
+        let _origScope4 = scope;
+        scope = Object.assign(Object.create(context), scope);
+        {
+            let c__0 = [];
+            utils.getScope(scope, 'iter').iter = 'inCall';
+            scope[utils.zero] = c__0;
+        }
+        this.subTemplates['ChildWidget'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
+        scope = _origScope4;
+    }
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('p', p5, c5);
+    c1.push(vn5);
+    if (scope.iter != null) {
+        c5.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
+exports[`other directives with t-component t-set not altered by child widget 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__2\\"
+    let utils = this.constructor.utils;
+    let QWeb = this.constructor;
+    let parent = context;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    utils.getScope(scope, 'iter').iter = 'source';
+    let c2 = [], p2 = {key:2};
+    let vn2 = h('p', p2, c2);
+    c1.push(vn2);
+    if (scope.iter != null) {
+        c2.push({text: scope.iter});
+    }
+    // Component 'ChildWidget'
+    let w3 = '__4__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__4__']] : false;
+    let props3 = {};
+    if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
+        w3.destroy();
+        w3 = false;
+    }
+    if (w3) {
+        w3.__updateProps(props3, extra.fiber, undefined);
+        let pvnode = w3.__owl__.pvnode;
+        c1.push(pvnode);
+    } else {
+        let componentKey3 = \`ChildWidget\`;
+        let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| scope['ChildWidget'];
+        if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
+        w3 = new W3(parent, props3);
+        parent.__owl__.cmap['__4__'] = w3.__owl__.id;
+        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+        let pvnode = h('dummy', {key: '__4__', hook: {remove() {},destroy(vn) {w3.destroy();}}});
+        c1.push(pvnode);
+        w3.__owl__.pvnode = pvnode;
+    }
+    w3.__owl__.parentLastFiberId = extra.fiber.id;
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('p', p5, c5);
+    c1.push(vn5);
+    if (scope.iter != null) {
+        c5.push({text: scope.iter});
     }
     return vn1;
 }"

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -58,7 +58,7 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.section_first = i1 === 0
         scope.section_last = i1 === _length3 - 1
@@ -75,7 +75,7 @@ exports[`basic widget properties reconciliation alg works for t-foreach in t-for
         }
         let _length7 = _7.length;
         let _origScope9 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         for (let i2 = 0; i2 < _length7; i2++) {
             scope.blip_first = i2 === 0
             scope.blip_last = i2 === _length7 - 1
@@ -432,7 +432,7 @@ exports[`composition sub components with some state rendered in a loop 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.number_first = i1 === 0
         scope.number_last = i1 === _length3 - 1
@@ -1017,6 +1017,54 @@ exports[`other directives with t-component t-on with stop and/or prevent modifie
 }"
 `;
 
+exports[`other directives with t-component t-set outside modified in t-foreach 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"__template__1\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    utils.getScope(scope, 'iter').iter = 0;
+    let _2 = scope['state'].values;
+    if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
+    let _3 = _4 = _2;
+    if (!(_2 instanceof Array)) {
+        _3 = Object.keys(_2);
+        _4 = Object.values(_2);
+    }
+    let _length3 = _3.length;
+    let _origScope5 = scope;
+    scope = Object.create(scope);
+    for (let i1 = 0; i1 < _length3; i1++) {
+        scope.val_first = i1 === 0
+        scope.val_last = i1 === _length3 - 1
+        scope.val_index = i1
+        scope.val = _3[i1]
+        scope.val_value = _4[i1]
+        let key1 = scope['val'];
+        let c6 = [], p6 = {key:\`\${key1}_6\`};
+        let vn6 = h('p', p6, c6);
+        c1.push(vn6);
+        c6.push({text: \`InLoop: \`});
+        if (scope.iter != null) {
+            c6.push({text: scope.iter});
+        }
+        utils.getScope(scope, 'iter').iter = scope.iter+1;
+    }
+    scope = _origScope5;
+    let c7 = [], p7 = {key:7};
+    let vn7 = h('p', p7, c7);
+    c1.push(vn7);
+    c7.push({text: \`EndLoop: \`});
+    if (scope.iter != null) {
+        c7.push({text: scope.iter});
+    }
+    return vn1;
+}"
+`;
+
 exports[`random stuff/miscellaneous can inject values in tagged templates 1`] = `
 "function anonymous(context, extra
 ) {
@@ -1093,7 +1141,7 @@ exports[`random stuff/miscellaneous t-on with handler bound to dynamic argument 
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -1342,7 +1390,7 @@ exports[`t-model directive in a t-foreach 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.thing_first = i1 === 0
         scope.thing_last = i1 === _length3 - 1

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -1542,9 +1542,9 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
     let c2 = [], p2 = {key:\`\${key0}_2\`,on:{}};
     let vn2 = h('p', p2, c2);
     c1.push(vn2);
-    let k4 = \`click__4__\${key0}__\`;
-    extra.handlers[k4] = extra.handlers[k4] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
-    p2.on['click'] = extra.handlers[k4];
+    let k3 = \`click__3__\${key0}__\`;
+    extra.handlers[k3] = extra.handlers[k3] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
+    p2.on['click'] = extra.handlers[k3];
     c2.push({text: \`lucas\`});
 }"
 `;

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -192,15 +192,15 @@ exports[`t-slot directive refs are properly bound in slots 1`] = `
     let c8 = [], p8 = {key:8,on:{}};
     let vn8 = h('button', p8, c8);
     c1.push(vn8);
-    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__10__'];
-    const ref11 = \`myButton\`;
+    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p8.on['click'] = extra.handlers['click__9__'];
+    const ref10 = \`myButton\`;
     p8.hook = {
       create: (_, n) => {
-        context.__owl__.refs[ref11] = n.elm;
+        context.__owl__.refs[ref10] = n.elm;
       },
       destroy: () => {
-        delete context.__owl__.refs[ref11];
+        delete context.__owl__.refs[ref10];
       },
     };
     c8.push({text: \`do something\`});
@@ -217,8 +217,8 @@ exports[`t-slot directive slots are rendered with proper context 1`] = `
     let c8 = [], p8 = {key:8,on:{}};
     let vn8 = h('button', p8, c8);
     c1.push(vn8);
-    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__10__'];
+    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p8.on['click'] = extra.handlers['click__9__'];
     c8.push({text: \`do something\`});
 }"
 `;

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -263,7 +263,7 @@ exports[`t-slot directive slots are rendered with proper context, part 2 2`] = `
     }
     let _length4 = _4.length;
     let _origScope6 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length4; i1++) {
         scope.user_first = i1 === 0
         scope.user_last = i1 === _length4 - 1
@@ -360,7 +360,7 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
     }
     let _length4 = _4.length;
     let _origScope6 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length4; i1++) {
         scope.user_first = i1 === 0
         scope.user_last = i1 === _length4 - 1
@@ -371,7 +371,7 @@ exports[`t-slot directive slots are rendered with proper context, part 3 2`] = `
         let c7 = [], p7 = {key:\`\${key1}_7\`};
         let vn7 = h('li', p7, c7);
         c2.push(vn7);
-        scope.userdescr = 'User '+scope['user'].name;
+        utils.getScope(scope, 'userdescr').userdescr = 'User '+scope['user'].name;
         // Component 'Link'
         let k9 = \`__9__\${key1}__\`;
         let w8 = k9 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k9]] : false;
@@ -427,7 +427,7 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.userdescr = 'User '+scope['state'].user.name;
+    utils.getScope(scope, 'userdescr').userdescr = 'User '+scope['state'].user.name;
     // Component 'Link'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {to:'/user/'+scope['state'].user.id};

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -192,15 +192,15 @@ exports[`t-slot directive refs are properly bound in slots 1`] = `
     let c8 = [], p8 = {key:8,on:{}};
     let vn8 = h('button', p8, c8);
     c1.push(vn8);
-    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__9__'];
-    const ref10 = \`myButton\`;
+    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p8.on['click'] = extra.handlers['click__10__'];
+    const ref11 = \`myButton\`;
     p8.hook = {
       create: (_, n) => {
-        context.__owl__.refs[ref10] = n.elm;
+        context.__owl__.refs[ref11] = n.elm;
       },
       destroy: () => {
-        delete context.__owl__.refs[ref10];
+        delete context.__owl__.refs[ref11];
       },
     };
     c8.push({text: \`do something\`});
@@ -217,8 +217,8 @@ exports[`t-slot directive slots are rendered with proper context 1`] = `
     let c8 = [], p8 = {key:8,on:{}};
     let vn8 = h('button', p8, c8);
     c1.push(vn8);
-    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__9__'];
+    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p8.on['click'] = extra.handlers['click__10__'];
     c8.push({text: \`do something\`});
 }"
 `;

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -427,7 +427,7 @@ exports[`t-slot directive slots are rendered with proper context, part 4 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'userdescr').userdescr = 'User '+scope['state'].user.name;
+    scope.userdescr = 'User '+scope['state'].user.name;
     // Component 'Link'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
     let props2 = {to:'/user/'+scope['state'].user.id};

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -2670,6 +2670,47 @@ describe("other directives with t-component", () => {
     await nextTick(); // wait for changes triggered in mounted to be applied
     expect(fixture.innerHTML).toBe("<div><span>B0</span><span>B1</span></div>");
   });
+
+  test("t-set outside modified in t-foreach", async () => {
+    class SomeWidget extends Component<any, any> {
+      static template = xml`
+      <div>
+        <t t-set="iter" t-value="0"/>
+        <t t-foreach="state.values" t-as="val" t-key="val">
+          <p>InLoop: <t t-esc="iter"/></p>
+          <t t-set="iter" t-value="iter + 1"/>
+        </t>
+        <p>EndLoop: <t t-esc="iter"/></p>
+      </div>`;
+
+      state = useState({values: ['a', 'b']});
+    }
+    const widget = new SomeWidget();
+    await widget.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><p>InLoop: 0</p><p>InLoop: 1</p><p>EndLoop: 2</p></div>");
+    expect(QWeb.TEMPLATES[SomeWidget.template].fn.toString()).toMatchSnapshot();
+  });
+
+  test.skip("t-set outside modified in t-foreach increment operator", async () => {
+    class SomeWidget extends Component<any, any> {
+      static template = xml`
+      <div>
+        <t t-set="iter" t-value="0"/>
+        <t t-foreach="state.values" t-as="val" t-key="val">
+          <p>InLoop: <t t-esc="iter"/></p>
+          <t t-set="iter" t-value="iter++"/>
+        </t>
+        <p>EndLoop: <t t-esc="iter"/></p>
+      </div>`;
+
+      state = useState({values: ['a', 'b']});
+    }
+    const widget = new SomeWidget();
+    await widget.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><p>Inloop: 0</p><p>Inloop: 1</p><p>EndLoop: 2</p></div>");
+  });
 });
 
 describe("random stuff/miscellaneous", () => {

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -2692,6 +2692,25 @@ describe("other directives with t-component", () => {
     expect(QWeb.TEMPLATES[SomeWidget.template].fn.toString()).toMatchSnapshot();
   });
 
+  test("t-set can't alter component", async () => {
+    class SomeWidget extends Component<any, any> {
+      static template = xml`
+      <div>
+        <p><t t-esc="iter"/></p>
+        <t t-set="iter" t-value="5"/>
+        <p><t t-esc="iter"/></p>
+      </div>`;
+
+      iter = 1;
+    }
+    const widget = new SomeWidget();
+    await widget.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><p>1</p><p>5</p></div>");
+    expect(widget.iter).toBe(1);
+    expect(QWeb.TEMPLATES[SomeWidget.template].fn.toString()).toMatchSnapshot();
+  });
+
   test.skip("t-set outside modified in t-foreach increment operator", async () => {
     class SomeWidget extends Component<any, any> {
       static template = xml`

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -2800,7 +2800,7 @@ describe("other directives with t-component", () => {
     expect(QWeb.TEMPLATES[SomeWidget.template].fn.toString()).toMatchSnapshot();
   });
 
-  test.skip("t-set outside modified in t-foreach increment operator", async () => {
+  test("t-set outside modified in t-foreach increment-after operator", async () => {
     class SomeWidget extends Component<any, any> {
       static template = xml`
       <div>
@@ -2816,8 +2816,26 @@ describe("other directives with t-component", () => {
     }
     const widget = new SomeWidget();
     await widget.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div><p>InLoop: 0</p><p>InLoop: 1</p><p>EndLoop: 0</p></div>");
+  });
 
-    expect(fixture.innerHTML).toBe("<div><p>Inloop: 0</p><p>Inloop: 1</p><p>EndLoop: 2</p></div>");
+  test("t-set outside modified in t-foreach increment-before operator", async () => {
+    class SomeWidget extends Component<any, any> {
+      static template = xml`
+      <div>
+        <t t-set="iter" t-value="0"/>
+        <t t-foreach="state.values" t-as="val" t-key="val">
+          <p>InLoop: <t t-esc="iter"/></p>
+          <t t-set="iter" t-value="++iter"/>
+        </t>
+        <p>EndLoop: <t t-esc="iter"/></p>
+      </div>`;
+
+      state = useState({values: ['a', 'b']});
+    }
+    const widget = new SomeWidget();
+    await widget.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div><p>InLoop: 0</p><p>InLoop: 1</p><p>EndLoop: 1</p></div>");
   });
 });
 

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -2919,7 +2919,6 @@ describe("other directives with t-component", () => {
     const widget = new SomeWidget();
     await widget.mount(fixture);
 
-    console.warn(QWeb.TEMPLATES[SomeWidget.template].fn.toString());
     expect(fixture.innerHTML).toBe("<div><div>0: a<button>Expr</button></div><div>1: b<button>Expr</button></div></div>");
     expect(widget.otherState.vals).toStrictEqual([]);
     const buttons = fixture.querySelectorAll('button');
@@ -2947,7 +2946,6 @@ describe("other directives with t-component", () => {
     const widget = new SomeWidget();
     await widget.mount(fixture);
 
-    console.warn(QWeb.TEMPLATES[SomeWidget.template].fn.toString());
     expect(fixture.innerHTML).toBe("<div><div>0: a<button>Expr</button></div><div>1: b<button>Expr</button></div></div>");
     expect(widget.otherState.vals).toStrictEqual([]);
     const buttons = fixture.querySelectorAll('button');

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -2187,8 +2187,8 @@ exports[`t-on can bind event handler 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
-    p1.on['click'] = extra.handlers['click__3__'];
+    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
+    p1.on['click'] = extra.handlers['click__2__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2307,10 +2307,10 @@ exports[`t-on can bind two event handlers 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleClick'](e);};
-    p1.on['click'] = extra.handlers['click__3__'];
-    extra.handlers['dblclick__5__'] = extra.handlers['dblclick__5__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleDblClick'](e);};
-    p1.on['dblclick'] = extra.handlers['dblclick__5__'];
+    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleClick'](e);};
+    p1.on['click'] = extra.handlers['click__2__'];
+    extra.handlers['dblclick__3__'] = extra.handlers['dblclick__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleDblClick'](e);};
+    p1.on['dblclick'] = extra.handlers['dblclick__3__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2324,8 +2324,8 @@ exports[`t-on handler is bound to proper owner 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
-    p1.on['click'] = extra.handlers['click__3__'];
+    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
+    p1.on['click'] = extra.handlers['click__2__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2343,11 +2343,11 @@ exports[`t-on t-on combined with t-esc 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
-    let _5 = scope['text'];
-    if (_5 != null) {
-        c2.push({text: _5});
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
+    let _4 = scope['text'];
+    if (_4 != null) {
+        c2.push({text: _4});
     }
     return vn1;
 }"
@@ -2365,11 +2365,11 @@ exports[`t-on t-on combined with t-raw 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
-    let _5 = scope['html'];
-    if (_5 != null) {
-        c2.push(...utils.htmlToVDOM(_5));
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
+    let _4 = scope['html'];
+    if (_4 != null) {
+        c2.push(...utils.htmlToVDOM(_4));
     }
     return vn1;
 }"
@@ -2464,12 +2464,12 @@ exports[`t-on t-on with prevent and self modifiers (order matters) 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();if (e.target !== this.elm) {return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('span', p5, c5);
-    c2.push(vn5);
-    c5.push({text: \`Button\`});
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();if (e.target !== this.elm) {return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('span', p4, c4);
+    c2.push(vn4);
+    c4.push({text: \`Button\`});
     return vn1;
 }"
 `;
@@ -2485,21 +2485,21 @@ exports[`t-on t-on with prevent and/or stop modifiers 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onClickPrevented'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onClickPrevented'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
     c2.push({text: \`Button 1\`});
-    let c5 = [], p5 = {key:5,on:{}};
-    let vn5 = h('button', p5, c5);
-    c1.push(vn5);
-    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}e.stopPropagation();utils.getComponent(context)['onClickStopped'](e);};
-    p5.on['click'] = extra.handlers['click__7__'];
-    c5.push({text: \`Button 2\`});
-    let c8 = [], p8 = {key:8,on:{}};
-    let vn8 = h('button', p8, c8);
-    c1.push(vn8);
-    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();e.stopPropagation();utils.getComponent(context)['onClickPreventedAndStopped'](e);};
-    p8.on['click'] = extra.handlers['click__10__'];
-    c8.push({text: \`Button 3\`});
+    let c4 = [], p4 = {key:4,on:{}};
+    let vn4 = h('button', p4, c4);
+    c1.push(vn4);
+    extra.handlers['click__5__'] = extra.handlers['click__5__'] || function (e) {if (!context.__owl__.isMounted){return}e.stopPropagation();utils.getComponent(context)['onClickStopped'](e);};
+    p4.on['click'] = extra.handlers['click__5__'];
+    c4.push({text: \`Button 2\`});
+    let c6 = [], p6 = {key:6,on:{}};
+    let vn6 = h('button', p6, c6);
+    c1.push(vn6);
+    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();e.stopPropagation();utils.getComponent(context)['onClickPreventedAndStopped'](e);};
+    p6.on['click'] = extra.handlers['click__7__'];
+    c6.push({text: \`Button 3\`});
     return vn1;
 }"
 `;
@@ -2561,12 +2561,12 @@ exports[`t-on t-on with self and prevent modifiers (order matters) 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}e.preventDefault();utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('span', p5, c5);
-    c2.push(vn5);
-    c5.push({text: \`Button\`});
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}e.preventDefault();utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('span', p4, c4);
+    c2.push(vn4);
+    c4.push({text: \`Button\`});
     return vn1;
 }"
 `;
@@ -2582,21 +2582,21 @@ exports[`t-on t-on with self modifier 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__4__'];
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('span', p5, c5);
-    c2.push(vn5);
-    c5.push({text: \`Button\`});
-    let c6 = [], p6 = {key:6,on:{}};
-    let vn6 = h('button', p6, c6);
-    c1.push(vn6);
-    extra.handlers['click__8__'] = extra.handlers['click__8__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}utils.getComponent(context)['onClickSelf'](e);};
-    p6.on['click'] = extra.handlers['click__8__'];
-    let c9 = [], p9 = {key:9};
-    let vn9 = h('span', p9, c9);
-    c6.push(vn9);
-    c9.push({text: \`Button\`});
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__3__'];
+    let c4 = [], p4 = {key:4};
+    let vn4 = h('span', p4, c4);
+    c2.push(vn4);
+    c4.push({text: \`Button\`});
+    let c5 = [], p5 = {key:5,on:{}};
+    let vn5 = h('button', p5, c5);
+    c1.push(vn5);
+    extra.handlers['click__6__'] = extra.handlers['click__6__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}utils.getComponent(context)['onClickSelf'](e);};
+    p5.on['click'] = extra.handlers['click__6__'];
+    let c7 = [], p7 = {key:7};
+    let vn7 = h('span', p7, c7);
+    c5.push(vn7);
+    c7.push({text: \`Button\`});
     return vn1;
 }"
 `;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -2187,8 +2187,8 @@ exports[`t-on can bind event handler 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
-    p1.on['click'] = extra.handlers['click__2__'];
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
+    p1.on['click'] = extra.handlers['click__3__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2307,10 +2307,10 @@ exports[`t-on can bind two event handlers 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleClick'](e);};
-    p1.on['click'] = extra.handlers['click__2__'];
-    extra.handlers['dblclick__3__'] = extra.handlers['dblclick__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleDblClick'](e);};
-    p1.on['dblclick'] = extra.handlers['dblclick__3__'];
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleClick'](e);};
+    p1.on['click'] = extra.handlers['click__3__'];
+    extra.handlers['dblclick__5__'] = extra.handlers['dblclick__5__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['handleDblClick'](e);};
+    p1.on['dblclick'] = extra.handlers['dblclick__5__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2324,8 +2324,8 @@ exports[`t-on handler is bound to proper owner 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    extra.handlers['click__2__'] = extra.handlers['click__2__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
-    p1.on['click'] = extra.handlers['click__2__'];
+    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['add'](e);};
+    p1.on['click'] = extra.handlers['click__3__'];
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2343,11 +2343,11 @@ exports[`t-on t-on combined with t-esc 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    let _4 = scope['text'];
-    if (_4 != null) {
-        c2.push({text: _4});
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
+    let _5 = scope['text'];
+    if (_5 != null) {
+        c2.push({text: _5});
     }
     return vn1;
 }"
@@ -2365,11 +2365,11 @@ exports[`t-on t-on combined with t-raw 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    let _4 = scope['html'];
-    if (_4 != null) {
-        c2.push(...utils.htmlToVDOM(_4));
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
+    let _5 = scope['html'];
+    if (_5 != null) {
+        c2.push(...utils.htmlToVDOM(_5));
     }
     return vn1;
 }"
@@ -2400,7 +2400,8 @@ exports[`t-on t-on with inline statement (function call) 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].incrementCounter(2)};
+    const state_2 = scope['state'];
+    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}state_2.incrementCounter(2)};
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2414,7 +2415,8 @@ exports[`t-on t-on with inline statement 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].counter++};
+    const state_2 = scope['state'];
+    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}state_2.counter++};
     c1.push({text: \`Click\`});
     return vn1;
 }"
@@ -2428,7 +2430,8 @@ exports[`t-on t-on with inline statement, part 2 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].flag=!scope['state'].flag};
+    const state_2 = scope['state'];
+    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}state_2.flag=!scope['state'].flag};
     c1.push({text: \`Toggle\`});
     return vn1;
 }"
@@ -2442,7 +2445,9 @@ exports[`t-on t-on with inline statement, part 3 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1,on:{}};
     let vn1 = h('button', p1, c1);
-    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}scope['state'].n=scope['someFunction'](3)};
+    const state_2 = scope['state'];
+    const someFunction_2 = scope['someFunction'];
+    p1.on['click'] = function (e) {if (!context.__owl__.isMounted){return}state_2.n=someFunction_2(3)};
     c1.push({text: \`Toggle\`});
     return vn1;
 }"
@@ -2459,12 +2464,12 @@ exports[`t-on t-on with prevent and self modifiers (order matters) 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();if (e.target !== this.elm) {return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c2.push(vn4);
-    c4.push({text: \`Button\`});
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();if (e.target !== this.elm) {return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c2.push(vn5);
+    c5.push({text: \`Button\`});
     return vn1;
 }"
 `;
@@ -2480,21 +2485,21 @@ exports[`t-on t-on with prevent and/or stop modifiers 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onClickPrevented'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();utils.getComponent(context)['onClickPrevented'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
     c2.push({text: \`Button 1\`});
-    let c4 = [], p4 = {key:4,on:{}};
-    let vn4 = h('button', p4, c4);
-    c1.push(vn4);
-    extra.handlers['click__5__'] = extra.handlers['click__5__'] || function (e) {if (!context.__owl__.isMounted){return}e.stopPropagation();utils.getComponent(context)['onClickStopped'](e);};
-    p4.on['click'] = extra.handlers['click__5__'];
-    c4.push({text: \`Button 2\`});
-    let c6 = [], p6 = {key:6,on:{}};
-    let vn6 = h('button', p6, c6);
-    c1.push(vn6);
-    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();e.stopPropagation();utils.getComponent(context)['onClickPreventedAndStopped'](e);};
-    p6.on['click'] = extra.handlers['click__7__'];
-    c6.push({text: \`Button 3\`});
+    let c5 = [], p5 = {key:5,on:{}};
+    let vn5 = h('button', p5, c5);
+    c1.push(vn5);
+    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}e.stopPropagation();utils.getComponent(context)['onClickStopped'](e);};
+    p5.on['click'] = extra.handlers['click__7__'];
+    c5.push({text: \`Button 2\`});
+    let c8 = [], p8 = {key:8,on:{}};
+    let vn8 = h('button', p8, c8);
+    c1.push(vn8);
+    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}e.preventDefault();e.stopPropagation();utils.getComponent(context)['onClickPreventedAndStopped'](e);};
+    p8.on['click'] = extra.handlers['click__10__'];
+    c8.push({text: \`Button 3\`});
     return vn1;
 }"
 `;
@@ -2556,12 +2561,12 @@ exports[`t-on t-on with self and prevent modifiers (order matters) 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}e.preventDefault();utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c2.push(vn4);
-    c4.push({text: \`Button\`});
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}e.preventDefault();utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c2.push(vn5);
+    c5.push({text: \`Button\`});
     return vn1;
 }"
 `;
@@ -2577,21 +2582,21 @@ exports[`t-on t-on with self modifier 1`] = `
     let c2 = [], p2 = {key:2,on:{}};
     let vn2 = h('button', p2, c2);
     c1.push(vn2);
-    extra.handlers['click__3__'] = extra.handlers['click__3__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
-    p2.on['click'] = extra.handlers['click__3__'];
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c2.push(vn4);
-    c4.push({text: \`Button\`});
-    let c5 = [], p5 = {key:5,on:{}};
-    let vn5 = h('button', p5, c5);
-    c1.push(vn5);
-    extra.handlers['click__6__'] = extra.handlers['click__6__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}utils.getComponent(context)['onClickSelf'](e);};
-    p5.on['click'] = extra.handlers['click__6__'];
-    let c7 = [], p7 = {key:7};
-    let vn7 = h('span', p7, c7);
-    c5.push(vn7);
-    c7.push({text: \`Button\`});
+    extra.handlers['click__4__'] = extra.handlers['click__4__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['onClick'](e);};
+    p2.on['click'] = extra.handlers['click__4__'];
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c2.push(vn5);
+    c5.push({text: \`Button\`});
+    let c6 = [], p6 = {key:6,on:{}};
+    let vn6 = h('button', p6, c6);
+    c1.push(vn6);
+    extra.handlers['click__8__'] = extra.handlers['click__8__'] || function (e) {if (!context.__owl__.isMounted){return}if (e.target !== this.elm) {return}utils.getComponent(context)['onClickSelf'](e);};
+    p6.on['click'] = extra.handlers['click__8__'];
+    let c9 = [], p9 = {key:9};
+    let vn9 = h('span', p9, c9);
+    c6.push(vn9);
+    c9.push({text: \`Button\`});
     return vn1;
 }"
 `;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -179,7 +179,7 @@ exports[`attributes from object variables set previously 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.o = {a:'b'};
+    utils.getScope(scope, 'o').o = {a:'b'};
     let _2 = utils.toObj(scope.o.a);
     let c3 = [], p3 = {key:3,class:_2};
     let vn3 = h('span', p3, c3);
@@ -197,7 +197,7 @@ exports[`attributes from variables set previously 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.abc = 'def';
+    utils.getScope(scope, 'abc').abc = 'def';
     let _2 = utils.toObj(scope.abc);
     let c3 = [], p3 = {key:3,class:_2};
     let vn3 = h('span', p3, c3);
@@ -394,11 +394,12 @@ exports[`debugging t-log 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.foo = 42;
+    utils.getScope(scope, 'foo').foo = 42;
     console.log(scope.foo+3)
     return vn1;
 }"
@@ -421,7 +422,7 @@ exports[`foreach does not pollute the rendering context 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -456,7 +457,7 @@ exports[`foreach iterate on items (on a element node) 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -494,7 +495,7 @@ exports[`foreach iterate on items 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -541,7 +542,7 @@ exports[`foreach iterate, dict param 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -588,7 +589,7 @@ exports[`foreach iterate, position 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.elem_first = i1 === 0
         scope.elem_last = i1 === _length3 - 1
@@ -632,7 +633,7 @@ exports[`foreach t-foreach in t-forach 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.number_first = i1 === 0
         scope.number_last = i1 === _length3 - 1
@@ -649,7 +650,7 @@ exports[`foreach t-foreach in t-forach 1`] = `
         }
         let _length7 = _7.length;
         let _origScope9 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         for (let i2 = 0; i2 < _length7; i2++) {
             scope.letter_first = i2 === 0
             scope.letter_last = i2 === _length7 - 1
@@ -692,7 +693,7 @@ exports[`foreach warn if no key in some case 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -757,7 +758,7 @@ exports[`misc global 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.value_first = i1 === 0
         scope.value_last = i1 === _length3 - 1
@@ -774,15 +775,15 @@ exports[`misc global 1`] = `
         }
         {
             let _origScope10 = scope;
-            scope = Object.assign(Object.create(context), scope);
+            scope = Object.create(scope);
             {
                 let c__0 = [];
                 {
                     let _origScope13 = scope;
-                    scope = Object.assign(Object.create(context), scope);
+                    scope = Object.create(scope);
                     {
                         let c__0 = [];
-                        scope.foo = 'aaa';
+                        utils.getScope(scope, 'foo').foo = 'aaa';
                         scope[utils.zero] = c__0;
                     }
                     let k14 = \`__14__\${key1}__\`;
@@ -791,7 +792,7 @@ exports[`misc global 1`] = `
                 }
                 let k15 = \`__15__\${key1}__\`;
                 this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k15}));
-                scope.foo = 'bbb';
+                utils.getScope(scope, 'foo').foo = 'bbb';
                 let k16 = \`__16__\${key1}__\`;
                 this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k16}));
                 scope[utils.zero] = c__0;
@@ -1100,7 +1101,7 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
     let vn1 = h('div', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
@@ -1148,7 +1149,7 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope12 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
             let c13 = [], p13 = {key:13};
@@ -1178,7 +1179,7 @@ exports[`t-call (template calling inherit context 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.foo = 1;
+    utils.getScope(scope, 'foo').foo = 1;
     this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     return vn1;
 }"
@@ -1238,10 +1239,10 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope11 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
-            scope.node = scope['root'];
+            utils.getScope(scope, 'node').node = scope['root'];
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
@@ -1279,7 +1280,7 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
     }
     let _length6 = _6.length;
     let _origScope8 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length6; i1++) {
         scope.subtree_first = i1 === 0
         scope.subtree_last = i1 === _length6 - 1
@@ -1289,10 +1290,10 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
         let key1 = i1;
         {
             let _origScope9 = scope;
-            scope = Object.assign(Object.create(context), scope);
+            scope = Object.create(scope);
             {
                 let c__0 = [];
-                scope.node = scope['subtree'];
+                utils.getScope(scope, 'node').node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
             let k10 = \`__10__\${key0}__\${key1}__\`;
@@ -1315,10 +1316,10 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope11 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
-            scope.node = scope['root'];
+            utils.getScope(scope, 'node').node = scope['root'];
             scope[utils.zero] = c__0;
         }
         this.subTemplates['nodeTemplate'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
@@ -1356,7 +1357,7 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
     }
     let _length6 = _6.length;
     let _origScope8 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length6; i1++) {
         scope.subtree_first = i1 === 0
         scope.subtree_last = i1 === _length6 - 1
@@ -1366,10 +1367,10 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
         let key1 = i1;
         {
             let _origScope9 = scope;
-            scope = Object.assign(Object.create(context), scope);
+            scope = Object.create(scope);
             {
                 let c__0 = [];
-                scope.node = scope['subtree'];
+                utils.getScope(scope, 'node').node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
             let k10 = \`__10__\${key0}__\${key1}__\`;
@@ -1392,10 +1393,10 @@ exports[`t-call (template calling scoped parameters 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope2 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
-            scope.foo = 42;
+            utils.getScope(scope, 'foo').foo = 42;
             scope[utils.zero] = c__0;
         }
         this.subTemplates['_basic-callee'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
@@ -1456,7 +1457,7 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.v_first = i1 === 0
         scope.v_last = i1 === _length3 - 1
@@ -1464,13 +1465,13 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         scope.v = _3[i1]
         scope.v_value = _4[i1]
         let key1 = i1;
-        scope.val = scope['v'].val;
+        utils.getScope(scope, 'val').val = scope['v'].val;
         {
             let _origScope8 = scope;
-            scope = Object.assign(Object.create(context), scope);
+            scope = Object.create(scope);
             {
                 let c__0 = [];
-                scope.val3 = scope.val*3;
+                utils.getScope(scope, 'val3').val3 = scope.val*3;
                 scope[utils.zero] = c__0;
             }
             let k9 = \`__9__\${key1}__\`;
@@ -1492,7 +1493,7 @@ exports[`t-call (template calling t-call with t-set inside and outside. 2 1`] = 
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('p', p1, c1);
-    scope.w = 'fromwrapper';
+    utils.getScope(scope, 'w').w = 'fromwrapper';
     this.subTemplates['main'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     return vn1;
 }"
@@ -1507,17 +1508,17 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v1 = 'elif';
+    utils.getScope(scope, 'v1').v1 = 'elif';
     if (scope.v1==='if') {
         this.subTemplates['callee1'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     }
     else if (scope.v1==='elif') {
         {
             let _origScope5 = scope;
-            scope = Object.assign(Object.create(context), scope);
+            scope = Object.create(scope);
             {
                 let c__0 = [];
-                scope.v = 'success';
+                utils.getScope(scope, 'v').v = 'success';
                 scope[utils.zero] = c__0;
             }
             this.subTemplates['callee2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
@@ -1552,7 +1553,7 @@ exports[`t-call (template calling with unused body 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
             c__0.push({text: \`WHEEE\`});
@@ -1577,10 +1578,10 @@ exports[`t-call (template calling with unused setbody 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
-            scope.qux = 3;
+            utils.getScope(scope, 'qux').qux = 3;
             scope[utils.zero] = c__0;
         }
         result = []
@@ -1602,7 +1603,7 @@ exports[`t-call (template calling with used body 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
             c__0.push({text: \`ok\`});
@@ -1628,10 +1629,10 @@ exports[`t-call (template calling with used set body 1`] = `
     let vn1 = h('span', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
-            scope.foo = 'ok';
+            utils.getScope(scope, 'foo').foo = 'ok';
             scope[utils.zero] = c__0;
         }
         this.subTemplates['_callee-uses-foo'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
@@ -1789,7 +1790,7 @@ exports[`t-esc t-esc is escaped 1`] = `
     scope.var = c2
     if (scope.var != null) {
         let _origScope4 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.var = scope.var instanceof utils.VDomArray ? utils.vDomToString(scope.var) : scope.var;
         c1.push({text: scope.var});
         scope = _origScope4;
@@ -1825,7 +1826,7 @@ exports[`t-esc t-esc=0 is escaped 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
@@ -2057,12 +2058,13 @@ exports[`t-if t-set, then t-elif, part 3 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.y = false;
-    scope.x = scope.y;
+    utils.getScope(scope, 'y').y = false;
+    utils.getScope(scope, 'x').x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
         let vn2 = h('span', p2, c2);
@@ -2083,11 +2085,12 @@ exports[`t-if t-set, then t-if 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.title = 'test';
+    utils.getScope(scope, 'title').title = 'test';
     if (scope.title) {
         if (scope.title != null) {
             c1.push({text: scope.title});
@@ -2101,12 +2104,13 @@ exports[`t-if t-set, then t-if, part 2 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.y = true;
-    scope.x = scope.y;
+    utils.getScope(scope, 'y').y = true;
+    utils.getScope(scope, 'x').x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
         let vn2 = h('span', p2, c2);
@@ -2156,7 +2160,7 @@ exports[`t-key t-key directive in a list 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.beer_first = i1 === 0
         scope.beer_last = i1 === _length3 - 1
@@ -2260,7 +2264,7 @@ exports[`t-on can bind handlers with loop variable as argument 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.action_first = i1 === 0
         scope.action_last = i1 === _length3 - 1
@@ -2517,7 +2521,7 @@ exports[`t-on t-on with prevent modifier in t-foreach 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.project_first = i1 === 0
         scope.project_last = i1 === _length3 - 1
@@ -2763,7 +2767,7 @@ exports[`t-ref refs in a loop 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.item_first = i1 === 0
         scope.item_last = i1 === _length3 - 1
@@ -2800,11 +2804,12 @@ exports[`t-set evaluate value expression 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.value = 1+2;
+    utils.getScope(scope, 'value').value = 1+2;
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2816,11 +2821,12 @@ exports[`t-set evaluate value expression, part 2 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.value = scope['somevariable']+2;
+    utils.getScope(scope, 'value').value = scope['somevariable']+2;
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2832,11 +2838,12 @@ exports[`t-set set from attribute literal 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.value = 'ok';
+    utils.getScope(scope, 'value').value = 'ok';
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2848,11 +2855,12 @@ exports[`t-set set from attribute lookup 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.stuff = scope['value'];
+    utils.getScope(scope, 'stuff').stuff = scope['value'];
     if (scope.stuff != null) {
         c1.push({text: scope.stuff});
     }
@@ -2873,7 +2881,7 @@ exports[`t-set set from body literal 1`] = `
     scope.value = c1
     if (scope.value != null) {
         let _origScope2 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
         let vn3 = {text: scope.value};
         result = vn3
@@ -2900,7 +2908,7 @@ exports[`t-set set from body lookup 1`] = `
     scope.stuff = c2
     if (scope.stuff != null) {
         let _origScope4 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.stuff = scope.stuff instanceof utils.VDomArray ? utils.vDomToString(scope.stuff) : scope.stuff;
         c1.push({text: scope.stuff});
         scope = _origScope4;
@@ -2913,6 +2921,7 @@ exports[`t-set set from empty body 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
@@ -2928,11 +2937,12 @@ exports[`t-set t-set and t-if 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v = scope['value'];
+    utils.getScope(scope, 'v').v = scope['value'];
     if (scope.v==='ok') {
         c1.push({text: \`grimbergen\`});
     }
@@ -2949,7 +2959,7 @@ exports[`t-set t-set body is evaluated immediately 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v1 = 'before';
+    utils.getScope(scope, 'v1').v1 = 'before';
     let c2 = new utils.VDomArray();
     let c3 = [], p3 = {key:3};
     let vn3 = h('span', p3, c3);
@@ -2958,7 +2968,7 @@ exports[`t-set t-set body is evaluated immediately 1`] = `
         c3.push({text: scope.v1});
     }
     scope.v2 = c2
-    scope.v1 = 'after';
+    utils.getScope(scope, 'v1').v1 = 'after';
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -2971,11 +2981,12 @@ exports[`t-set t-set evaluates an expression only once 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v = scope['value']+' artois';
+    utils.getScope(scope, 'v').v = scope['value']+' artois';
     if (scope.v != null) {
         c1.push({text: scope.v});
     }
@@ -2990,11 +3001,12 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
+    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v = 1;
+    utils.getScope(scope, 'v').v = 1;
     let _2 = scope['list'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
     let _3 = _4 = _2;
@@ -3004,7 +3016,7 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
     }
     let _length3 = _3.length;
     let _origScope5 = scope;
-    scope = Object.assign(Object.create(context), scope);
+    scope = Object.create(scope);
     for (let i1 = 0; i1 < _length3; i1++) {
         scope.elem_first = i1 === 0
         scope.elem_last = i1 === _length3 - 1
@@ -3022,7 +3034,7 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
         if (scope.v != null) {
             c7.push({text: scope.v});
         }
-        scope.v = scope['elem'];
+        utils.getScope(scope, 'v').v = scope['elem'];
     }
     scope = _origScope5;
     return vn1;
@@ -3047,7 +3059,7 @@ exports[`t-set t-set with content and sub t-esc 1`] = `
     scope.setvar = c2
     if (scope.setvar != null) {
         let _origScope4 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.setvar = scope.setvar instanceof utils.VDomArray ? utils.vDomToString(scope.setvar) : scope.setvar;
         c1.push({text: scope.setvar});
         scope = _origScope4;
@@ -3065,9 +3077,9 @@ exports[`t-set t-set with t-value (falsy) and body 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v3 = false;
-    scope.v1 = 'before';
-    scope.v2 = scope.v3;
+    utils.getScope(scope, 'v3').v3 = false;
+    utils.getScope(scope, 'v1').v1 = 'before';
+    utils.getScope(scope, 'v2').v2 = scope.v3;
     if (!(scope.v2)) {
         let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
@@ -3078,8 +3090,8 @@ exports[`t-set t-set with t-value (falsy) and body 1`] = `
         }
         scope.v2 = c2
     }
-    scope.v1 = 'after';
-    scope.v3 = true;
+    utils.getScope(scope, 'v1').v1 = 'after';
+    utils.getScope(scope, 'v3').v3 = true;
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -3097,9 +3109,9 @@ exports[`t-set t-set with t-value (truthy) and body 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.v3 = 'Truthy';
-    scope.v1 = 'before';
-    scope.v2 = scope.v3;
+    utils.getScope(scope, 'v3').v3 = 'Truthy';
+    utils.getScope(scope, 'v1').v1 = 'before';
+    utils.getScope(scope, 'v2').v2 = scope.v3;
     if (!(scope.v2)) {
         let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
@@ -3110,8 +3122,8 @@ exports[`t-set t-set with t-value (truthy) and body 1`] = `
         }
         scope.v2 = c2
     }
-    scope.v1 = 'after';
-    scope.v3 = false;
+    utils.getScope(scope, 'v1').v1 = 'after';
+    utils.getScope(scope, 'v3').v3 = false;
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -3135,11 +3147,11 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 1`] = `
         scope.ourvar = c2
     }
     else {
-        scope.ourvar = 0;
+        utils.getScope(scope, 'ourvar').ourvar = 0;
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3163,11 +3175,11 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 2`] = `
         scope.ourvar = c2
     }
     else {
-        scope.ourvar = 0;
+        utils.getScope(scope, 'ourvar').ourvar = 0;
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3186,7 +3198,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        scope.ourvar = 1;
+        utils.getScope(scope, 'ourvar').ourvar = 1;
     }
     else {
         let c2 = new utils.VDomArray();
@@ -3195,7 +3207,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 1`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3214,7 +3226,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 2`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        scope.ourvar = 1;
+        utils.getScope(scope, 'ourvar').ourvar = 1;
     }
     else {
         let c2 = new utils.VDomArray();
@@ -3223,7 +3235,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 2`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3241,7 +3253,7 @@ exports[`t-set value priority 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    scope.value = 1;
+    utils.getScope(scope, 'value').value = 1;
     if (!(scope.value)) {
         let c2 = new utils.VDomArray();
         c2.push({text: \`2\`});
@@ -3249,7 +3261,7 @@ exports[`t-set value priority 1`] = `
     }
     if (scope.value != null) {
         let _origScope3 = scope;
-        scope = Object.assign(Object.create(context), scope);
+        scope = Object.create(scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
         c1.push({text: scope.value});
         scope = _origScope3;

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -179,7 +179,7 @@ exports[`attributes from object variables set previously 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'o').o = {a:'b'};
+    scope.o = {a:'b'};
     let _2 = utils.toObj(scope.o.a);
     let c3 = [], p3 = {key:3,class:_2};
     let vn3 = h('span', p3, c3);
@@ -197,7 +197,7 @@ exports[`attributes from variables set previously 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'abc').abc = 'def';
+    scope.abc = 'def';
     let _2 = utils.toObj(scope.abc);
     let c3 = [], p3 = {key:3,class:_2};
     let vn3 = h('span', p3, c3);
@@ -394,12 +394,11 @@ exports[`debugging t-log 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'foo').foo = 42;
+    scope.foo = 42;
     console.log(scope.foo+3)
     return vn1;
 }"
@@ -1179,7 +1178,7 @@ exports[`t-call (template calling inherit context 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'foo').foo = 1;
+    scope.foo = 1;
     this.subTemplates['_callee-uses-foo'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     return vn1;
 }"
@@ -1493,7 +1492,7 @@ exports[`t-call (template calling t-call with t-set inside and outside. 2 1`] = 
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('p', p1, c1);
-    utils.getScope(scope, 'w').w = 'fromwrapper';
+    scope.w = 'fromwrapper';
     this.subTemplates['main'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     return vn1;
 }"
@@ -1508,7 +1507,7 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v1').v1 = 'elif';
+    scope.v1 = 'elif';
     if (scope.v1==='if') {
         this.subTemplates['callee1'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context)}));
     }
@@ -2058,13 +2057,12 @@ exports[`t-if t-set, then t-elif, part 3 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'y').y = false;
-    utils.getScope(scope, 'x').x = scope.y;
+    scope.y = false;
+    scope.x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
         let vn2 = h('span', p2, c2);
@@ -2085,12 +2083,11 @@ exports[`t-if t-set, then t-if 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'title').title = 'test';
+    scope.title = 'test';
     if (scope.title) {
         if (scope.title != null) {
             c1.push({text: scope.title});
@@ -2104,13 +2101,12 @@ exports[`t-if t-set, then t-if, part 2 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'y').y = true;
-    utils.getScope(scope, 'x').x = scope.y;
+    scope.y = true;
+    scope.x = scope.y;
     if (scope.x) {
         let c2 = [], p2 = {key:2};
         let vn2 = h('span', p2, c2);
@@ -2804,12 +2800,11 @@ exports[`t-set evaluate value expression 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'value').value = 1+2;
+    scope.value = 1+2;
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2821,12 +2816,11 @@ exports[`t-set evaluate value expression, part 2 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'value').value = scope['somevariable']+2;
+    scope.value = scope['somevariable']+2;
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2838,12 +2832,11 @@ exports[`t-set set from attribute literal 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'value').value = 'ok';
+    scope.value = 'ok';
     if (scope.value != null) {
         c1.push({text: scope.value});
     }
@@ -2855,12 +2848,11 @@ exports[`t-set set from attribute lookup 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'stuff').stuff = scope['value'];
+    scope.stuff = scope['value'];
     if (scope.stuff != null) {
         c1.push({text: scope.stuff});
     }
@@ -2921,7 +2913,6 @@ exports[`t-set set from empty body 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
@@ -2937,12 +2928,11 @@ exports[`t-set t-set and t-if 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v').v = scope['value'];
+    scope.v = scope['value'];
     if (scope.v==='ok') {
         c1.push({text: \`grimbergen\`});
     }
@@ -2959,7 +2949,7 @@ exports[`t-set t-set body is evaluated immediately 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v1').v1 = 'before';
+    scope.v1 = 'before';
     let c2 = new utils.VDomArray();
     let c3 = [], p3 = {key:3};
     let vn3 = h('span', p3, c3);
@@ -2968,7 +2958,7 @@ exports[`t-set t-set body is evaluated immediately 1`] = `
         c3.push({text: scope.v1});
     }
     scope.v2 = c2
-    utils.getScope(scope, 'v1').v1 = 'after';
+    scope.v1 = 'after';
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -2981,12 +2971,11 @@ exports[`t-set t-set evaluates an expression only once 1`] = `
 "function anonymous(context, extra
 ) {
     // Template name: \\"test\\"
-    let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v').v = scope['value']+' artois';
+    scope.v = scope['value']+' artois';
     if (scope.v != null) {
         c1.push({text: scope.v});
     }
@@ -3006,7 +2995,7 @@ exports[`t-set t-set should reuse variable if possible 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v').v = 1;
+    scope.v = 1;
     let _2 = scope['list'];
     if (!_2) { throw new Error('QWeb error: Invalid loop expression')}
     let _3 = _4 = _2;
@@ -3077,9 +3066,9 @@ exports[`t-set t-set with t-value (falsy) and body 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v3').v3 = false;
-    utils.getScope(scope, 'v1').v1 = 'before';
-    utils.getScope(scope, 'v2').v2 = scope.v3;
+    scope.v3 = false;
+    scope.v1 = 'before';
+    scope.v2 = scope.v3;
     if (!(scope.v2)) {
         let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
@@ -3090,8 +3079,8 @@ exports[`t-set t-set with t-value (falsy) and body 1`] = `
         }
         scope.v2 = c2
     }
-    utils.getScope(scope, 'v1').v1 = 'after';
-    utils.getScope(scope, 'v3').v3 = true;
+    scope.v1 = 'after';
+    scope.v3 = true;
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -3109,9 +3098,9 @@ exports[`t-set t-set with t-value (truthy) and body 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'v3').v3 = 'Truthy';
-    utils.getScope(scope, 'v1').v1 = 'before';
-    utils.getScope(scope, 'v2').v2 = scope.v3;
+    scope.v3 = 'Truthy';
+    scope.v1 = 'before';
+    scope.v2 = scope.v3;
     if (!(scope.v2)) {
         let c2 = new utils.VDomArray();
         let c3 = [], p3 = {key:3};
@@ -3122,8 +3111,8 @@ exports[`t-set t-set with t-value (truthy) and body 1`] = `
         }
         scope.v2 = c2
     }
-    utils.getScope(scope, 'v1').v1 = 'after';
-    utils.getScope(scope, 'v3').v3 = false;
+    scope.v1 = 'after';
+    scope.v3 = false;
     if (scope.v2 != null) {
         const vnodeArray = scope.v2 instanceof utils.VDomArray ? scope.v2 : utils.htmlToVDOM(scope.v2);
         c1.push(...vnodeArray);
@@ -3147,7 +3136,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 1`] = `
         scope.ourvar = c2
     }
     else {
-        utils.getScope(scope, 'ourvar').ourvar = 0;
+        scope.ourvar = 0;
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
@@ -3175,7 +3164,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 2`] = `
         scope.ourvar = c2
     }
     else {
-        utils.getScope(scope, 'ourvar').ourvar = 0;
+        scope.ourvar = 0;
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
@@ -3198,7 +3187,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        utils.getScope(scope, 'ourvar').ourvar = 1;
+        scope.ourvar = 1;
     }
     else {
         let c2 = new utils.VDomArray();
@@ -3226,7 +3215,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 2`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        utils.getScope(scope, 'ourvar').ourvar = 1;
+        scope.ourvar = 1;
     }
     else {
         let c2 = new utils.VDomArray();
@@ -3253,7 +3242,7 @@ exports[`t-set value priority 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    utils.getScope(scope, 'value').value = 1;
+    scope.value = 1;
     if (!(scope.value)) {
         let c2 = new utils.VDomArray();
         c2.push({text: \`2\`});

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -775,12 +775,12 @@ exports[`misc global 1`] = `
         }
         {
             let _origScope10 = scope;
-            scope = Object.create(scope);
+            scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 {
                     let _origScope13 = scope;
-                    scope = Object.create(scope);
+                    scope = Object.assign(Object.create(context), scope);
                     {
                         let c__0 = [];
                         utils.getScope(scope, 'foo').foo = 'aaa';
@@ -1101,7 +1101,7 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
     let vn1 = h('div', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
@@ -1149,7 +1149,7 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope12 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c13 = [], p13 = {key:13};
@@ -1239,7 +1239,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope11 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             utils.getScope(scope, 'node').node = scope['root'];
@@ -1290,7 +1290,7 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
         let key1 = i1;
         {
             let _origScope9 = scope;
-            scope = Object.create(scope);
+            scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 utils.getScope(scope, 'node').node = scope['subtree'];
@@ -1316,7 +1316,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope11 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             utils.getScope(scope, 'node').node = scope['root'];
@@ -1367,7 +1367,7 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
         let key1 = i1;
         {
             let _origScope9 = scope;
-            scope = Object.create(scope);
+            scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 utils.getScope(scope, 'node').node = scope['subtree'];
@@ -1393,7 +1393,7 @@ exports[`t-call (template calling scoped parameters 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope2 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             utils.getScope(scope, 'foo').foo = 42;
@@ -1468,7 +1468,7 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         utils.getScope(scope, 'val').val = scope['v'].val;
         {
             let _origScope8 = scope;
-            scope = Object.create(scope);
+            scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 utils.getScope(scope, 'val3').val3 = scope.val*3;
@@ -1515,7 +1515,7 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     else if (scope.v1==='elif') {
         {
             let _origScope5 = scope;
-            scope = Object.create(scope);
+            scope = Object.assign(Object.create(context), scope);
             {
                 let c__0 = [];
                 utils.getScope(scope, 'v').v = 'success';
@@ -1553,7 +1553,7 @@ exports[`t-call (template calling with unused body 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             c__0.push({text: \`WHEEE\`});
@@ -1578,7 +1578,7 @@ exports[`t-call (template calling with unused setbody 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             utils.getScope(scope, 'qux').qux = 3;
@@ -1603,7 +1603,7 @@ exports[`t-call (template calling with used body 1`] = `
     let h = this.h;
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             c__0.push({text: \`ok\`});
@@ -1629,7 +1629,7 @@ exports[`t-call (template calling with used set body 1`] = `
     let vn1 = h('span', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             utils.getScope(scope, 'foo').foo = 'ok';
@@ -1790,7 +1790,7 @@ exports[`t-esc t-esc is escaped 1`] = `
     scope.var = c2
     if (scope.var != null) {
         let _origScope4 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.var = scope.var instanceof utils.VDomArray ? utils.vDomToString(scope.var) : scope.var;
         c1.push({text: scope.var});
         scope = _origScope4;
@@ -1826,7 +1826,7 @@ exports[`t-esc t-esc=0 is escaped 1`] = `
     let vn1 = h('div', p1, c1);
     {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         {
             let c__0 = [];
             let c4 = [], p4 = {key:4};
@@ -2881,7 +2881,7 @@ exports[`t-set set from body literal 1`] = `
     scope.value = c1
     if (scope.value != null) {
         let _origScope2 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
         let vn3 = {text: scope.value};
         result = vn3
@@ -2908,7 +2908,7 @@ exports[`t-set set from body lookup 1`] = `
     scope.stuff = c2
     if (scope.stuff != null) {
         let _origScope4 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.stuff = scope.stuff instanceof utils.VDomArray ? utils.vDomToString(scope.stuff) : scope.stuff;
         c1.push({text: scope.stuff});
         scope = _origScope4;
@@ -3059,7 +3059,7 @@ exports[`t-set t-set with content and sub t-esc 1`] = `
     scope.setvar = c2
     if (scope.setvar != null) {
         let _origScope4 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.setvar = scope.setvar instanceof utils.VDomArray ? utils.vDomToString(scope.setvar) : scope.setvar;
         c1.push({text: scope.setvar});
         scope = _origScope4;
@@ -3151,7 +3151,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 1`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3179,7 +3179,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 1 2`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3207,7 +3207,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 1`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3235,7 +3235,7 @@ exports[`t-set t-set, t-if, and mix of expression/body lookup, 2 2`] = `
     }
     if (scope.ourvar != null) {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.ourvar = scope.ourvar instanceof utils.VDomArray ? utils.vDomToString(scope.ourvar) : scope.ourvar;
         c1.push({text: scope.ourvar});
         scope = _origScope3;
@@ -3261,7 +3261,7 @@ exports[`t-set value priority 1`] = `
     }
     if (scope.value != null) {
         let _origScope3 = scope;
-        scope = Object.create(scope);
+        scope = Object.assign(Object.create(context), scope);
         scope.value = scope.value instanceof utils.VDomArray ? utils.vDomToString(scope.value) : scope.value;
         c1.push({text: scope.value});
         scope = _origScope3;

--- a/tests/router/__snapshots__/link.test.ts.snap
+++ b/tests/router/__snapshots__/link.test.ts.snap
@@ -11,11 +11,11 @@ exports[`Link component can render simple cases 1`] = `
     let _5 = scope['href'];
     let c6 = [], p6 = {key:6,attrs:{href: _5},class:_4,on:{}};
     let vn6 = h('a', p6, c6);
-    extra.handlers['click__8__'] = extra.handlers['click__8__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
-    p6.on['click'] = extra.handlers['click__8__'];
-    const slot9 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot9) {
-        slot9.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c6, parent: extra.parent || context}));
+    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
+    p6.on['click'] = extra.handlers['click__7__'];
+    const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot8) {
+        slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c6, parent: extra.parent || context}));
     }
     return vn6;
 }"

--- a/tests/router/__snapshots__/link.test.ts.snap
+++ b/tests/router/__snapshots__/link.test.ts.snap
@@ -11,11 +11,11 @@ exports[`Link component can render simple cases 1`] = `
     let _5 = scope['href'];
     let c6 = [], p6 = {key:6,attrs:{href: _5},class:_4,on:{}};
     let vn6 = h('a', p6, c6);
-    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
-    p6.on['click'] = extra.handlers['click__7__'];
-    const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot8) {
-        slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c6, parent: extra.parent || context}));
+    extra.handlers['click__8__'] = extra.handlers['click__8__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
+    p6.on['click'] = extra.handlers['click__8__'];
+    const slot9 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot9) {
+        slot9.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c6, parent: extra.parent || context}));
     }
     return vn6;
 }"


### PR DESCRIPTION
In a template, have t-set t-value outside a t-foreach
in the t-foreach, alter that variable by resetting it (as for a incrementation variable)

Before this commit, when printing the variable when the loop had finished
its value was the one set in the first place

After this commit, the value becomes the one altered by the loop iterations