### PR TITLE
[FIX] tests: fix cause of non determinism

### DIFF
--- a/tests/animations.test.ts
+++ b/tests/animations.test.ts
@@ -1,15 +1,15 @@
 import { Component, Env } from "../src/component/component";
+import { useRef, useState } from "../src/hooks";
 import { QWeb } from "../src/qweb/index";
-import { useState, useRef } from "../src/hooks";
 import { xml } from "../src/tags";
 import {
   makeDeferred,
-  makeTestFixture,
   makeTestEnv,
+  makeTestFixture,
+  nextFrame,
   patchNextFrame,
   renderToDOM,
   unpatchNextFrame,
-  nextTick,
 } from "./helpers";
 
 //------------------------------------------------------------------------------
@@ -420,29 +420,29 @@ describe("animations", () => {
 
     widget.state.flag = true;
 
-    await nextTick();
+    await nextFrame();
     widget.el!.querySelector("span")!.dispatchEvent(new Event("transitionend"));
     expect(fixture.innerHTML).toBe('<div><span class="">blue</span></div>');
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(1);
 
     widget.state.flag = false;
-    await nextTick();
+    await nextFrame();
     expect(fixture.innerHTML).toBe(
       '<div><span class="chimay-leave-active chimay-leave-to" data-owl-key="__3__">blue</span></div>'
     );
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(1);
 
     widget.state.flag = true;
-    await nextTick();
+    await nextFrame();
     expect(fixture.innerHTML).toBe(
       '<div><span class="chimay-enter-active chimay-enter-to" data-owl-key="__3__">blue</span></div>'
     );
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(2);
 
     widget.state.flag = false;
-    await nextTick();
+    await nextFrame();
     widget.state.flag = true;
-    await nextTick();
+    await nextFrame();
 
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(3);
     widget.el!.querySelector("span")!.dispatchEvent(new Event("transitionend"));

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -37,8 +37,13 @@ export function nextMicroTick(): Promise<void> {
 }
 
 export async function nextTick(): Promise<void> {
-  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
   await new Promise((resolve) => setTimeout(resolve));
+  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
+}
+
+export async function nextFrame(): Promise<void> {
+  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
+  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
 }
 
 export function makeTestFixture() {
@@ -127,7 +132,7 @@ export function renderToString(
 // is useful for animations tests, as we hook before repaints to trigger
 // animations (thanks to requestAnimationFrame). Patching nextFrame allows to
 // simulate calls to this hook. One must not forget to unpatch afterwards.
-let nextFrame = QWeb.utils.nextFrame;
+let _nextFrame = QWeb.utils.nextFrame;
 export function patchNextFrame(f: Function) {
   QWeb.utils.nextFrame = (cb: () => void) => {
     setTimeout(() => f(cb));
@@ -135,7 +140,7 @@ export function patchNextFrame(f: Function) {
 }
 
 export function unpatchNextFrame() {
-  QWeb.utils.nextFrame = nextFrame;
+  QWeb.utils.nextFrame = _nextFrame;
 }
 
 export async function editInput(input: HTMLInputElement | HTMLTextAreaElement, value: string) {


### PR DESCRIPTION
Since commit 7e4baf6, some tests were failing non deterministically. It
seems like the root cause for the problem is that the nextTick method
was sometimes completed too early.

From my understanding of the problem, the nextTick method was correct,
however it is running in a jest test, in node, which simulates the
requestanimationframe behaviour, probably not perfectly.

Switching to an alternate implementation, which swaps the setTimeout and
the requestanimationframe seems to be more solid.

Note that this commit had to introduce the nextFrame method as well,
because the animation tests really seems to want to be in the next
frame, not in a callback executed in the same frame, but at the end.

closes #757