### PR TITLE
[IMP] reserving __target key to return the target of Observer's proxy

### DIFF
--- a/src/core/observer.ts
+++ b/src/core/observer.ts
@@ -43,6 +43,7 @@ export class Observer {
 
     const proxy = new Proxy(value, {
       get(target, k) {
+        if (k === '__target') return target;
         const targetValue = target[k];
         return self.observe(targetValue, value);
       },


### PR DESCRIPTION
The return of useState is basically a Proxy returned by observe method of
Observer instance. I'm not fully sure but there might be instances that
we want the real object consumed by useState. If for example we want to
compare the state's original obj to another obj that might actually be
the same to the original, then perhaps having access to the original obj
can be important. We can actually skip shallow or deep compares here as
we know that the returning obj is just the original obj.

With this commit, I'm suggesting to reserve the `__target` key such that
if accessed thru the state, it returns the original obj consumed by
useState.

Sample usage:

--in the constructor--
`this.state = useState(this.props.originalObj);`

--somewhere inside one of component's methods --
`const originalObj = this.state.__target`