### PR TITLE
[IMP] allow anonymous Component extensions

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -604,9 +604,10 @@ export class Component<Props extends {} = any, T extends Env = Env> {
       // key. So we fall back on looking for a template matching its name (or
       // one of its subclass).
 
-      let template: string;
-      while ((template = p.name) && !(template in qweb.templates) && p !== Component) {
+      let template: string = p.name;
+      while (!(template in qweb.templates) && p !== Component) {
         p = p.__proto__;
+        template = p.name;
       }
       if (p === Component) {
         throw new Error(`Could not find template for component "${this.constructor.name}"`);

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -3080,6 +3080,15 @@ describe("can deduce template from name", () => {
     expect(fixture.innerHTML).toBe("<span>Orval</span>");
   });
 
+  test("can find template of anonymous component", async () => {
+    class ABC extends Component {}
+    const Anonymous = class extends ABC {};
+    env.qweb.addTemplate("ABC", "<span>Orval</span>");
+    const def = new Anonymous();
+    await def.mount(fixture);
+    expect(fixture.innerHTML).toBe("<span>Orval</span>");
+  });
+
   test("can find template of parent component, defined by template key", async () => {
     class ABC extends Component {
       static template = "Achel";


### PR DESCRIPTION
It is possible that a Component is extended dynamically and if this is
the case, the class that extends it can be anonymous, with property
name=''. If this is the case, current implementation interprets the empty
string to be false so the while loop is terminated without further
scanning the super classes.

In this proposal, we allow anonymous class to be scanned until its
Component ancestor. Basically, the anonymous class assumes the name of
it super.