### PR TITLE
[REF] qweb: simplify _compile method arguments

### DIFF
--- a/doc/reference/qweb_templating_language.md
+++ b/doc/reference/qweb_templating_language.md
@@ -15,6 +15,7 @@
   - [Dynamic Attributes](#dynamic-attributes)
   - [Loops](#loops)
   - [Rendering Sub Templates](#rendering-sub-templates)
+  - [Dynamic Sub Templates](#dynamic-sub-templates)
   - [Translations](#translations)
   - [Debugging](#debugging)
 
@@ -508,6 +509,22 @@ This can be used to define variables scoped to a sub template:
 </t>
 <!-- "var" does not exist here -->
 ```
+
+### Dynamic sub templates
+
+The `t-call` directive can also be used to dynamically call a sub template,
+using string interpolation. For example:
+
+```xml
+<div t-name="main-template">
+    <t t-call="{{template}}">
+        <em>content</em>
+    </t>
+</div>
+```
+
+Here, the name of the template is obtained from the `template` value in the
+template rendering context.
 
 ### Translations
 

--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -446,7 +446,7 @@ QWeb.addDirective({
           slotNode.removeAttribute("t-set-slot");
           slotNode.parentElement!.removeChild(slotNode);
 
-          const slotFn = qweb._compile(`slot_${key}_template`, slotNode, ctx);
+          const slotFn = qweb._compile(`slot_${key}_template`, { elem: slotNode, hasParent: true });
           QWeb.slots[`${slotId}_${key}`] = slotFn;
         }
       }
@@ -455,7 +455,7 @@ QWeb.addDirective({
         for (let child of Object.values(clone.childNodes)) {
           t.appendChild(child);
         }
-        const slotFn = qweb._compile(`slot_default_template`, t, ctx);
+        const slotFn = qweb._compile(`slot_default_template`, { elem: t, hasParent: true });
         QWeb.slots[`${slotId}_default`] = slotFn;
       }
     }

--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -235,7 +235,7 @@ QWeb.addDirective({
     if (!subId) {
       subId = QWeb.nextId++;
       qweb.subTemplates[subTemplate] = subId;
-      const subTemplateFn = qweb._compile(subTemplate, nodeTemplate.elem, ctx, true);
+      const subTemplateFn = qweb._compile(subTemplate, { hasParent: true, defineKey: true });
       QWeb.subTemplates[subId] = subTemplateFn;
     }
 

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -312,7 +312,7 @@ export class QWeb extends EventBus {
     const template = {
       elem,
       fn: function (this: QWeb, context, extra) {
-        const compiledFunction = this._compile(name, elem);
+        const compiledFunction = this._compile(name);
         template.fn = compiledFunction;
         return compiledFunction.call(this, context, extra);
       },
@@ -417,30 +417,33 @@ export class QWeb extends EventBus {
 
   _compile(
     name: string,
-    elem: Element,
-    parentContext?: CompilationContext,
-    defineKey?: boolean
+    options: {
+      elem?: Element;
+      hasParent?: boolean;
+      defineKey?: boolean;
+    } = {}
   ): CompiledTemplate {
+    const elem = options.elem || this.templates[name].elem;
     const isDebug = elem.attributes.hasOwnProperty("t-debug");
     const ctx = new CompilationContext(name);
     if (elem.tagName !== "t") {
       ctx.shouldDefineResult = false;
     }
-    if (parentContext) {
-      ctx.variables = Object.create(parentContext.variables);
-      ctx.parentNode = parentContext.parentNode || ctx.generateID();
+    if (options.hasParent) {
+      ctx.variables = Object.create(null);
+      ctx.parentNode = ctx.generateID();
       ctx.allowMultipleRoots = true;
       ctx.hasParentWidget = true;
       ctx.shouldDefineResult = false;
       ctx.addLine(`let c${ctx.parentNode} = extra.parentNode;`);
-      if (defineKey) {
+      if (options.defineKey) {
         ctx.addLine(`let key0 = extra.key || "";`);
         ctx.hasKey0 = true;
       }
     }
     this._compileNode(elem, ctx);
 
-    if (!parentContext) {
+    if (!options.hasParent) {
       if (ctx.shouldDefineResult) {
         ctx.addLine(`return result;`);
       } else {

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -534,11 +534,11 @@ exports[`other directives with t-component slot setted value (with t-set) not ac
         w3.__owl__.pvnode = pvnode;
     }
     w3.__owl__.parentLastFiberId = extra.fiber.id;
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('p', p5, c5);
-    c1.push(vn5);
+    let c6 = [], p6 = {key:6};
+    let vn6 = h('p', p6, c6);
+    c1.push(vn6);
     if (scope.iter != null) {
-        c5.push({text: scope.iter});
+        c6.push({text: scope.iter});
     }
     return vn1;
 }"
@@ -1253,16 +1253,16 @@ exports[`other directives with t-component t-set can't alter from within callee 
     if (scope.iter != null) {
         c2.push({text: scope.iter});
     }
-    let _origScope4 = scope;
+    let _origScope6 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
-    scope = _origScope4;
-    let c6 = [], p6 = {key:6};
-    let vn6 = h('p', p6, c6);
-    c1.push(vn6);
+    this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__7__'}));
+    scope = _origScope6;
+    let c8 = [], p8 = {key:8};
+    let vn8 = h('p', p8, c8);
+    c1.push(vn8);
     if (scope.iter != null) {
-        c6.push({text: scope.iter});
+        c8.push({text: scope.iter});
     }
     return vn1;
 }"
@@ -1284,7 +1284,7 @@ exports[`other directives with t-component t-set can't alter in t-call body 1`] 
     if (scope.iter != null) {
         c2.push({text: scope.iter});
     }
-    let _origScope4 = scope;
+    let _origScope6 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -1293,14 +1293,14 @@ exports[`other directives with t-component t-set can't alter in t-call body 1`] 
             utils.getScope(scope, 'iter').iter = 'inCall';
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+        this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__7__'}));
     }
-    scope = _origScope4;
-    let c6 = [], p6 = {key:6};
-    let vn6 = h('p', p6, c6);
-    c1.push(vn6);
+    scope = _origScope6;
+    let c8 = [], p8 = {key:8};
+    let vn8 = h('p', p8, c8);
+    c1.push(vn8);
     if (scope.iter != null) {
-        c6.push({text: scope.iter});
+        c8.push({text: scope.iter});
     }
     return vn1;
 }"
@@ -1455,11 +1455,11 @@ exports[`random stuff/miscellaneous can inject values in tagged templates 1`] = 
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope4 = scope;
+    let _origScope5 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['3'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
-    scope = _origScope4;
+    this.constructor.subTemplates['3'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+    scope = _origScope5;
     return vn1;
 }"
 `;
@@ -1574,15 +1574,15 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
     // Template name: \\"sub\\"
     let utils = this.constructor.utils;
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c2 = [], p2 = {key:\`\${key0}_2\`,on:{}};
-    let vn2 = h('p', p2, c2);
-    c1.push(vn2);
-    let k3 = \`click__3__\${key0}__\`;
-    extra.handlers[k3] = extra.handlers[k3] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
-    p2.on['click'] = extra.handlers[k3];
-    c2.push({text: \`lucas\`});
+    let c3 = [], p3 = {key:\`\${key0}_3\`,on:{}};
+    let vn3 = h('p', p3, c3);
+    c2.push(vn3);
+    let k4 = \`click__4__\${key0}__\`;
+    extra.handlers[k4] = extra.handlers[k4] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](e);};
+    p3.on['click'] = extra.handlers[k4];
+    c3.push({text: \`lucas\`});
 }"
 `;
 
@@ -1593,14 +1593,14 @@ exports[`t-call handlers with arguments are properly bound through a t-call 1`] 
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c2 = [], p2 = {key:\`\${key0}_2\`,on:{}};
-    let vn2 = h('p', p2, c2);
-    c1.push(vn2);
-    let args3 = [scope['a']];
-    p2.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](...args3, e);};
-    c2.push({text: \`lucas\`});
+    let c3 = [], p3 = {key:\`\${key0}_3\`,on:{}};
+    let vn3 = h('p', p3, c3);
+    c2.push(vn3);
+    let args4 = [scope['a']];
+    p3.on['click'] = function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['update'](...args4, e);};
+    c3.push({text: \`lucas\`});
 }"
 `;
 
@@ -1613,32 +1613,32 @@ exports[`t-call parent is set within t-call 1`] = `
     let parent = extra.parent;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
     // Component 'Child'
-    let k3 = \`__3__\${key0}__\`;
-    let w2 = k3 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k3]] : false;
-    let props2 = {};
-    if (w2 && w2.__owl__.currentFiber && !w2.__owl__.vnode) {
-        w2.destroy();
-        w2 = false;
+    let k4 = \`__4__\${key0}__\`;
+    let w3 = k4 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k4]] : false;
+    let props3 = {};
+    if (w3 && w3.__owl__.currentFiber && !w3.__owl__.vnode) {
+        w3.destroy();
+        w3 = false;
     }
-    if (w2) {
-        w2.__updateProps(props2, extra.fiber, undefined);
-        let pvnode = w2.__owl__.pvnode;
-        c1.push(pvnode);
+    if (w3) {
+        w3.__updateProps(props3, extra.fiber, undefined);
+        let pvnode = w3.__owl__.pvnode;
+        c2.push(pvnode);
     } else {
-        let componentKey2 = \`Child\`;
-        let W2 = context.constructor.components[componentKey2] || QWeb.components[componentKey2]|| scope['Child'];
-        if (!W2) {throw new Error('Cannot find the definition of component \\"' + componentKey2 + '\\"')}
-        w2 = new W2(parent, props2);
-        parent.__owl__.cmap[k3] = w2.__owl__.id;
-        let fiber = w2.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
-        let pvnode = h('dummy', {key: k3, hook: {remove() {},destroy(vn) {w2.destroy();}}});
-        c1.push(pvnode);
-        w2.__owl__.pvnode = pvnode;
+        let componentKey3 = \`Child\`;
+        let W3 = context.constructor.components[componentKey3] || QWeb.components[componentKey3]|| scope['Child'];
+        if (!W3) {throw new Error('Cannot find the definition of component \\"' + componentKey3 + '\\"')}
+        w3 = new W3(parent, props3);
+        parent.__owl__.cmap[k4] = w3.__owl__.id;
+        let fiber = w3.__prepare(extra.fiber, undefined, () => { const vnode = fiber.vnode; pvnode.sel = vnode.sel; });
+        let pvnode = h('dummy', {key: k4, hook: {remove() {},destroy(vn) {w3.destroy();}}});
+        c2.push(pvnode);
+        w3.__owl__.pvnode = pvnode;
     }
-    w2.__owl__.parentLastFiberId = extra.fiber.id;
+    w3.__owl__.parentLastFiberId = extra.fiber.id;
 }"
 `;
 

--- a/tests/component/__snapshots__/slots.test.ts.snap
+++ b/tests/component/__snapshots__/slots.test.ts.snap
@@ -44,23 +44,23 @@ exports[`t-slot directive can define and call slots 2`] = `
 ) {
     // Template name: \\"Dialog\\"
     let h = this.h;
-    let c6 = [], p6 = {key:6};
-    let vn6 = h('div', p6, c6);
-    let c7 = [], p7 = {key:7};
-    let vn7 = h('div', p7, c7);
-    c6.push(vn7);
-    const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
-    if (slot8) {
-        slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || context}));
-    }
     let c9 = [], p9 = {key:9};
     let vn9 = h('div', p9, c9);
-    c6.push(vn9);
-    const slot10 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
-    if (slot10) {
-        slot10.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c9, parent: extra.parent || context}));
+    let c10 = [], p10 = {key:10};
+    let vn10 = h('div', p10, c10);
+    c9.push(vn10);
+    const slot11 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
+    if (slot11) {
+        slot11.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || context}));
     }
-    return vn6;
+    let c12 = [], p12 = {key:12};
+    let vn12 = h('div', p12, c12);
+    c9.push(vn12);
+    const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
+    if (slot13) {
+        slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
+    }
+    return vn9;
 }"
 `;
 
@@ -69,11 +69,11 @@ exports[`t-slot directive can define and call slots 3`] = `
 ) {
     // Template name: \\"slot_header_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c1.push(vn4);
-    c4.push({text: \`header\`});
+    let c4 = extra.parentNode;
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c4.push(vn5);
+    c5.push({text: \`header\`});
 }"
 `;
 
@@ -82,11 +82,11 @@ exports[`t-slot directive can define and call slots 4`] = `
 ) {
     // Template name: \\"slot_footer_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`footer\`});
+    let c6 = extra.parentNode;
+    let c7 = [], p7 = {key:7};
+    let vn7 = h('span', p7, c7);
+    c6.push(vn7);
+    c7.push({text: \`footer\`});
 }"
 `;
 
@@ -134,23 +134,23 @@ exports[`t-slot directive can define and call slots using old t-set keyword 2`] 
 ) {
     // Template name: \\"__template__1\\"
     let h = this.h;
-    let c6 = [], p6 = {key:6};
-    let vn6 = h('div', p6, c6);
-    let c7 = [], p7 = {key:7};
-    let vn7 = h('div', p7, c7);
-    c6.push(vn7);
-    const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
-    if (slot8) {
-        slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || context}));
-    }
     let c9 = [], p9 = {key:9};
     let vn9 = h('div', p9, c9);
-    c6.push(vn9);
-    const slot10 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
-    if (slot10) {
-        slot10.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c9, parent: extra.parent || context}));
+    let c10 = [], p10 = {key:10};
+    let vn10 = h('div', p10, c10);
+    c9.push(vn10);
+    const slot11 = this.constructor.slots[context.__owl__.slotId + '_' + 'header'];
+    if (slot11) {
+        slot11.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c10, parent: extra.parent || context}));
     }
