### PR TITLE
[FIX] qweb: t-esc inside t-call using outside t-set

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -49,6 +49,7 @@ function compileValueNode(value: any, node: Element, qweb: QWeb, ctx: Compilatio
   if (ctx.escaping) {
     let protectID;
     if (value.hasBody) {
+      ctx.rootContext.shouldDefineUtils = true;
       protectID = ctx.startProtectScope();
       ctx.addLine(
         `${exprID} = ${exprID} instanceof utils.VDomArray ? utils.vDomToString(${exprID}) : ${exprID};`

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -1937,6 +1937,23 @@ exports[`t-esc literal 1`] = `
 }"
 `;
 
+exports[`t-esc t-esc inside t-call, with t-set outside 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"main\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let c2 = new utils.VDomArray();
+    c2.push({text: \`Hi\`});
+    scope.v = c2
+    this.subTemplates['sub'].call(this, Object.assign(Object.create(context), scope), Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    return vn1;
+}"
+`;
+
 exports[`t-esc t-esc is escaped 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -207,6 +207,13 @@ describe("t-esc", () => {
     const result = renderToString(qweb, "test", { state: { list: [1, 2] } });
     expect(result).toBe("<span>1,2</span>");
   });
+
+  test("t-esc inside t-call, with t-set outside", () => {
+    qweb.addTemplate("main", `<div><t t-set="v">Hi</t><t t-call="sub"/></div>`);
+    qweb.addTemplate("sub", `<span t-esc="v"/>`);
+    const result = renderToString(qweb, "main");
+    expect(result).toBe("<div><span>Hi</span></div>");
+  });
 });
 
 describe("t-raw", () => {


### PR DESCRIPTION
Before this commit, the generated code was incorrect, and crashed,
when there was a t-esc="abc" in a subtemplate, with t-set="abc"
done outside the subtemplate, with syntax <t t-set="abc">value</t>.