### PR TITLE
[FIX] test: timing issue

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -8,12 +8,6 @@ import "../src/qweb/extensions";
 import "../src/component/directive";
 import { browser } from "../src/browser";
 
-// modifies scheduler to make it faster to test components
-scheduler.requestAnimationFrame = function (callback: FrameRequestCallback) {
-  setTimeout(callback, 1);
-  return 1;
-};
-
 // Some static cleanup
 let nextSlotId;
 let slots;
@@ -43,9 +37,8 @@ export function nextMicroTick(): Promise<void> {
 }
 
 export async function nextTick(): Promise<void> {
-  return new Promise(function (resolve) {
-    setTimeout(() => scheduler.requestAnimationFrame(() => resolve()));
-  });
+  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
+  await new Promise((resolve) => setTimeout(resolve));
 }
 
 export function makeTestFixture() {


### PR DESCRIPTION
Before this commit, we artificially replaced in the tests the
requestAnimationFrame by a setTimeout, to actually increase the speed of
the tests.  However, this is not really a true replacement.  For
example, a real setTimeout can come before or after a real
nextAnimationFrame, depending on when/where it is requested.

Also, this change exposed another problem: the nextTick function did a
setTimeout before a nextanimationframe. This is not a problem when
nextAnimationFrame is replaced by a setTimeout, because then all
expectations holds in owl.  However, it is wrong: to get to the next
animation frame, we need to request an animation frame, and THEN wait
with a setTimeout.

closes #729