### PR TITLE
[IMP] hooks: improve useRef typings

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -94,12 +94,12 @@ export const onWillUpdateProps = makeAsyncHook("willUpdatePropsCB");
  * The purpose of this hook is to allow components to get a reference to a sub
  * html node or component.
  */
-interface Ref {
+interface Ref<C extends Component = Component> {
   el: HTMLElement | null;
-  comp: Component | null;
+  comp: C | null;
 }
 
-export function useRef(name: string): Ref {
+export function useRef<C extends Component = Component>(name: string): Ref<C> {
   const __owl__ = Component.current!.__owl__;
   return {
     get el(): HTMLElement | null {
@@ -111,9 +111,9 @@ export function useRef(name: string): Ref {
       }
       return null;
     },
-    get comp(): Component | null {
+    get comp(): C | null {
       const val = __owl__.refs && __owl__.refs[name];
-      return val instanceof Component ? val : null;
+      return val instanceof Component ? (val as C) : null;
     },
   };
 }

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -267,7 +267,7 @@ describe("hooks", () => {
     class WidgetC extends Component {
       static template = xml`<div class="outer-div">Hello<WidgetB t-ref="mywidgetb" /></div>`;
       static components = { WidgetB };
-      ref = useRef("mywidgetb");
+      ref = useRef<WidgetB>("mywidgetb");
     }
 
     const widget = new WidgetC();


### PR DESCRIPTION
With this commit, we can get the type for the target component for a
ref.

By default, if the generic type is not given, the ref will simply use
the base Component type.