### PR TITLE
[DOC] props validation: The validation type should be a String object.

### DIFF
--- a/doc/reference/props_validation.md
+++ b/doc/reference/props_validation.md
@@ -30,7 +30,7 @@ class ComponentB extends owl.Component {
     count: {type: Number},
     messages: {
       type: Array,
-      element: {type: Object, shape: {id: Boolean, text: 'string' }
+      element: {type: Object, shape: {id: Boolean, text: String }
     },
    date: Date,
    combinedVal: [Number, Boolean]


### PR DESCRIPTION
The validation type should be a String object.