-    return vn6;
+    let c12 = [], p12 = {key:12};
+    let vn12 = h('div', p12, c12);
+    c9.push(vn12);
+    const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'footer'];
+    if (slot13) {
+        slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
+    }
+    return vn9;
 }"
 `;
 
@@ -159,11 +159,11 @@ exports[`t-slot directive can define and call slots using old t-set keyword 3`] 
 ) {
     // Template name: \\"slot_header_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c1.push(vn4);
-    c4.push({text: \`header\`});
+    let c4 = extra.parentNode;
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c4.push(vn5);
+    c5.push({text: \`header\`});
 }"
 `;
 
@@ -172,11 +172,11 @@ exports[`t-slot directive can define and call slots using old t-set keyword 4`] 
 ) {
     // Template name: \\"slot_footer_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c5 = [], p5 = {key:5};
-    let vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`footer\`});
+    let c6 = extra.parentNode;
+    let c7 = [], p7 = {key:7};
+    let vn7 = h('span', p7, c7);
+    c6.push(vn7);
+    c7.push({text: \`footer\`});
 }"
 `;
 
@@ -185,11 +185,11 @@ exports[`t-slot directive content is the default slot 1`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c1.push(vn4);
-    c4.push({text: \`sts rocks\`});
+    let c4 = extra.parentNode;
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    c4.push(vn5);
+    c5.push({text: \`sts rocks\`});
 }"
 `;
 
@@ -215,8 +215,8 @@ exports[`t-slot directive default slot work with text nodes 1`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    c1.push({text: \`sts rocks\`});
+    let c4 = extra.parentNode;
+    c4.push({text: \`sts rocks\`});
 }"
 `;
 
@@ -225,15 +225,15 @@ exports[`t-slot directive multiple roots are allowed in a default slot 1`] = `
 ) {
     // Template name: \\"slot_default_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c1.push(vn4);
-    c4.push({text: \`sts\`});
+    let c4 = extra.parentNode;
     let c5 = [], p5 = {key:5};
     let vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`rocks\`});
+    c4.push(vn5);
+    c5.push({text: \`sts\`});
+    let c6 = [], p6 = {key:6};
+    let vn6 = h('span', p6, c6);
+    c4.push(vn6);
+    c6.push({text: \`rocks\`});
 }"
 `;
 
@@ -242,15 +242,15 @@ exports[`t-slot directive multiple roots are allowed in a named slot 1`] = `
 ) {
     // Template name: \\"slot_content_template\\"
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    c1.push(vn4);
-    c4.push({text: \`sts\`});
+    let c4 = extra.parentNode;
     let c5 = [], p5 = {key:5};
     let vn5 = h('span', p5, c5);
-    c1.push(vn5);
-    c5.push({text: \`rocks\`});
+    c4.push(vn5);
+    c5.push({text: \`sts\`});
+    let c6 = [], p6 = {key:6};
+    let vn6 = h('span', p6, c6);
+    c4.push(vn6);
+    c6.push({text: \`rocks\`});
 }"
 `;
 
@@ -278,22 +278,22 @@ exports[`t-slot directive refs are properly bound in slots 1`] = `
     let utils = this.constructor.utils;
     context.__owl__.refs = context.__owl__.refs || {};
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c8 = [], p8 = {key:8,on:{}};
-    let vn8 = h('button', p8, c8);
-    c1.push(vn8);
-    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__9__'];
-    const ref10 = \`myButton\`;
-    p8.hook = {
+    let c8 = extra.parentNode;
+    let c9 = [], p9 = {key:9,on:{}};
+    let vn9 = h('button', p9, c9);
+    c8.push(vn9);
+    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p9.on['click'] = extra.handlers['click__10__'];
+    const ref11 = \`myButton\`;
+    p9.hook = {
       create: (_, n) => {
-        context.__owl__.refs[ref10] = n.elm;
+        context.__owl__.refs[ref11] = n.elm;
       },
       destroy: () => {
-        delete context.__owl__.refs[ref10];
+        delete context.__owl__.refs[ref11];
       },
     };
-    c8.push({text: \`do something\`});
+    c9.push({text: \`do something\`});
 }"
 `;
 
@@ -303,13 +303,13 @@ exports[`t-slot directive slots are rendered with proper context 1`] = `
     // Template name: \\"slot_footer_template\\"
     let utils = this.constructor.utils;
     let h = this.h;
-    let c1 = extra.parentNode;
-    let c8 = [], p8 = {key:8,on:{}};
-    let vn8 = h('button', p8, c8);
-    c1.push(vn8);
-    extra.handlers['click__9__'] = extra.handlers['click__9__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
-    p8.on['click'] = extra.handlers['click__9__'];
-    c8.push({text: \`do something\`});
+    let c8 = extra.parentNode;
+    let c9 = [], p9 = {key:9,on:{}};
+    let vn9 = h('button', p9, c9);
+    c8.push(vn9);
+    extra.handlers['click__10__'] = extra.handlers['click__10__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['doSomething'](e);};
+    p9.on['click'] = extra.handlers['click__10__'];
+    c9.push({text: \`do something\`});
 }"
 `;
 
@@ -319,14 +319,14 @@ exports[`t-slot directive slots are rendered with proper context, part 2 1`] = `
     // Template name: \\"Link\\"
     let scope = Object.create(context);
     let h = this.h;
-    let _11 = scope['props'].to;
-    let c12 = [], p12 = {key:12,attrs:{href: _11}};
-    let vn12 = h('a', p12, c12);
-    const slot13 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot13) {
-        slot13.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c12, parent: extra.parent || context}));
+    let _12 = scope['props'].to;
+    let c13 = [], p13 = {key:13,attrs:{href: _12}};
+    let vn13 = h('a', p13, c13);
+    const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot14) {
+        slot14.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || context}));
     }
-    return vn12;
+    return vn13;
 }"
 `;
 
@@ -401,11 +401,11 @@ exports[`t-slot directive slots are rendered with proper context, part 2 3`] = `
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
     let h = this.h;
-    let c7 = extra.parentNode;
-    c7.push({text: \`User \`});
-    let _10 = scope['user'].name;
-    if (_10 != null) {
-        c7.push({text: _10});
+    let c10 = extra.parentNode;
+    c10.push({text: \`User \`});
+    let _11 = scope['user'].name;
+    if (_11 != null) {
+        c10.push({text: _11});
     }
 }"
 `;
@@ -416,14 +416,14 @@ exports[`t-slot directive slots are rendered with proper context, part 3 1`] = `
     // Template name: \\"Link\\"
     let scope = Object.create(context);
     let h = this.h;
-    let _10 = scope['props'].to;
-    let c11 = [], p11 = {key:11,attrs:{href: _10}};
-    let vn11 = h('a', p11, c11);
-    const slot12 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot12) {
-        slot12.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c11, parent: extra.parent || context}));
+    let _12 = scope['props'].to;
+    let c13 = [], p13 = {key:13,attrs:{href: _12}};
+    let vn13 = h('a', p13, c13);
+    const slot14 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot14) {
+        slot14.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c13, parent: extra.parent || context}));
     }
-    return vn11;
+    return vn13;
 }"
 `;
 
@@ -499,9 +499,10 @@ exports[`t-slot directive slots are rendered with proper context, part 3 3`] = `
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
     let h = this.h;
-    let c7 = extra.parentNode;
-    if (scope.userdescr != null) {
-        c7.push({text: scope.userdescr});
+    let c10 = extra.parentNode;
+    let _11 = scope['userdescr'];
+    if (_11 != null) {
+        c10.push({text: _11});
     }
 }"
 `;
@@ -552,9 +553,10 @@ exports[`t-slot directive slots are rendered with proper context, part 4 2`] = `
     // Template name: \\"slot_default_template\\"
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
-    if (scope.userdescr != null) {
-        c1.push({text: scope.userdescr});
+    let c4 = extra.parentNode;
+    let _5 = scope['userdescr'];
+    if (_5 != null) {
+        c4.push({text: _5});
     }
 }"
 `;
@@ -564,13 +566,13 @@ exports[`t-slot directive t-set t-value in a slot 1`] = `
 ) {
     // Template name: \\"__template__1\\"
     let h = this.h;
-    let c4 = [], p4 = {key:4};
-    let vn4 = h('span', p4, c4);
-    const slot5 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot5) {
-        slot5.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c4, parent: extra.parent || context}));
+    let c5 = [], p5 = {key:5};
+    let vn5 = h('span', p5, c5);
+    const slot6 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot6) {
+        slot6.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c5, parent: extra.parent || context}));
     }
-    return vn4;
+    return vn5;
 }"
 `;
 
@@ -581,12 +583,12 @@ exports[`t-slot directive template can just return a slot 1`] = `
     let utils = this.constructor.utils;
     let result;
     let h = this.h;
-    const slot6 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot6) {
-        let children7= []
+    const slot7 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot7) {
+        let children8= []
         result = {}
-        slot6.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: children7, parent: extra.parent || context}));
-        utils.defineProxy(result, children7[0]);
+        slot7.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: children8, parent: extra.parent || context}));
+        utils.defineProxy(result, children8[0]);
     }
     return result;
 }"

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -1391,6 +1391,54 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
 }"
 `;
 
+exports[`t-call (template calling dynamic t-call 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"main\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let tname2 = (scope['template']);
+    let tid2 = this.constructor.nextId++;
+    if (!(tname2 in this.subTemplates)) {
+        this.subTemplates[tname2] = tid2;
+        this.constructor.subTemplates[tid2] = this._compile(tname2, {hasParent: true, defineKey: true});
+    }
+    let _origScope3 = scope;
+    scope = Object.create(scope);
+    scope.__access_mode__ = 'ro';
+    this.constructor.subTemplates[tid2].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
+    scope = _origScope3;
+    return vn1;
+}"
+`;
+
+exports[`t-call (template calling dynamic t-call 2`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"main\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let tname2 = (scope['template']);
+    let tid2 = this.constructor.nextId++;
+    if (!(tname2 in this.subTemplates)) {
+        this.subTemplates[tname2] = tid2;
+        this.constructor.subTemplates[tid2] = this._compile(tname2, {hasParent: true, defineKey: true});
+    }
+    let _origScope3 = scope;
+    scope = Object.create(scope);
+    scope.__access_mode__ = 'ro';
+    this.constructor.subTemplates[tid2].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
+    scope = _origScope3;
+    return vn1;
+}"
+`;
+
 exports[`t-call (template calling inherit context 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -673,7 +673,7 @@ exports[`foreach t-call with body in t-foreach in t-foreach 1`] = `
             scope.b = _7[i2]
             scope.b_value = _8[i2]
             let key2 = i2;
-            let _origScope13 = scope;
+            let _origScope14 = scope;
             scope = Object.create(scope);
             scope.__access_mode__ = 'ro';
             {
@@ -682,38 +682,38 @@ exports[`foreach t-call with body in t-foreach in t-foreach 1`] = `
                     utils.getScope(scope, 'c').c = 'x'+'_'+scope['a']+'_'+scope['b'];
                     scope[utils.zero] = c__0;
                 }
-                let k14 = \`__14__\${key1}__\${key2}__\`;
-                this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k14}));
+                let k15 = \`__15__\${key1}__\${key2}__\`;
+                this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k15}));
             }
-            scope = _origScope13;
+            scope = _origScope14;
         }
         scope = _origScope9;
-        let c15 = [], p15 = {key:\`\${key1}_15\`};
-        let vn15 = h('span', p15, c15);
-        c1.push(vn15);
+        let c16 = [], p16 = {key:\`\${key1}_16\`};
+        let vn16 = h('span', p16, c16);
+        c1.push(vn16);
         if (scope.c != null) {
-            c15.push({text: scope.c});
+            c16.push({text: scope.c});
         }
     }
     scope = _origScope5;
-    let c16 = [], p16 = {key:16};
-    let vn16 = h('span', p16, c16);
-    c1.push(vn16);
-    c16.push({text: \`[\`});
-    let _17 = scope['a'];
-    if (_17 != null) {
-        c16.push({text: _17});
-    }
-    c16.push({text: \`][\`});
-    let _18 = scope['b'];
+    let c17 = [], p17 = {key:17};
+    let vn17 = h('span', p17, c17);
+    c1.push(vn17);
+    c17.push({text: \`[\`});
+    let _18 = scope['a'];
     if (_18 != null) {
-        c16.push({text: _18});
+        c17.push({text: _18});
     }
-    c16.push({text: \`][\`});
+    c17.push({text: \`][\`});
+    let _19 = scope['b'];
+    if (_19 != null) {
+        c17.push({text: _19});
+    }
+    c17.push({text: \`][\`});
     if (scope.c != null) {
-        c16.push({text: scope.c});
+        c17.push({text: scope.c});
     }
-    c16.push({text: \`]\`});
+    c17.push({text: \`]\`});
     return vn1;
 }"
 `;
@@ -761,42 +761,42 @@ exports[`foreach t-call without body in t-foreach in t-foreach 1`] = `
             scope.b = _7[i2]
             scope.b_value = _8[i2]
             let key2 = i2;
-            let _origScope12 = scope;
+            let _origScope13 = scope;
             scope = Object.create(scope);
             scope.__access_mode__ = 'ro';
-            let k13 = \`__13__\${key1}__\${key2}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k13}));
-            scope = _origScope12;
+            let k14 = \`__14__\${key1}__\${key2}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k14}));
+            scope = _origScope13;
         }
         scope = _origScope9;
-        let c14 = [], p14 = {key:\`\${key1}_14\`};
-        let vn14 = h('span', p14, c14);
-        c1.push(vn14);
-        let _15 = scope['c'];
-        if (_15 != null) {
-            c14.push({text: _15});
+        let c15 = [], p15 = {key:\`\${key1}_15\`};
+        let vn15 = h('span', p15, c15);
+        c1.push(vn15);
+        let _16 = scope['c'];
+        if (_16 != null) {
+            c15.push({text: _16});
         }
     }
     scope = _origScope5;
-    let c16 = [], p16 = {key:16};
-    let vn16 = h('span', p16, c16);
-    c1.push(vn16);
-    c16.push({text: \`[\`});
-    let _17 = scope['a'];
-    if (_17 != null) {
-        c16.push({text: _17});
-    }
-    c16.push({text: \`][\`});
-    let _18 = scope['b'];
+    let c17 = [], p17 = {key:17};
+    let vn17 = h('span', p17, c17);
+    c1.push(vn17);
+    c17.push({text: \`[\`});
+    let _18 = scope['a'];
     if (_18 != null) {
-        c16.push({text: _18});
+        c17.push({text: _18});
     }
-    c16.push({text: \`][\`});
-    let _19 = scope['c'];
+    c17.push({text: \`][\`});
+    let _19 = scope['b'];
     if (_19 != null) {
-        c16.push({text: _19});
+        c17.push({text: _19});
     }
-    c16.push({text: \`]\`});
+    c17.push({text: \`][\`});
+    let _20 = scope['c'];
+    if (_20 != null) {
+        c17.push({text: _20});
+    }
+    c17.push({text: \`]\`});
     return vn1;
 }"
 `;
@@ -920,11 +920,11 @@ exports[`loading templates can load a few templates from a xml string 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('ul', p1, c1);
-    let _origScope4 = scope;
+    let _origScope5 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
-    scope = _origScope4;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+    scope = _origScope5;
     return vn1;
 }"
 `;
@@ -962,13 +962,13 @@ exports[`misc global 1`] = `
         if (_7 != null) {
             c6.push({text: _7});
         }
-        let _origScope10 = scope;
+        let _origScope11 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
             {
                 let c__0 = [];
-                let _origScope13 = scope;
+                let _origScope15 = scope;
                 scope = Object.create(scope);
                 scope.__access_mode__ = 'ro';
                 {
@@ -977,36 +977,36 @@ exports[`misc global 1`] = `
                         utils.getScope(scope, 'foo').foo = 'aaa';
                         scope[utils.zero] = c__0;
                     }
-                    let k14 = \`__14__\${key1}__\`;
-                    this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k14}));
+                    let k16 = \`__16__\${key1}__\`;
+                    this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k16}));
                 }
-                scope = _origScope13;
-                let _origScope15 = scope;
-                scope = Object.create(scope);
-                scope.__access_mode__ = 'ro';
-                let k16 = \`__16__\${key1}__\`;
-                this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k16}));
                 scope = _origScope15;
-                utils.getScope(scope, 'foo').foo = 'bbb';
                 let _origScope17 = scope;
                 scope = Object.create(scope);
                 scope.__access_mode__ = 'ro';
                 let k18 = \`__18__\${key1}__\`;
                 this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k18}));
                 scope = _origScope17;
+                utils.getScope(scope, 'foo').foo = 'bbb';
+                let _origScope19 = scope;
+                scope = Object.create(scope);
+                scope.__access_mode__ = 'ro';
+                let k20 = \`__20__\${key1}__\`;
+                this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c__0, parent: utils.getComponent(context), key: k20}));
+                scope = _origScope19;
                 scope[utils.zero] = c__0;
             }
-            let k19 = \`__19__\${key1}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k19}));
+            let k21 = \`__21__\${key1}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k21}));
         }
-        scope = _origScope10;
+        scope = _origScope11;
     }
     scope = _origScope5;
-    let _origScope22 = scope;
+    let _origScope25 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['3'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__23__'}));
-    scope = _origScope22;
+    this.constructor.subTemplates['3'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__26__'}));
+    scope = _origScope25;
     return vn1;
 }"
 `;
@@ -1295,11 +1295,11 @@ exports[`t-call (template calling basic caller 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-    scope = _origScope3;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1332,26 +1332,26 @@ exports[`t-call (template calling call with several sub nodes on same line 1`] =
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
         {
             let c__0 = [];
-            let c4 = [], p4 = {key:4};
-            let vn4 = h('span', p4, c4);
-            c__0.push(vn4);
-            c4.push({text: \`hey\`});
-            c__0.push({text: \` \`});
             let c5 = [], p5 = {key:5};
             let vn5 = h('span', p5, c5);
             c__0.push(vn5);
-            c5.push({text: \`yay\`});
+            c5.push({text: \`hey\`});
+            c__0.push({text: \` \`});
+            let c6 = [], p6 = {key:6};
+            let vn6 = h('span', p6, c6);
+            c__0.push(vn6);
+            c6.push({text: \`yay\`});
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__7__'}));
     }
-    scope = _origScope3;
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1367,26 +1367,26 @@ exports[`t-call (template calling cascading t-call t-raw='0' 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope12 = scope;
+    let _origScope15 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
         {
             let c__0 = [];
-            let c13 = [], p13 = {key:13};
-            let vn13 = h('span', p13, c13);
-            c__0.push(vn13);
-            c13.push({text: \`hey\`});
+            let c16 = [], p16 = {key:16};
+            let vn16 = h('span', p16, c16);
+            c__0.push(vn16);
+            c16.push({text: \`hey\`});
             c__0.push({text: \` \`});
-            let c14 = [], p14 = {key:14};
-            let vn14 = h('span', p14, c14);
-            c__0.push(vn14);
-            c14.push({text: \`yay\`});
+            let c17 = [], p17 = {key:17};
+            let vn17 = h('span', p17, c17);
+            c__0.push(vn17);
+            c17.push({text: \`yay\`});
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__15__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__18__'}));
     }
-    scope = _origScope12;
+    scope = _origScope15;
     return vn1;
 }"
 `;
@@ -1401,11 +1401,11 @@ exports[`t-call (template calling inherit context 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     scope.foo = 1;
-    let _origScope2 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__3__'}));
-    scope = _origScope2;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1424,11 +1424,11 @@ exports[`t-call (template calling recursive template, part 1 1`] = `
     c1.push(vn2);
     c2.push({text: \`hey\`});
     if (false) {
-        let _origScope7 = scope;
+        let _origScope8 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__8__'}));
-        scope = _origScope7;
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__9__'}));
+        scope = _origScope8;
     }
     return vn1;
 }"
@@ -1441,22 +1441,22 @@ exports[`t-call (template calling recursive template, part 1 2`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c3 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c3 = [], p3 = {key:\`\${key0}_3\`};
-    let vn3 = h('div', p3, c3);
-    c1.push(vn3);
     let c4 = [], p4 = {key:\`\${key0}_4\`};
-    let vn4 = h('span', p4, c4);
+    let vn4 = h('div', p4, c4);
     c3.push(vn4);
-    c4.push({text: \`hey\`});
+    let c5 = [], p5 = {key:\`\${key0}_5\`};
+    let vn5 = h('span', p5, c5);
+    c4.push(vn5);
+    c5.push({text: \`hey\`});
     if (false) {
-        let _origScope5 = scope;
+        let _origScope6 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
-        let k6 = \`__6__\${key0}__\`;
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k6}));
-        scope = _origScope5;
+        let k7 = \`__7__\${key0}__\`;
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c4, parent: utils.getComponent(context), key: k7}));
+        scope = _origScope6;
     }
 }"
 `;
@@ -1470,7 +1470,7 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope11 = scope;
+    let _origScope12 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -1479,9 +1479,9 @@ exports[`t-call (template calling recursive template, part 2 1`] = `
             utils.getScope(scope, 'node').node = scope['root'];
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__12__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__13__'}));
     }
-    scope = _origScope11;
+    scope = _origScope12;
     return vn1;
 }"
 `;
@@ -1493,36 +1493,36 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c2 = [], p2 = {key:\`\${key0}_2\`};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
     let c3 = [], p3 = {key:\`\${key0}_3\`};
-    let vn3 = h('p', p3, c3);
+    let vn3 = h('div', p3, c3);
     c2.push(vn3);
-    let _4 = scope['node'].val;
-    if (_4 != null) {
-        c3.push({text: _4});
+    let c4 = [], p4 = {key:\`\${key0}_4\`};
+    let vn4 = h('p', p4, c4);
+    c3.push(vn4);
+    let _5 = scope['node'].val;
+    if (_5 != null) {
+        c4.push({text: _5});
     }
-    let _5 = scope['node'].children||[];
-    if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    let _6 = _7 = _5;
-    if (!(_5 instanceof Array)) {
-        _6 = Object.keys(_5);
-        _7 = Object.values(_5);
+    let _6 = scope['node'].children||[];
+    if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
+    let _7 = _8 = _6;
+    if (!(_6 instanceof Array)) {
+        _7 = Object.keys(_6);
+        _8 = Object.values(_6);
     }
-    let _length6 = _6.length;
-    let _origScope8 = scope;
+    let _length7 = _7.length;
+    let _origScope9 = scope;
     scope = Object.create(scope);
-    for (let i1 = 0; i1 < _length6; i1++) {
+    for (let i1 = 0; i1 < _length7; i1++) {
         scope.subtree_first = i1 === 0
-        scope.subtree_last = i1 === _length6 - 1
+        scope.subtree_last = i1 === _length7 - 1
         scope.subtree_index = i1
-        scope.subtree = _6[i1]
-        scope.subtree_value = _7[i1]
+        scope.subtree = _7[i1]
+        scope.subtree_value = _8[i1]
         let key1 = i1;
-        let _origScope9 = scope;
+        let _origScope10 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
@@ -1531,12 +1531,12 @@ exports[`t-call (template calling recursive template, part 2 2`] = `
                 utils.getScope(scope, 'node').node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
-            let k10 = \`__10__\${key0}__\${key1}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k10}));
+            let k11 = \`__11__\${key0}__\${key1}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k11}));
         }
-        scope = _origScope9;
+        scope = _origScope10;
     }
-    scope = _origScope8;
+    scope = _origScope9;
 }"
 `;
 
@@ -1549,7 +1549,7 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope11 = scope;
+    let _origScope12 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -1558,9 +1558,9 @@ exports[`t-call (template calling recursive template, part 3 1`] = `
             utils.getScope(scope, 'node').node = scope['root'];
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__12__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__13__'}));
     }
-    scope = _origScope11;
+    scope = _origScope12;
     return vn1;
 }"
 `;
@@ -1572,36 +1572,36 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c2 = [], p2 = {key:\`\${key0}_2\`};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
     let c3 = [], p3 = {key:\`\${key0}_3\`};
-    let vn3 = h('p', p3, c3);
+    let vn3 = h('div', p3, c3);
     c2.push(vn3);
-    let _4 = scope['node'].val;
-    if (_4 != null) {
-        c3.push({text: _4});
+    let c4 = [], p4 = {key:\`\${key0}_4\`};
+    let vn4 = h('p', p4, c4);
+    c3.push(vn4);
+    let _5 = scope['node'].val;
+    if (_5 != null) {
+        c4.push({text: _5});
     }
-    let _5 = scope['node'].children||[];
-    if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    let _6 = _7 = _5;
-    if (!(_5 instanceof Array)) {
-        _6 = Object.keys(_5);
-        _7 = Object.values(_5);
+    let _6 = scope['node'].children||[];
+    if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
+    let _7 = _8 = _6;
+    if (!(_6 instanceof Array)) {
+        _7 = Object.keys(_6);
+        _8 = Object.values(_6);
     }
-    let _length6 = _6.length;
-    let _origScope8 = scope;
+    let _length7 = _7.length;
+    let _origScope9 = scope;
     scope = Object.create(scope);
-    for (let i1 = 0; i1 < _length6; i1++) {
+    for (let i1 = 0; i1 < _length7; i1++) {
         scope.subtree_first = i1 === 0
-        scope.subtree_last = i1 === _length6 - 1
+        scope.subtree_last = i1 === _length7 - 1
         scope.subtree_index = i1
-        scope.subtree = _6[i1]
-        scope.subtree_value = _7[i1]
+        scope.subtree = _7[i1]
+        scope.subtree_value = _8[i1]
         let key1 = i1;
-        let _origScope9 = scope;
+        let _origScope10 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
@@ -1610,12 +1610,12 @@ exports[`t-call (template calling recursive template, part 3 2`] = `
                 utils.getScope(scope, 'node').node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
-            let k10 = \`__10__\${key0}__\${key1}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k10}));
+            let k11 = \`__11__\${key0}__\${key1}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k11}));
         }
-        scope = _origScope9;
+        scope = _origScope10;
     }
-    scope = _origScope8;
+    scope = _origScope9;
 }"
 `;
 
@@ -1628,7 +1628,7 @@ exports[`t-call (template calling recursive template, part 4: with t-set recursi
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope11 = scope;
+    let _origScope12 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -1638,9 +1638,9 @@ exports[`t-call (template calling recursive template, part 4: with t-set recursi
             utils.getScope(scope, 'node').node = scope['root'];
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__12__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__13__'}));
     }
-    scope = _origScope11;
+    scope = _origScope12;
     return vn1;
 }"
 `;
@@ -1652,41 +1652,41 @@ exports[`t-call (template calling recursive template, part 4: with t-set recursi
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let c1 = extra.parentNode;
+    let c2 = extra.parentNode;
     let key0 = extra.key || \\"\\";
-    let c2 = [], p2 = {key:\`\${key0}_2\`};
-    let vn2 = h('div', p2, c2);
-    c1.push(vn2);
-    scope.recursive_idx = scope.recursive_idx+1;
     let c3 = [], p3 = {key:\`\${key0}_3\`};
-    let vn3 = h('p', p3, c3);
+    let vn3 = h('div', p3, c3);
     c2.push(vn3);
-    let _4 = scope['node'].val;
-    if (_4 != null) {
-        c3.push({text: _4});
+    scope.recursive_idx = scope.recursive_idx+1;
+    let c4 = [], p4 = {key:\`\${key0}_4\`};
+    let vn4 = h('p', p4, c4);
+    c3.push(vn4);
+    let _5 = scope['node'].val;
+    if (_5 != null) {
+        c4.push({text: _5});
     }
-    c3.push({text: \` \`});
+    c4.push({text: \` \`});
     if (scope.recursive_idx != null) {
-        c3.push({text: scope.recursive_idx});
+        c4.push({text: scope.recursive_idx});
     }
-    let _5 = scope['node'].children||[];
-    if (!_5) { throw new Error('QWeb error: Invalid loop expression')}
-    let _6 = _7 = _5;
-    if (!(_5 instanceof Array)) {
-        _6 = Object.keys(_5);
-        _7 = Object.values(_5);
+    let _6 = scope['node'].children||[];
+    if (!_6) { throw new Error('QWeb error: Invalid loop expression')}
+    let _7 = _8 = _6;
+    if (!(_6 instanceof Array)) {
+        _7 = Object.keys(_6);
+        _8 = Object.values(_6);
     }
-    let _length6 = _6.length;
-    let _origScope8 = scope;
+    let _length7 = _7.length;
+    let _origScope9 = scope;
     scope = Object.create(scope);
-    for (let i1 = 0; i1 < _length6; i1++) {
+    for (let i1 = 0; i1 < _length7; i1++) {
         scope.subtree_first = i1 === 0
-        scope.subtree_last = i1 === _length6 - 1
+        scope.subtree_last = i1 === _length7 - 1
         scope.subtree_index = i1
-        scope.subtree = _6[i1]
-        scope.subtree_value = _7[i1]
+        scope.subtree = _7[i1]
+        scope.subtree_value = _8[i1]
         let key1 = i1;
-        let _origScope9 = scope;
+        let _origScope10 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
@@ -1695,12 +1695,12 @@ exports[`t-call (template calling recursive template, part 4: with t-set recursi
                 utils.getScope(scope, 'node').node = scope['subtree'];
                 scope[utils.zero] = c__0;
             }
-            let k10 = \`__10__\${key0}__\${key1}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c2, parent: utils.getComponent(context), key: k10}));
+            let k11 = \`__11__\${key0}__\${key1}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c3, parent: utils.getComponent(context), key: k11}));
         }
-        scope = _origScope9;
+        scope = _origScope10;
     }
-    scope = _origScope8;
+    scope = _origScope9;
 }"
 `;
 
@@ -1713,7 +1713,7 @@ exports[`t-call (template calling scoped parameters 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope2 = scope;
+    let _origScope3 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -1722,9 +1722,9 @@ exports[`t-call (template calling scoped parameters 1`] = `
             utils.getScope(scope, 'foo').foo = 42;
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__3__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
     }
-    scope = _origScope2;
+    scope = _origScope3;
     if (scope.foo != null) {
         c1.push({text: scope.foo});
     }
@@ -1741,11 +1741,11 @@ exports[`t-call (template calling t-call allowed on a non t node 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-    scope = _origScope3;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1760,11 +1760,11 @@ exports[`t-call (template calling t-call with t-if 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     if (scope['flag']) {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-        scope = _origScope3;
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+        scope = _origScope4;
     }
     return vn1;
 }"
@@ -1779,20 +1779,20 @@ exports[`t-call (template calling t-call with t-set inside and body text content
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope4 = scope;
+    let _origScope5 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
         {
             let c__0 = [];
-            let c5 = new utils.VDomArray();
-            c5.push({text: \`yip yip\`});
-            scope.val = c5
+            let c6 = new utils.VDomArray();
+            c6.push({text: \`yip yip\`});
+            scope.val = c6
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__7__'}));
     }
-    scope = _origScope4;
+    scope = _origScope5;
     return vn1;
 }"
 `;
@@ -1824,7 +1824,7 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
         scope.v_value = _4[i1]
         let key1 = i1;
         utils.getScope(scope, 'val').val = scope['v'].val;
-        let _origScope8 = scope;
+        let _origScope9 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
@@ -1833,10 +1833,10 @@ exports[`t-call (template calling t-call with t-set inside and outside 1`] = `
                 utils.getScope(scope, 'val3').val3 = scope.val*3;
                 scope[utils.zero] = c__0;
             }
-            let k9 = \`__9__\${key1}__\`;
-            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k9}));
+            let k10 = \`__10__\${key1}__\`;
+            this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: k10}));
         }
-        scope = _origScope8;
+        scope = _origScope9;
     }
     scope = _origScope5;
     return vn1;
@@ -1853,11 +1853,11 @@ exports[`t-call (template calling t-call with t-set inside and outside. 2 1`] = 
     let c1 = [], p1 = {key:1};
     let vn1 = h('p', p1, c1);
     scope.w = 'fromwrapper';
-    let _origScope11 = scope;
+    let _origScope14 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__12__'}));
-    scope = _origScope11;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__15__'}));
+    scope = _origScope14;
     return vn1;
 }"
 `;
@@ -1873,14 +1873,14 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
     let vn1 = h('div', p1, c1);
     scope.v1 = 'elif';
     if (scope.v1==='if') {
-        let _origScope3 = scope;
+        let _origScope4 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-        scope = _origScope3;
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+        scope = _origScope4;
     }
     else if (scope.v1==='elif') {
-        let _origScope7 = scope;
+        let _origScope9 = scope;
         scope = Object.create(scope);
         scope.__access_mode__ = 'ro';
         {
@@ -1889,9 +1889,9 @@ exports[`t-call (template calling t-call, conditional and t-set in t-call body 1
                 utils.getScope(scope, 'v').v = 'success';
                 scope[utils.zero] = c__0;
             }
-            this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__8__'}));
+            this.constructor.subTemplates['2'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__10__'}));
         }
-        scope = _origScope7;
+        scope = _origScope9;
     }
     return vn1;
 }"
@@ -1906,11 +1906,11 @@ exports[`t-call (template calling t-call, global templates 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-    scope = _origScope3;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1924,11 +1924,11 @@ exports[`t-call (template calling two different QWeb instances, and shared templ
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-    scope = _origScope3;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -1942,11 +1942,11 @@ exports[`t-call (template calling two different QWeb instances, and shared templ
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
-    scope = _origScope3;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -2038,7 +2038,7 @@ exports[`t-call (template calling with used set body 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('span', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
@@ -2047,9 +2047,9 @@ exports[`t-call (template calling with used set body 1`] = `
             utils.getScope(scope, 'foo').foo = 'ok';
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
     }
-    scope = _origScope3;
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -2197,11 +2197,11 @@ exports[`t-esc t-esc inside t-call, with t-set outside 1`] = `
     let c2 = new utils.VDomArray();
     c2.push({text: \`Hi\`});
     scope.v = c2
-    let _origScope5 = scope;
+    let _origScope6 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
-    scope = _origScope5;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__7__'}));
+    scope = _origScope6;
     return vn1;
 }"
 `;
@@ -2258,21 +2258,21 @@ exports[`t-esc t-esc=0 is escaped 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope3 = scope;
+    let _origScope4 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
     {
         {
             let c__0 = [];
-            let c4 = [], p4 = {key:4};
-            let vn4 = h('p', p4, c4);
-            c__0.push(vn4);
-            c4.push({text: \`escaped\`});
+            let c5 = [], p5 = {key:5};
+            let vn5 = h('p', p5, c5);
+            c__0.push(vn5);
+            c5.push({text: \`escaped\`});
             scope[utils.zero] = c__0;
         }
-        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
+        this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
     }
-    scope = _origScope3;
+    scope = _origScope4;
     return vn1;
 }"
 `;
@@ -3066,11 +3066,11 @@ exports[`t-on t-on with t-call 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope4 = scope;
+    let _origScope5 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
-    scope = _origScope4;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+    scope = _origScope5;
     return vn1;
 }"
 `;
@@ -3084,11 +3084,11 @@ exports[`t-on t-on, with arguments and t-call 1`] = `
     let h = this.h;
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
-    let _origScope4 = scope;
+    let _origScope5 = scope;
     scope = Object.create(scope);
     scope.__access_mode__ = 'ro';
-    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__5__'}));
-    scope = _origScope4;
+    this.constructor.subTemplates['1'].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__6__'}));
+    scope = _origScope5;
     return vn1;
 }"
 `;

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -1088,6 +1088,16 @@ describe("t-call (template calling", () => {
     const expected = "<div><p>yip yip</p></div>";
     expect(renderToString(qweb, "main")).toBe(expected);
   });
+
+  test("dynamic t-call", () => {
+    qweb.addTemplate("foo", `<foo><t t-esc="val"/></foo>`);
+    qweb.addTemplate("bar", `<bar><t t-esc="val"/></bar>`);
+    qweb.addTemplate("main", `<div><t t-call="{{template}}"/></div>`);
+    const expected = "<div><foo>foo</foo></div>";
+    expect(renderToString(qweb, "main", { template: "foo", val: "foo" })).toBe(expected);
+    const expected2 = "<div><bar>quux</bar></div>";
+    expect(renderToString(qweb, "main", { template: "bar", val: "quux" })).toBe(expected2);
+  });
 });
 
 describe("foreach", () => {

--- a/tests/router/__snapshots__/link.test.ts.snap
+++ b/tests/router/__snapshots__/link.test.ts.snap
@@ -7,16 +7,16 @@ exports[`Link component can render simple cases 1`] = `
     let utils = this.constructor.utils;
     let scope = Object.create(context);
     let h = this.h;
-    let _4 = utils.toObj({'router-link-active':scope['isActive']});
-    let _5 = scope['href'];
-    let c6 = [], p6 = {key:6,attrs:{href: _5},class:_4,on:{}};
-    let vn6 = h('a', p6, c6);
-    extra.handlers['click__7__'] = extra.handlers['click__7__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
-    p6.on['click'] = extra.handlers['click__7__'];
-    const slot8 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
-    if (slot8) {
-        slot8.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c6, parent: extra.parent || context}));
+    let _5 = utils.toObj({'router-link-active':scope['isActive']});
+    let _6 = scope['href'];
+    let c7 = [], p7 = {key:7,attrs:{href: _6},class:_5,on:{}};
+    let vn7 = h('a', p7, c7);
+    extra.handlers['click__8__'] = extra.handlers['click__8__'] || function (e) {if (!context.__owl__.isMounted){return}utils.getComponent(context)['navigate'](e);};
+    p7.on['click'] = extra.handlers['click__8__'];
+    const slot9 = this.constructor.slots[context.__owl__.slotId + '_' + 'default'];
+    if (slot9) {
+        slot9.call(this, context.__owl__.scope, Object.assign({}, extra, {parentNode: c7, parent: extra.parent || context}));
     }
-    return vn6;
+    return vn7;
 }"
 `;


### PR DESCRIPTION
Strangely, the _compile method required a CompilationContext whenever it
was compiled as a sub template, but this parent context was actually not
really needed.  I guess that it was the case in the past, but this was
changed at some point.