### PR TITLE
One playground to rule them all

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^23.6.0",
     "jest-environment-jsdom": "^24.7.1",
     "live-server": "^1.2.1",
+    "monaco-editor": "^0.21.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
     "rollup": "^1.6.0",

--- a/tools/playground/app.js
+++ b/tools/playground/app.js
@@ -206,8 +206,13 @@ class Editor extends owl.Component {
         currentExtension: 'js', 
         js: this.props.js,
         css: this.props.css,
-        xml: this.props.xml
+        xml: this.props.xml,
+        
     })
+
+    jsModel =  null;
+    cssModel =  null;
+    xmlModel =  null;
 
     editor = null;
 
@@ -216,6 +221,11 @@ class Editor extends owl.Component {
         this.state.js = nextProps.js;
         this.state.css = nextProps.css;
         this.state.xml = nextProps.xml;
+        
+        this.jsModel = null;
+        this.cssModel = null;
+        this.xmlModel = null;
+
         this._openFile(this.state.currentExtension, false) 
     }
 
@@ -230,24 +240,69 @@ class Editor extends owl.Component {
 
     _openFile(extension, save = true) {
         if (save) this._saveCodeState();
+
         this.state.currentExtension = extension;
-        let language = 'javascript';
-        switch (extension) {
-            case 'xml':
-                language = 'xml';
-                break;
-            case 'css':
-                language = 'css';
-                break;
+        let language = null;
+        let model = null;
+
+        if (extension === 'js') {
+            console.log("here")
+
+            if (this.jsModel) {
+                model = this.jsModel;
+            }
+
+            else {
+                language = 'javascript'
+            }
         }
 
-        const model = monaco.editor.createModel(
-            this.state[this.state.currentExtension],
-            language,
-            null
-        )
+        if (extension === 'xml') {
+
+            if (this.xmlModel) {
+                model = this.xmlModel;
+            }
+
+            else {
+                language = 'xml'
+            }
+        }
+
+        if (extension === 'css') {
+
+            if (this.cssModel) {
+                model = this.cssModel;
+            }
+
+            else {
+                language = 'css'
+            }
+        }
+
+        console.log(model)
+
+        if (!model) {
+            model = monaco.editor.createModel(
+                this.state[this.state.currentExtension],
+                language,
+                null
+            )
+
+            if (extension === 'js') {
+                this.jsModel = model;
+            }
+    
+            if (extension === 'xml') {
+               this.xmlModel = model;
+            }
+    
+            if (extension === 'css') {
+                this.cssModel = model;
+            }
+        }
 
         this.editor.setModel(model)
+
     }
 
     mounted() {

--- a/tools/playground/app.js
+++ b/tools/playground/app.js
@@ -1,4 +1,4 @@
-import { SAMPLES } from "./samples.js";
+import { SAMPLES as samples }  from "./samples.js" ;
 const { useState, useRef, onMounted, onWillUnmount } = owl.hooks;
 //------------------------------------------------------------------------------
 // Constants, helpers, utils
@@ -6,18 +6,18 @@ const { useState, useRef, onMounted, onWillUnmount } = owl.hooks;
 let owlJS;
 
 async function owlSourceCode() {
-  if (owlJS) {
+    if (owlJS) {
+        return owlJS;
+    }
+    const result = await fetch("../owl.js");
+    owlJS = await result.text();
     return owlJS;
-  }
-  const result = await fetch("../owl.js");
-  owlJS = await result.text();
-  return owlJS;
 }
 
 const MODES = {
-  js: "ace/mode/javascript",
-  css: "ace/mode/css",
-  xml: "ace/mode/xml"
+    js: "ace/mode/javascript",
+    css: "ace/mode/css",
+    xml: "ace/mode/xml"
 };
 
 const DEFAULT_XML = `<templates>
@@ -71,22 +71,23 @@ if __name__ == "__main__":
  * Make an iframe, with all the js, css and xml properly injected.
  */
 function makeCodeIframe(js, css, xml) {
-  const sanitizedXML = xml.replace(/<!--[\s\S]*?-->/g, "");
+    const sanitizedXML = xml.replace(/<!--[\s\S]*?-->/g, "");
 
 
-  // create iframe
-  const iframe = document.createElement("iframe");
+    // create iframe
+    const iframe = document.createElement("iframe");
+    iframe.className += "h-full w-full";
 
-  iframe.onload = () => {
-    const doc = iframe.contentDocument;
-    // inject js
-    const owlScript = doc.createElement("script");
-    owlScript.type = "text/javascript";
-    owlScript.src = "../owl.js";
-    owlScript.addEventListener("load", () => {
-      const script = doc.createElement("script");
-      script.type = "text/javascript";
-      const content = `
+    iframe.onload = () => {
+        const doc = iframe.contentDocument;
+        // inject js
+        const owlScript = doc.createElement("script");
+        owlScript.type = "text/javascript";
+        owlScript.src = "../owl.js";
+        owlScript.addEventListener("load", () => {
+            const script = doc.createElement("script");
+            script.type = "text/javascript";
+            const content = `
         {
           owl.config.mode = 'dev';
           let templates = \`${sanitizedXML}\`;
@@ -94,32 +95,32 @@ function makeCodeIframe(js, css, xml) {
           owl.Component.env = { qweb };
         }
         ${js}`;
-      script.innerHTML = content;
-      doc.body.appendChild(script);
-    });
-    doc.head.appendChild(owlScript);
+            script.innerHTML = content;
+            doc.body.appendChild(script);
+        });
+        doc.head.appendChild(owlScript);
 
-    // inject css
-    const style = document.createElement("style");
-    style.innerHTML = css;
-    doc.head.appendChild(style);
-  };
-  return iframe;
+        // inject css
+        const style = document.createElement("style");
+        style.innerHTML = css;
+        doc.head.appendChild(style);
+    };
+    return iframe;
 }
 
 /**
  * Make a zip file containing a functioning application
  */
 async function makeApp(js, css, xml) {
-  await owl.utils.loadJS("libs/jszip.min.js");
+    await owl.utils.loadJS("libs/jszip.min.js");
 
-  const zip = new JSZip();
-  const processedJS = js
-    .split("\n")
-    .map(l => (l === "" ? "" : "  " + l))
-    .join("\n");
+    const zip = new JSZip();
+    const processedJS = js
+        .split("\n")
+        .map(l => (l === "" ? "" : "  " + l))
+        .join("\n");
 
-  const JS = `
+    const JS = `
 /**
  * This is the javascript code defined in the playground.
  * In a larger application, this code should probably be moved in different
@@ -150,278 +151,193 @@ async function start() {
 start();
 `;
 
-  zip.file("app.js", JS);
-  zip.file("app.css", css);
-  zip.file("app.py", APP_PY);
-  zip.file("app.xml", xml);
-  zip.file("index.html", DEFAULT_HTML);
-  zip.file("owl.js", owlSourceCode());
-  return zip.generateAsync({ type: "blob" });
+    zip.file("app.js", JS);
+    zip.file("app.css", css);
+    zip.file("app.py", APP_PY);
+    zip.file("app.xml", xml);
+    zip.file("index.html", DEFAULT_HTML);
+    zip.file("owl.js", owlSourceCode());
+    return zip.generateAsync({ type: "blob" });
 }
 
 //------------------------------------------------------------------------------
 // SAMPLES
 //------------------------------------------------------------------------------
 function loadSamples() {
-  let result = SAMPLES.slice();
-  const localSample = localStorage.getItem("owl-playground-local-sample");
-  if (localSample) {
-    const { js, css, xml } = JSON.parse(localSample);
-    result.unshift({
-      description: "Local Storage Code",
-      code: js,
-      xml,
-      css
-    });
-  }
-  return result;
+    let result = samples.slice();
+    const localSample = localStorage.getItem("owl-playground-local-sample");
+    if (localSample) {
+        const { js, css, xml } = JSON.parse(localSample);
+        result.unshift({
+            description: "Local Storage Code",
+            code: js,
+            xml,
+            css
+        });
+    }
+    return result;
 }
 
 function saveLocalSample(js, css, xml) {
-  const str = JSON.stringify({ js, css, xml });
-  localStorage.setItem("owl-playground-local-sample", str);
+    const str = JSON.stringify({ js, css, xml });
+    localStorage.setItem("owl-playground-local-sample", str);
 }
 
 function deleteLocalSample() {
-  localStorage.removeItem("owl-playground-local-sample");
+    localStorage.removeItem("owl-playground-local-sample");
 }
 
 function useSamples() {
-  const samples = loadSamples();
-  const component = owl.Component.current;
-  let interval;
-
-  onMounted(() => {
-    const state = component.state;
-    interval = setInterval(() => {
-      if (component.isDirty) {
-        saveLocalSample(state.js, state.css, state.xml);
-      }
-    }, 1000);
-  });
-  onWillUnmount(() => {
-    clearInterval(interval);
-  });
-  return samples;
-}
-//------------------------------------------------------------------------------
-// Tabbed editor
-//------------------------------------------------------------------------------
-class TabbedEditor extends owl.Component {
-  constructor(parent, props) {
-    super(parent, props);
-    this.state = useState({
-      currentTab: props.js !== false ? "js" : props.xml ? "xml" : "css"
-    });
-    this.setTab = owl.utils.debounce(this.setTab, 250, true);
-
-    this.sessions = {};
-    this._setupSessions(props);
-    this.editorNode = useRef("editor");
-    this._updateCode = this._updateCode.bind(this);
-  }
-
-  mounted() {
-    this.editor = this.editor || ace.edit(this.editorNode.el);
-
-    this.editor.setValue(this.props[this.state.currentTab], -1);
-    this.editor.setFontSize("12px");
-    this.editor.setTheme("ace/theme/monokai");
-    this.editor.setSession(this.sessions[this.state.currentTab]);
-    const tabSize = this.state.currentTab === "xml" ? 2 : 4;
-    this.editor.session.setOption("tabSize", tabSize);
-    this.editor.on("blur", this._updateCode);
-    this.interval = setInterval(this._updateCode, 3000);
-  }
-
-  willUnmount() {
-    clearInterval(this.interval);
-    this.editor.off("blur", this._updateCode);
-  }
-  willUpdateProps(nextProps) {
-    this._setupSessions(nextProps);
-  }
-
-  patched() {
-    const session = this.sessions[this.state.currentTab];
-    let content = this.props[this.state.currentTab];
-    if (content === false) {
-      const tab = this.props.js !== false ? "js" : this.props.xml ? "xml" : "css";
-      content = this.props[tab];
-      this.state.currentTab = tab;
-    }
-    if (this.editor.getValue() !== content) {
-      session.setValue(content, -1);
-      this.editor.setSession(session);
-      this.editor.resize();
-    }
-  }
-
-  setTab(tab) {
-    if (this.state.currentTab !== tab) {
-      this.state.currentTab = tab;
-      const session = this.sessions[this.state.currentTab];
-      session.doc.setValue(this.props[tab], -1);
-      this.editor.setSession(session);
-    }
-  }
-
-  onMouseDown(ev) {
-    if (ev.target.tagName === "DIV") {
-      let y = ev.clientY;
-      const resizer = ev => {
-        const delta = ev.clientY - y;
-        y = ev.clientY;
-        this.trigger("updatePanelHeight", { delta });
-      };
-      document.body.addEventListener("mousemove", resizer);
-      document.body.addEventListener("mouseup", () => {
-        document.body.removeEventListener("mousemove", resizer);
-      });
-    }
-  }
-
-  _setupSessions(props) {
-    for (let tab of ["js", "xml", "css"]) {
-      if (props[tab] !== false && !this.sessions[tab]) {
-        this.sessions[tab] = new ace.EditSession(props[tab], MODES[tab]);
-        this.sessions[tab].setOption("useWorker", false);
-        const tabSize = tab === "xml" ? 2 : 4;
-        this.sessions[tab].setOption("tabSize", tabSize);
-        this.sessions[tab].setUndoManager(new ace.UndoManager());
-      }
-    }
-  }
-
-  _updateCode() {
-    const editorValue = this.editor.getValue();
-    const propsValue = this.props[this.state.currentTab];
-    if (editorValue !== propsValue) {
-      this.trigger("updateCode", {
-        type: this.state.currentTab,
-        value: editorValue
-      });
-    }
-  }
+    return loadSamples();
 }
 
 //------------------------------------------------------------------------------
 // MAIN APP
 //------------------------------------------------------------------------------
-class App extends owl.Component {
-  constructor(...args) {
-    super(...args);
-    this.version = owl.__info__.version;
-    this.SAMPLES = useSamples();
-    this.isDirty = false;
 
-    this.state = useState({
-      js: this.SAMPLES[0].code,
-      css: this.SAMPLES[0].css || "",
-      xml: this.SAMPLES[0].xml || DEFAULT_XML,
-      displayWelcome: true,
-      splitLayout: true,
-      leftPaneWidth: Math.ceil(window.innerWidth / 2),
-      topPanelHeight: null
-    });
-
-    this.toggleLayout = owl.utils.debounce(this.toggleLayout, 250, true);
-    this.runCode = owl.utils.debounce(this.runCode, 250, true);
-    this.downloadCode = owl.utils.debounce(this.downloadCode, 250, true);
-    this.content = useRef("content");
-  }
-
-  runCode() {
-    this.content.el.innerHTML = "";
-    this.state.displayWelcome = false;
-
-    const { js, css, xml } = this.state;
-    const subiframe = makeCodeIframe(js, css, xml);
-    this.content.el.appendChild(subiframe);
-  }
-
-  setSample(ev) {
-    const sample = this.SAMPLES.find(s => s.description === ev.target.value);
-    this.state.js = sample.code;
-    this.state.css = sample.css || "";
-    this.state.xml = sample.xml || DEFAULT_XML;
-    deleteLocalSample();
-    this.isDirty = false;
-  }
-
-  get leftPaneStyle() {
-    return `width:${this.state.leftPaneWidth}px`;
-  }
-
-  get rightPaneStyle() {
-    return `width:${window.innerWidth - 6 - this.state.leftPaneWidth}px`;
-  }
-
-  get topEditorStyle() {
-    return `flex: 0 0 ${this.state.topPanelHeight}px`;
-  }
-
-  onMouseDown() {
-    const resizer = ev => {
-      this.state.leftPaneWidth = ev.clientX;
-    };
-
-    document.body.addEventListener("mousemove", resizer);
-    for (let iframe of document.getElementsByTagName("iframe")) {
-      iframe.classList.add("disabled");
-    }
-
-    document.body.addEventListener("mouseup", () => {
-      document.body.removeEventListener("mousemove", resizer);
-      for (let iframe of document.getElementsByTagName("iframe")) {
-        iframe.classList.remove("disabled");
-      }
-    });
-  }
-  updateCode(ev) {
-    if (this.state[ev.detail.type] !== ev.detail.value) {
-      this.state[ev.detail.type] = ev.detail.value;
-      this.isDirty = true;
-    }
-  }
-  toggleLayout() {
-    this.state.splitLayout = !this.state.splitLayout;
-  }
-  updatePanelHeight(ev) {
-    if (!ev.detail.delta) {
-      return;
-    }
-    let height = this.state.topPanelHeight;
-    if (!height) {
-      height = document.getElementsByClassName("tabbed-editor")[0].clientHeight;
-    }
-    this.state.topPanelHeight = height + ev.detail.delta;
-  }
-
-  async downloadCode() {
-    const { js, css, xml } = this.state;
-    const content = await makeApp(js, css, xml);
-    await owl.utils.loadJS("libs/FileSaver.min.js");
-    saveAs(content, "app.zip");
-  }
+class Tab extends owl.Component {
 }
-App.components = { TabbedEditor };
+
+class Editor extends owl.Component {
+
+    static props = ['js', 'xml', 'css']
+
+    state = useState({ 
+        currentExtension: 'js', 
+        js: this.props.js,
+        css: this.props.css,
+        xml: this.props.xml
+    })
+
+    editor = null;
+
+    willUpdateProps(nextProps) {
+        console.log(nextProps);
+        this.state.js = nextProps.js;
+        this.state.css = nextProps.css;
+        this.state.xml = nextProps.xml;
+        this._openFile(this.state.currentExtension, false) 
+    }
+
+    _run(ev) {
+        this._saveCodeState();
+        this.trigger('run-project', {
+            js: this.state.js,
+            xml: this.state.xml,
+            css: this.state.css
+        })
+    }
+
+    _openFile(extension, save = true) {
+        if (save) this._saveCodeState();
+        this.state.currentExtension = extension;
+        let language = 'javascript';
+        switch (extension) {
+            case 'xml':
+                language = 'xml';
+                break;
+            case 'css':
+                language = 'css';
+                break;
+        }
+
+        const model = monaco.editor.createModel(
+            this.state[this.state.currentExtension],
+            language,
+            null
+        )
+
+        this.editor.setModel(model)
+    }
+
+    mounted() {
+        this.editor = monaco.editor.create(document.getElementById('container'), {
+            value: this.state[this.state.currentExtension],
+            language: 'javascript',
+            automaticLayout: true,
+            minimap: {
+                enabled: false
+            }
+        });
+    }
+
+    _saveCodeState() {
+        this.state[this.state.currentExtension] = this.editor.getValue();
+    }
+
+    _openCSS(ev) {
+        this._openFile('css')
+    }
+
+    _openXML(ev) {
+        this._openFile('xml')
+    }
+
+    _openJS(ev) {
+        this._openFile('js')
+    }
+
+}
+
+Editor.components = { Tab }
+
+
+class App extends owl.Component {
+
+    samples = [];
+
+    constructor(...args) {
+        super(...args);
+        this.version = owl.__info__.version;
+        this.samples = useSamples();
+
+        this.state = useState({ 
+            js: this.samples[0].code,
+            css: this.samples[0].css || "",
+            xml: this.samples[0].xml || DEFAULT_XML,
+        });
+
+        this.runCode = owl.utils.debounce(this.runCode, 250, true);
+        this.downloadCode = owl.utils.debounce(this.downloadCode, 250, true);
+        this.content = useRef("iframe-container");
+    }
+
+
+    _run(ev) {
+        this.content.el.innerHTML = "";
+        const { js, css, xml } = ev.detail;
+        const subiframe = makeCodeIframe(js, css, xml);
+        this.content.el.appendChild(subiframe);
+    }
+
+    _setSample(ev) {
+        const sample = this.samples.find(s => s.description === ev.target.value);
+        this.state.js = sample.code;
+        this.state.css = sample.css || "";
+        this.state.xml = sample.xml || DEFAULT_XML;
+        deleteLocalSample();
+    }
+
+
+}
+
+App.components = { Editor }
 
 //------------------------------------------------------------------------------
 // Application initialization
 //------------------------------------------------------------------------------
 async function start() {
-  document.title = `${document.title} (v${owl.__info__.version})`;
-  const commit = `https://github.com/odoo/owl/commit/${owl.__info__.hash}`;
-  console.info(`This application is using Owl built with the following commit:`, commit);
-  const [templates] = await Promise.all([
-    owl.utils.loadFile("templates.xml"),
-    owl.utils.whenReady()
-  ]);
-  const qweb = new owl.QWeb({ templates });
-  owl.Component.env = { qweb };
-  const app = new App();
-  app.mount(document.body);
+    document.title = `${document.title} (v${owl.__info__.version})`;
+    const commit = `https://github.com/odoo/owl/commit/${owl.__info__.hash}`;
+    console.info(`This application is using Owl built with the following commit:`, commit);
+    const [templates] = await Promise.all([
+        owl.utils.loadFile("templates.xml"),
+        owl.utils.whenReady()
+    ]);
+    const qweb = new owl.QWeb({ templates });
+    owl.Component.env = { qweb };
+    const app = new App();
+    app.mount(document.body);
 }
 
 start();

--- a/tools/playground/index.html
+++ b/tools/playground/index.html
@@ -1,20 +1,26 @@
+
+
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>OWL Playground</title>
-    <link rel="icon" href="data:,">
-
-    <script src="libs/ace.js" type="text/javascript" charset="utf-8"></script>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+		<link
+			rel="stylesheet"
+			data-name="vs/editor/editor.main"
+			href="../../node_modules/monaco-editor/min/vs/editor/editor.main.css"
+    />
     <script src="../owl.js"></script>
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/solid.css" integrity="sha384-QokYePQSOwpBDuhlHOsX0ymF6R/vLk/UQVz3WHa6wygxI5oGTmDTv8wahFOSspdm" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/fontawesome.css" integrity="sha384-vd1e11sR28tEK9YANUtpIOdjGW14pS87bUBuOIoBILVWLFnS+MCX9T6MMf0VdPGq" crossorigin="anonymous">
-
-    <!-- Application JS/CSS -->
-    <link rel="stylesheet" href="playground.css">
     <script type="module" src="app.js"></script>
+    <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+	</head>
+	<body class="h-screen bg-gray-200">
 
-  </head>
-  <body>
-  </body>
+		<script>
+			var require = { paths: { vs: '../../node_modules/monaco-editor/min/vs' } };
+		</script>
+		<script src="../../node_modules/monaco-editor/min/vs/loader.js"></script>
+		<script src="../../node_modules/monaco-editor/min/vs/editor/editor.main.nls.js"></script>
+        <script src="../../node_modules/monaco-editor/min/vs/editor/editor.main.js"></script>
+
+	</body>
 </html>

--- a/tools/playground/old_app.js
+++ b/tools/playground/old_app.js
@@ -1,0 +1,427 @@
+import { SAMPLES } from "./samples.js";
+const { useState, useRef, onMounted, onWillUnmount } = owl.hooks;
+//------------------------------------------------------------------------------
+// Constants, helpers, utils
+//------------------------------------------------------------------------------
+let owlJS;
+
+async function owlSourceCode() {
+  if (owlJS) {
+    return owlJS;
+  }
+  const result = await fetch("../owl.js");
+  owlJS = await result.text();
+  return owlJS;
+}
+
+const MODES = {
+  js: "ace/mode/javascript",
+  css: "ace/mode/css",
+  xml: "ace/mode/xml"
+};
+
+const DEFAULT_XML = `<templates>
+</templates>`;
+
+const DEFAULT_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>OWL App</title>
+    <link rel="icon" href="data:,">
+
+    <script src="owl.js"></script>
+    <link rel="stylesheet" href="app.css">
+    <script src="app.js"></script>
+  </head>
+  <body>
+  </body>
+</html>
+`;
+
+const APP_PY = `#!/usr/bin/env python3
+
+import threading
+import time
+
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+def start_server():
+    SimpleHTTPRequestHandler.extensions_map['.js'] = 'application/javascript'
+    httpd = HTTPServer(('0.0.0.0', 3600), SimpleHTTPRequestHandler)
+    httpd.serve_forever()
+
+url = 'http://127.0.0.1:3600'
+
+if __name__ == "__main__":
+    print("Owl Application")
+    print("---------------")
+    print("Server running on: {}".format(url))
+    threading.Thread(target=start_server, daemon=True).start()
+
+    while True:
+        try:
+            time.sleep(1)
+        except KeyboardInterrupt:
+            httpd.server_close()
+            quit(0)
+`;
+
+/**
+ * Make an iframe, with all the js, css and xml properly injected.
+ */
+function makeCodeIframe(js, css, xml) {
+  const sanitizedXML = xml.replace(/<!--[\s\S]*?-->/g, "");
+
+
+  // create iframe
+  const iframe = document.createElement("iframe");
+
+  iframe.onload = () => {
+    const doc = iframe.contentDocument;
+    // inject js
+    const owlScript = doc.createElement("script");
+    owlScript.type = "text/javascript";
+    owlScript.src = "../owl.js";
+    owlScript.addEventListener("load", () => {
+      const script = doc.createElement("script");
+      script.type = "text/javascript";
+      const content = `
+        {
+          owl.config.mode = 'dev';
+          let templates = \`${sanitizedXML}\`;
+          const qweb = new owl.QWeb({ templates });
+          owl.Component.env = { qweb };
+        }
+        ${js}`;
+      script.innerHTML = content;
+      doc.body.appendChild(script);
+    });
+    doc.head.appendChild(owlScript);
+
+    // inject css
+    const style = document.createElement("style");
+    style.innerHTML = css;
+    doc.head.appendChild(style);
+  };
+  return iframe;
+}
+
+/**
+ * Make a zip file containing a functioning application
+ */
+async function makeApp(js, css, xml) {
+  await owl.utils.loadJS("libs/jszip.min.js");
+
+  const zip = new JSZip();
+  const processedJS = js
+    .split("\n")
+    .map(l => (l === "" ? "" : "  " + l))
+    .join("\n");
+
+  const JS = `
+/**
+ * This is the javascript code defined in the playground.
+ * In a larger application, this code should probably be moved in different
+ * sub files.
+ */
+function app() {
+${processedJS}
+}
+
+/**
+ * Initialization code
+ * This code load templates, and make sure everything is properly connected.
+ */
+async function start() {
+  let templates;
+  try {
+    templates = await owl.utils.loadFile('app.xml');
+  } catch(e) {
+    console.error(\`This app requires a static server.  If you have python installed, try 'python app.py'\`);
+    return;
+  }
+  const env = { qweb: new owl.QWeb({templates})};
+  owl.Component.env = env;
+  await owl.utils.whenReady();
+  app();
+}
+
+start();
+`;
+
+  zip.file("app.js", JS);
+  zip.file("app.css", css);
+  zip.file("app.py", APP_PY);
+  zip.file("app.xml", xml);
+  zip.file("index.html", DEFAULT_HTML);
+  zip.file("owl.js", owlSourceCode());
+  return zip.generateAsync({ type: "blob" });
+}
+
+//------------------------------------------------------------------------------
+// SAMPLES
+//------------------------------------------------------------------------------
+function loadSamples() {
+  let result = SAMPLES.slice();
+  const localSample = localStorage.getItem("owl-playground-local-sample");
+  if (localSample) {
+    const { js, css, xml } = JSON.parse(localSample);
+    result.unshift({
+      description: "Local Storage Code",
+      code: js,
+      xml,
+      css
+    });
+  }
+  return result;
+}
+
+function saveLocalSample(js, css, xml) {
+  const str = JSON.stringify({ js, css, xml });
+  localStorage.setItem("owl-playground-local-sample", str);
+}
+
+function deleteLocalSample() {
+  localStorage.removeItem("owl-playground-local-sample");
+}
+
+function useSamples() {
+  const samples = loadSamples();
+  const component = owl.Component.current;
+  let interval;
+
+  onMounted(() => {
+    const state = component.state;
+    interval = setInterval(() => {
+      if (component.isDirty) {
+        saveLocalSample(state.js, state.css, state.xml);
+      }
+    }, 1000);
+  });
+  onWillUnmount(() => {
+    clearInterval(interval);
+  });
+  return samples;
+}
+//------------------------------------------------------------------------------
+// Tabbed editor
+//------------------------------------------------------------------------------
+class TabbedEditor extends owl.Component {
+  constructor(parent, props) {
+    super(parent, props);
+    this.state = useState({
+      currentTab: props.js !== false ? "js" : props.xml ? "xml" : "css"
+    });
+    this.setTab = owl.utils.debounce(this.setTab, 250, true);
+
+    this.sessions = {};
+    this._setupSessions(props);
+    this.editorNode = useRef("editor");
+    this._updateCode = this._updateCode.bind(this);
+  }
+
+  mounted() {
+    this.editor = this.editor || ace.edit(this.editorNode.el);
+
+    this.editor.setValue(this.props[this.state.currentTab], -1);
+    this.editor.setFontSize("12px");
+    this.editor.setTheme("ace/theme/monokai");
+    this.editor.setSession(this.sessions[this.state.currentTab]);
+    const tabSize = this.state.currentTab === "xml" ? 2 : 4;
+    this.editor.session.setOption("tabSize", tabSize);
+    this.editor.on("blur", this._updateCode);
+    this.interval = setInterval(this._updateCode, 3000);
+  }
+
+  willUnmount() {
+    clearInterval(this.interval);
+    this.editor.off("blur", this._updateCode);
+  }
+  willUpdateProps(nextProps) {
+    this._setupSessions(nextProps);
+  }
+
+  patched() {
+    const session = this.sessions[this.state.currentTab];
+    let content = this.props[this.state.currentTab];
+    if (content === false) {
+      const tab = this.props.js !== false ? "js" : this.props.xml ? "xml" : "css";
+      content = this.props[tab];
+      this.state.currentTab = tab;
+    }
+    if (this.editor.getValue() !== content) {
+      session.setValue(content, -1);
+      this.editor.setSession(session);
+      this.editor.resize();
+    }
+  }
+
+  setTab(tab) {
+    if (this.state.currentTab !== tab) {
+      this.state.currentTab = tab;
+      const session = this.sessions[this.state.currentTab];
+      session.doc.setValue(this.props[tab], -1);
+      this.editor.setSession(session);
+    }
+  }
+
+  onMouseDown(ev) {
+    if (ev.target.tagName === "DIV") {
+      let y = ev.clientY;
+      const resizer = ev => {
+        const delta = ev.clientY - y;
+        y = ev.clientY;
+        this.trigger("updatePanelHeight", { delta });
+      };
+      document.body.addEventListener("mousemove", resizer);
+      document.body.addEventListener("mouseup", () => {
+        document.body.removeEventListener("mousemove", resizer);
+      });
+    }
+  }
+
+  _setupSessions(props) {
+    for (let tab of ["js", "xml", "css"]) {
+      if (props[tab] !== false && !this.sessions[tab]) {
+        this.sessions[tab] = new ace.EditSession(props[tab], MODES[tab]);
+        this.sessions[tab].setOption("useWorker", false);
+        const tabSize = tab === "xml" ? 2 : 4;
+        this.sessions[tab].setOption("tabSize", tabSize);
+        this.sessions[tab].setUndoManager(new ace.UndoManager());
+      }
+    }
+  }
+
+  _updateCode() {
+    const editorValue = this.editor.getValue();
+    const propsValue = this.props[this.state.currentTab];
+    if (editorValue !== propsValue) {
+      this.trigger("updateCode", {
+        type: this.state.currentTab,
+        value: editorValue
+      });
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// MAIN APP
+//------------------------------------------------------------------------------
+class App extends owl.Component {
+  constructor(...args) {
+    super(...args);
+    this.version = owl.__info__.version;
+    this.SAMPLES = useSamples();
+    this.isDirty = false;
+
+    this.state = useState({
+      js: this.SAMPLES[0].code,
+      css: this.SAMPLES[0].css || "",
+      xml: this.SAMPLES[0].xml || DEFAULT_XML,
+      displayWelcome: true,
+      splitLayout: true,
+      leftPaneWidth: Math.ceil(window.innerWidth / 2),
+      topPanelHeight: null
+    });
+
+    this.toggleLayout = owl.utils.debounce(this.toggleLayout, 250, true);
+    this.runCode = owl.utils.debounce(this.runCode, 250, true);
+    this.downloadCode = owl.utils.debounce(this.downloadCode, 250, true);
+    this.content = useRef("content");
+  }
+
+  runCode() {
+    this.content.el.innerHTML = "";
+    this.state.displayWelcome = false;
+
+    const { js, css, xml } = this.state;
+    const subiframe = makeCodeIframe(js, css, xml);
+    this.content.el.appendChild(subiframe);
+  }
+
+  setSample(ev) {
+    const sample = this.SAMPLES.find(s => s.description === ev.target.value);
+    this.state.js = sample.code;
+    this.state.css = sample.css || "";
+    this.state.xml = sample.xml || DEFAULT_XML;
+    deleteLocalSample();
+    this.isDirty = false;
+  }
+
+  get leftPaneStyle() {
+    return `width:${this.state.leftPaneWidth}px`;
+  }
+
+  get rightPaneStyle() {
+    return `width:${window.innerWidth - 6 - this.state.leftPaneWidth}px`;
+  }
+
+  get topEditorStyle() {
+    return `flex: 0 0 ${this.state.topPanelHeight}px`;
+  }
+
+  onMouseDown() {
+    const resizer = ev => {
+      this.state.leftPaneWidth = ev.clientX;
+    };
+
+    document.body.addEventListener("mousemove", resizer);
+    for (let iframe of document.getElementsByTagName("iframe")) {
+      iframe.classList.add("disabled");
+    }
+
+    document.body.addEventListener("mouseup", () => {
+      document.body.removeEventListener("mousemove", resizer);
+      for (let iframe of document.getElementsByTagName("iframe")) {
+        iframe.classList.remove("disabled");
+      }
+    });
+  }
+  updateCode(ev) {
+    if (this.state[ev.detail.type] !== ev.detail.value) {
+      this.state[ev.detail.type] = ev.detail.value;
+      this.isDirty = true;
+    }
+  }
+  toggleLayout() {
+    this.state.splitLayout = !this.state.splitLayout;
+  }
+  updatePanelHeight(ev) {
+    if (!ev.detail.delta) {
+      return;
+    }
+    let height = this.state.topPanelHeight;
+    if (!height) {
+      height = document.getElementsByClassName("tabbed-editor")[0].clientHeight;
+    }
+    this.state.topPanelHeight = height + ev.detail.delta;
+  }
+
+  async downloadCode() {
+    const { js, css, xml } = this.state;
+    const content = await makeApp(js, css, xml);
+    await owl.utils.loadJS("libs/FileSaver.min.js");
+    saveAs(content, "app.zip");
+  }
+}
+App.components = { TabbedEditor };
+
+//------------------------------------------------------------------------------
+// Application initialization
+//------------------------------------------------------------------------------
+async function start() {
+  document.title = `${document.title} (v${owl.__info__.version})`;
+  const commit = `https://github.com/odoo/owl/commit/${owl.__info__.hash}`;
+  console.info(`This application is using Owl built with the following commit:`, commit);
+  const [templates] = await Promise.all([
+    owl.utils.loadFile("templates.xml"),
+    owl.utils.whenReady()
+  ]);
+  const qweb = new owl.QWeb({ templates });
+  owl.Component.env = { qweb };
+  const app = new App();
+  app.mount(document.body);
+}
+
+start();

--- a/tools/playground/old_index.html
+++ b/tools/playground/old_index.html
@@ -1,0 +1,21 @@
+<!---->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>OWL Playground</title>
+    <link rel="icon" href="data:,">
+
+    <script src="libs/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="../owl.js"></script>
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/solid.css" integrity="sha384-QokYePQSOwpBDuhlHOsX0ymF6R/vLk/UQVz3WHa6wygxI5oGTmDTv8wahFOSspdm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/fontawesome.css" integrity="sha384-vd1e11sR28tEK9YANUtpIOdjGW14pS87bUBuOIoBILVWLFnS+MCX9T6MMf0VdPGq" crossorigin="anonymous">
+
+    <!-- Application JS/CSS -->
+    <link rel="stylesheet" href="playground.css">
+    <script type="module" src="app.js"></script>
+
+  </head>
+  <body>
+  </body>
+</html>

--- a/tools/playground/old_templates.xml
+++ b/tools/playground/old_templates.xml
@@ -1,0 +1,57 @@
+<templates>
+  <div t-name="TabbedEditor" class="tabbed-editor">
+    <div class="tabBar" t-att-class="{resizeable: props.resizeable}" t-on-mousedown="onMouseDown">
+        <t t-foreach="['js', 'xml', 'css']" t-as="tab">
+            <a t-ref="{{tab}}" t-if="props[tab] !== false" t-key="tab" class="tab flash" t-att-class="{active: state.currentTab===tab}" t-on-click="setTab(tab)">
+                <t t-esc="tab"/>
+            </a>
+        </t>
+    </div>
+    <div class="code-editor" t-ref="editor"></div>
+  </div>
+
+  <div t-name="App" class="playground">
+      <div class="left-bar" t-att-class="{split: state.splitLayout}"
+           t-att-style="leftPaneStyle"
+           t-on-updateCode="updateCode">
+        <div class="menubar">
+          <a class="btn run-code flash" t-on-click="runCode" title="Execute this Code">▶ Run</a>
+          <select t-on-change="setSample">
+            <option t-foreach="SAMPLES" t-as="sample" t-key="sample_index">
+              <t t-esc="sample.description"/>
+            </option>
+          </select>
+          <a class="btn flash" t-on-click="downloadCode" title="Download a Zip with this Code"><i class="fas fa-download"></i></a>
+          <a class="layout-selector flash" t-on-click="toggleLayout" title="Toggle Layout"><i class="fas"  t-att-class="state.splitLayout ?  'fa-toggle-on' : 'fa-toggle-off'"></i></a>
+        </div>
+        <TabbedEditor
+            js="state.js"
+            css="!state.splitLayout and state.css"
+            xml="!state.splitLayout and state.xml"
+            t-att-style="topEditorStyle"/>
+        <t t-if="state.splitLayout">
+          <div class="separator horizontal"/>
+          <TabbedEditor
+             js="false"
+             css="state.css"
+             xml="state.xml"
+             resizeable="true"
+             t-on-updatePanelHeight="updatePanelHeight"/>
+        </t>
+      </div>
+      <div class="separator vertical" t-on-mousedown="onMouseDown"/>
+      <div class="right-pane"  t-att-style="rightPaneStyle">
+        <div class="welcome" t-if="state.displayWelcome">
+          <div>🦉 Odoo Web Library 🦉</div>
+          <div>v<t t-esc="version"/></div>
+          <div class="url"><a href="https://github.com/odoo/owl">https://github.com/odoo/owl</a></div>
+          <div class="note">
+            <p>Note: these examples are using recent features of Javascript, and require a recent browser to work without a transpilation step!
+              For example, it makes use of class fields and class static fields. These examples should work in a recent Chrome version.
+            </p>
+          </div>
+        </div>
+        <div class="content" t-ref="content"/>
+      </div>
+  </div>
+</templates>

--- a/tools/playground/templates.xml
+++ b/tools/playground/templates.xml
@@ -1,57 +1,79 @@
 <templates>
-  <div t-name="TabbedEditor" class="tabbed-editor">
-    <div class="tabBar" t-att-class="{resizeable: props.resizeable}" t-on-mousedown="onMouseDown">
-        <t t-foreach="['js', 'xml', 'css']" t-as="tab">
-            <a t-ref="{{tab}}" t-if="props[tab] !== false" t-key="tab" class="tab flash" t-att-class="{active: state.currentTab===tab}" t-on-click="setTab(tab)">
-                <t t-esc="tab"/>
-            </a>
-        </t>
-    </div>
-    <div class="code-editor" t-ref="editor"></div>
-  </div>
 
-  <div t-name="App" class="playground">
-      <div class="left-bar" t-att-class="{split: state.splitLayout}"
-           t-att-style="leftPaneStyle"
-           t-on-updateCode="updateCode">
-        <div class="menubar">
-          <a class="btn run-code flash" t-on-click="runCode" title="Execute this Code">▶ Run</a>
-          <select t-on-change="setSample">
-            <option t-foreach="SAMPLES" t-as="sample" t-key="sample_index">
-              <t t-esc="sample.description"/>
-            </option>
-          </select>
-          <a class="btn flash" t-on-click="downloadCode" title="Download a Zip with this Code"><i class="fas fa-download"></i></a>
-          <a class="layout-selector flash" t-on-click="toggleLayout" title="Toggle Layout"><i class="fas"  t-att-class="state.splitLayout ?  'fa-toggle-on' : 'fa-toggle-off'"></i></a>
+    <div t-name="App" t-on-run-project="_run" class="h-full flex">
+
+        <Editor js="state.js" xml="state.xml" css="state.css" />
+
+
+        <div class="flex flex-col w-1/2 h-full">
+
+            <div class="bg-purple-300 mx-2 my-1 p-2 rounded-sm" style="background-color: #865A7B">
+                <div class="flex items-center">
+                    <div class="relative">
+                        <select t-on-change="_setSample" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-1 px-2 pr-8 rounded-sm leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+                            <t t-foreach="samples" t-as="sample" t-key="sample_index">
+                                <option>
+                                    <t t-esc="sample.description"/>
+                                </option>
+                            </t>
+                        </select>
+                        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+                            <svg class="fill-current h-4 w-4"
+                                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <div t-ref="iframe-container" class="bg-white flex-grow m-2 rounded-sm shadow"></div>
         </div>
-        <TabbedEditor
-            js="state.js"
-            css="!state.splitLayout and state.css"
-            xml="!state.splitLayout and state.xml"
-            t-att-style="topEditorStyle"/>
-        <t t-if="state.splitLayout">
-          <div class="separator horizontal"/>
-          <TabbedEditor
-             js="false"
-             css="state.css"
-             xml="state.xml"
-             resizeable="true"
-             t-on-updatePanelHeight="updatePanelHeight"/>
-        </t>
-      </div>
-      <div class="separator vertical" t-on-mousedown="onMouseDown"/>
-      <div class="right-pane"  t-att-style="rightPaneStyle">
-        <div class="welcome" t-if="state.displayWelcome">
-          <div>🦉 Odoo Web Library 🦉</div>
-          <div>v<t t-esc="version"/></div>
-          <div class="url"><a href="https://github.com/odoo/owl">https://github.com/odoo/owl</a></div>
-          <div class="note">
-            <p>Note: these examples are using recent features of Javascript, and require a recent browser to work without a transpilation step!
-              For example, it makes use of class fields and class static fields. These examples should work in a recent Chrome version.
-            </p>
-          </div>
+
+
+    </div>
+
+    <t t-name="Editor" t-on-open-file="_openFile">
+        <div class="resize-x w-1/2">
+
+            <div class="flex justify-between items-center" style="background-color: #865A7B">
+                <ul class="flex justify-start">
+                    <li>
+                        <Tab t-on-click="_openXML">
+                            xml
+                        </Tab>
+                    </li>
+                    <li>
+                        <Tab t-on-click="_openJS">
+                            js
+                        </Tab>
+                    </li>
+                    <li>
+                        <Tab t-on-click="_openCSS">
+                            css
+                        </Tab>
+                    </li>
+                </ul>
+                <ul class="flex justify-end m-2">
+                    <li>
+                        <button class="h-6 w-6 bg-white rounded-full p-1 shadow" t-on-click="_run">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                        </button>
+                    </li>
+                </ul>
+            </div>
+
+            <div id="container" class="h-full"></div>
         </div>
-        <div class="content" t-ref="content"/>
-      </div>
-  </div>
+    </t>
+
+    <t t-name="Tab">
+        <button class="bg-white hover:bg-gray-300 uppercase rounded-sm px-2 shadow mx-1">
+            <t t-slot="default"/>
+        </button>
+    </t>
+
 </templates>


### PR DESCRIPTION
In an effort to improve the owl ecosystem, some work can be done to improve the playground. 
In a perfect world, it should be nice to use and could be shared. 

It is, in its current state, usable. Don't forget to npm install for the monaco editor. 

- [x] Switch to [monaco editor](https://microsoft.github.io/monaco-editor/index.html) 
- [ ] Tweak the settings to make it perfect
- [ ] See if we can give it better autocompletion (Like it would know @odoo/owl) 
- [ ] Move it to own repository and switch to typescript ? Only keep the resulting /dist to the owl repo.
- [ ] Add a backend (maybe firebase to avoid hosting our own ?)

Add old behavior back
- [ ] Make it resizable 
- [ ] Make it so we can see both xml and js at the same time
- [x] Ctrl z doesn't work if we switch from js / css / xml. We can probably fix this. 

- [ ] Clean the code nicely to make it easier to upgrade. 

Removed: 
Downloadable files