### PR TITLE
[FIX] qweb: do not render comments as text in t-raw

### DIFF
--- a/src/vdom/html_to_vdom.ts
+++ b/src/vdom/html_to_vdom.ts
@@ -13,6 +13,9 @@ export function htmlToVDOM(html: string): VNode[] {
 
 function htmlToVNode(node: ChildNode): VNode {
   if (!(node instanceof Element)) {
+    if (node instanceof Comment) {
+      return h("!", node.textContent);
+    }
     return { text: node.textContent! } as VNode;
   }
   const attrs = {};

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -3148,6 +3148,23 @@ exports[`t-raw t-raw and another sibling node 1`] = `
 }"
 `;
 
+exports[`t-raw t-raw with comment 1`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"test\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('span', p1, c1);
+    let _2 = scope['var'];
+    if (_2 != null) {
+        c1.push(...utils.htmlToVDOM(_2));
+    }
+    return vn1;
+}"
+`;
+
 exports[`t-raw variable 1`] = `
 "function anonymous(context, extra
 ) {

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -238,6 +238,13 @@ describe("t-raw", () => {
       "<span><span>hello</span><ok>world</ok></span>"
     );
   });
+
+  test("t-raw with comment", () => {
+    qweb.addTemplate("test", `<span><t t-raw="var"/></span>`);
+    expect(renderToString(qweb, "test", { var: "<p>text<!-- top secret --></p>" })).toBe(
+      "<span><p>text<!-- top secret --></p></span>"
+    );
+  });
 });
 
 describe("t-set", () => {


### PR DESCRIPTION
The code converting html to a vnode did not handle comment nodes as
expected.

closes #761