### PR TITLE
[FIX] qweb: allow t-call on arbitrary html nodes

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -223,9 +223,6 @@ QWeb.addDirective({
     // ------------------------------------------------
     ctx.rootContext.shouldDefineScope = true;
     ctx.rootContext.shouldDefineUtils = true;
-    if (node.nodeName !== "t") {
-      throw new Error("Invalid tag for t-call directive (should be 't')");
-    }
     const subTemplate = node.getAttribute("t-call")!;
     const nodeTemplate = qweb.templates[subTemplate];
     if (!nodeTemplate) {

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -517,10 +517,17 @@ export class QWeb extends EventBus {
       return;
     }
 
+    if (node.tagName !== "t" && node.hasAttribute("t-call")) {
+      const tCallNode = document.createElement("t");
+      tCallNode.setAttribute("t-call", node.getAttribute("t-call")!);
+      node.removeAttribute("t-call");
+      node.prepend(tCallNode);
+    }
+
     const firstLetter = node.tagName[0];
     if (firstLetter === firstLetter.toUpperCase()) {
       // this is a component, we modify in place the xml document to change
-      // <SomeComponent ... /> to <t t-component="SomeComponent" ... />
+      // <SomeComponent ... /> to <SomeComponent t-component="SomeComponent" ... />
       node.setAttribute("t-component", node.tagName);
     } else if (node.tagName !== "t" && node.hasAttribute("t-component")) {
       throw new Error(

--- a/tests/component/slots.test.ts
+++ b/tests/component/slots.test.ts
@@ -929,4 +929,62 @@ describe("t-slot directive", () => {
     expect(fixture.innerHTML).toBe("<div><span>dash</span></div>");
     expect(env.qweb.templates[Dialog.template].fn.toString()).toMatchSnapshot();
   });
+
+  test("slot and t-esc", async () => {
+    class Dialog extends Component {
+      static template = xml`<span><t t-slot="default"/></span>`;
+    }
+    class Parent extends Component {
+      static template = xml`<div><Dialog><t t-esc="'toph'"/></Dialog></div>`;
+      static components = { Dialog };
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><span>toph</span></div>");
+  });
+
+  test("slot and (inline) t-esc", async () => {
+    class Dialog extends Component {
+      static template = xml`<span><t t-slot="default"/></span>`;
+    }
+    class Parent extends Component {
+      static template = xml`<div><Dialog t-esc="'toph'"/></div>`;
+      static components = { Dialog };
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><span>toph</span></div>");
+  });
+
+  test("slot and t-call", async () => {
+    env.qweb.addTemplate("sokka", "<p>sokka</p>");
+    class Dialog extends Component {
+      static template = xml`<span><t t-slot="default"/></span>`;
+    }
+    class Parent extends Component {
+      static template = xml`<div><Dialog><t t-call="sokka"/></Dialog></div>`;
+      static components = { Dialog };
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><span><p>sokka</p></span></div>");
+  });
+
+  test("slot and (inline) t-call", async () => {
+    env.qweb.addTemplate("sokka", "<p>sokka</p>");
+    class Dialog extends Component {
+      static template = xml`<span><t t-slot="default"/></span>`;
+    }
+    class Parent extends Component {
+      static template = xml`<div><Dialog t-call="sokka"/></div>`;
+      static components = { Dialog };
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><span><p>sokka</p></span></div>");
+  });
 });

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -1732,6 +1732,24 @@ exports[`t-call (template calling scoped parameters 1`] = `
 }"
 `;
 
+exports[`t-call (template calling t-call allowed on a non t node 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"caller\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let _origScope3 = scope;
+    scope = Object.create(scope);
+    scope.__access_mode__ = 'ro';
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
+    scope = _origScope3;
+    return vn1;
+}"
+`;
+
 exports[`t-call (template calling t-call with t-if 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -766,10 +766,11 @@ describe("t-call (template calling", () => {
     expect(qweb.subTemplates["sub"]).toBeTruthy();
   });
 
-  test("t-call not allowed on a non t node", () => {
-    qweb.addTemplate("_basic-callee", "<t>ok</t>");
+  test("t-call allowed on a non t node", () => {
+    qweb.addTemplate("_basic-callee", "<span>ok</span>");
     qweb.addTemplate("caller", '<div t-call="_basic-callee"/>');
-    expect(() => renderToString(qweb, "caller")).toThrow("Invalid tag");
+    const expected = "<div><span>ok</span></div>";
+    expect(renderToString(qweb, "caller")).toBe(expected);
   });
 
   test("with unused body", () => {


### PR DESCRIPTION
This is a rarely (if ever) used feature, but according to our qweb
reference implementation, it is possible to use the
t-call directive on an arbitrary html tag, like this:

<div t-call="my.template"/>

It is then interpreted as:

<div><t t-call="my.template"/></div>

So, with this commit, we make sure that the owl qweb implementation
matches that behaviour.

closes #706