### PR TITLE
[FIX] hooks: order of brackets for multiple async hooks

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -70,7 +70,7 @@ function makeAsyncHook(method: string) {
     if (component.__owl__[method]) {
       const current = component.__owl__[method];
       component.__owl__[method] = function(...args) {
-        return Promise.all[(current.call(component, ...args), cb.call(component, ...args))];
+        return Promise.all([current.call(component, ...args), cb.call(component, ...args)]);
       };
     } else {
       component.__owl__[method] = cb;


### PR DESCRIPTION
If the brackets are not corrected, the 'onWillStart' and 'onWillUpdateProps' don't work if given with async functions. 