### PR TITLE
[FIX] qweb: ignore comment nodes between t-if/t-elif/t-else

### DIFF
--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -328,10 +328,11 @@ export class QWeb extends EventBus {
         ) {
           throw new Error("Only one conditional branching directive is allowed per node");
         }
-        // All text nodes between branch nodes are removed
+        // All text (with only spaces) and comment nodes (nodeType 8) between
+        // branch nodes are removed
         let textNode;
         while ((textNode = node.previousSibling) !== prevElem) {
-          if (textNode.nodeValue.trim().length) {
+          if (textNode.nodeValue.trim().length && textNode.nodeType !== 8) {
             throw new Error("text is not allowed between branching directives");
           }
           textNode.remove();

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -987,6 +987,30 @@ exports[`static templates properly handle comments 1`] = `
 }"
 `;
 
+exports[`static templates properly handle comments between t-if/t-else 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"test\\"
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    if (true) {
+        let c2 = [], p2 = {key:2};
+        let vn2 = h('span', p2, c2);
+        c1.push(vn2);
+        c2.push({text: \`true\`});
+    }
+    else {
+        let c3 = [], p3 = {key:3};
+        let vn3 = h('span', p3, c3);
+        c1.push(vn3);
+        c3.push({text: \`owl\`});
+    }
+    return vn1;
+}"
+`;
+
 exports[`static templates simple dynamic value 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -65,6 +65,19 @@ describe("static templates", () => {
     qweb.addTemplate("test", "<div>hello <!-- comment-->owl</div>");
     expect(renderToString(qweb, "test")).toBe("<div>hello <!-- comment-->owl</div>");
   });
+
+  test("properly handle comments between t-if/t-else", () => {
+    qweb.addTemplate(
+      "test",
+      `
+      <div>
+        <span t-if="true">true</span>
+        <!-- comment-->
+        <span t-else="">owl</span>
+      </div>`
+    );
+    expect(renderToString(qweb, "test")).toBe("<div><span>true</span></div>");
+  });
 });
 
 describe("error handling", () => {


### PR DESCRIPTION
closes #636