### PR TITLE
[FIX] component: properly validate multiple props

### DIFF
--- a/src/component/props_validation.ts
+++ b/src/component/props_validation.ts
@@ -37,7 +37,7 @@ QWeb.utils.validateProps = function (Widget, props: Object) {
         if (propsDef[propName] && !propsDef[propName].optional) {
           throw new Error(`Missing props '${propName}' (component '${Widget.name}')`);
         } else {
-          break;
+          continue;
         }
       }
       let isValid;

--- a/tests/component/props_validation.test.ts
+++ b/tests/component/props_validation.test.ts
@@ -786,6 +786,31 @@ describe("props validation", () => {
     await nextTick();
     expect(fixture.innerHTML).toBe("<div><div>4</div></div>");
   });
+
+  test("mix of optional and mandatory", async () => {
+    class Child extends Component {
+      static props = {
+        optional: { type: String, optional: true },
+        mandatory: Number,
+      };
+      static template = xml` <div><t t-esc="props.mandatory"/></div>`;
+    }
+
+    class App extends Component {
+      static components = { Child };
+      static template = xml`<div><Child/></div>`;
+    }
+
+    const w = new App(undefined, {});
+    let error;
+    try {
+      await w.mount(fixture);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toBe("Missing props 'mandatory' (component 'Child')");
+  });
 });
 
 describe("default props", () => {


### PR DESCRIPTION
Because of a "break" statement instead of "continue", the check for valid
props was stopping as soon as it met an optional props, which kind of
invalidate the whole system.

closes #717