### PR TITLE
[FIX] qweb: support of svg in t-raw

### DIFF
--- a/src/vdom/html_to_vdom.ts
+++ b/src/vdom/html_to_vdom.ts
@@ -1,4 +1,4 @@
-import { VNode, h } from "./vdom";
+import { VNode, h, addNS } from "./vdom";
 
 const parser = new DOMParser();
 
@@ -23,5 +23,9 @@ function htmlToVNode(node: ChildNode): VNode {
   for (let c of node.childNodes) {
     children.push(htmlToVNode(c));
   }
-  return h((node as Element).tagName, { attrs }, children);
+  const vnode = h((node as Element).tagName, { attrs }, children);
+  if (vnode.sel === "svg") {
+    addNS(vnode.data, (vnode as any).children, vnode.sel);
+  }
+  return vnode;
 }

--- a/tests/vdom.test.ts
+++ b/tests/vdom.test.ts
@@ -1105,4 +1105,11 @@ describe("html to vdom", function () {
     elm = patch(vnode0, nodeList[0]).elm;
     expect(elm.outerHTML).toEqual(`<span a="1" b="2">abc<div>1</div></span>`);
   });
+
+  test("svg", function () {
+      const nodeList = htmlToVDOM(`<svg></svg>`);
+      expect(nodeList).toHaveLength(1);
+      elm = patch(vnode0, nodeList[0]).elm;
+      expect(elm).toBeInstanceOf(SVGSVGElement);
+  });
 });


### PR DESCRIPTION
Before this commit, t-raw a string containing `<svg>` did not display
the svg element. This was because of missing namespace in vnode's data.

Now, `vdom.addNS` is called to add the svg namespace when necessary.