### PR TITLE
[IMP] component: allow using TypeScript type hints

### DIFF
--- a/doc/reference/event_handling.md
+++ b/doc/reference/event_handling.md
@@ -78,6 +78,19 @@ The `t-on` directive allows to prebind its arguments. For example,
 Here, `expr` is a valid Owl expression, so it could be `true` or some variable
 from the rendering context.
 
+### Type Hinting
+
+Note that if you work with Typescript, the `trigger` method is generic on the type of the payload.
+
+You can then describe the type of the event, so you will see typing errors...
+
+```typescript
+this.trigger<MyCustomPayload>('my-custom-event', payload);
+```
+```typescript
+myCustomEventHandler(ev: OwlEvent<MyCustomPayload>) { ... }
+```
+
 ## Inline Event Handlers
 
 One can also directly specify inline statements. For example,

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -433,8 +433,8 @@ export class Component<Props extends {} = any, T extends Env = Env> {
    * up to the parent DOM nodes. Thus, it must be called between mounted() and
    * willUnmount().
    */
-  trigger(eventType: string, payload?: any) {
-    this.__trigger(this, eventType, payload);
+  trigger<T=any>(eventType: string, payload?: T) {
+    this.__trigger<T>(this, eventType, payload);
   }
 
   //--------------------------------------------------------------------------
@@ -512,9 +512,9 @@ export class Component<Props extends {} = any, T extends Env = Env> {
    * Private trigger method, allows to choose the component which triggered
    * the event in the first place
    */
-  __trigger(component: Component, eventType: string, payload?: any) {
+  __trigger<T>(component: Component, eventType: string, payload?: T) {
     if (this.el) {
-      const ev = new OwlEvent(component, eventType, {
+      const ev = new OwlEvent<T>(component, eventType, {
         bubbles: true,
         cancelable: true,
         detail: payload,


### PR DESCRIPTION
Just to have nice and beautiful type hinting like that:
![image](https://user-images.githubusercontent.com/1159815/96242639-f934b900-0fa3-11eb-9f9c-2fa8c134e133.png)
