### PR TITLE
[FIX] qweb: issue when rendering twice dynamic t-calls

### DIFF
--- a/src/qweb/base_directives.ts
+++ b/src/qweb/base_directives.ts
@@ -236,8 +236,9 @@ QWeb.addDirective({
     if (isDynamic) {
       const _id = ctx.generateID();
       ctx.addLine(`let tname${_id} = ${ctx.interpolate(subTemplate)};`);
-      ctx.addLine(`let tid${_id} = this.constructor.nextId++;`);
-      ctx.addIf(`!(tname${_id} in this.subTemplates)`);
+      ctx.addLine(`let tid${_id} = this.subTemplates[tname${_id}];`);
+      ctx.addIf(`!tid${_id}`);
+      ctx.addLine(`tid${_id} = this.constructor.nextId++;`);
       ctx.addLine(`this.subTemplates[tname${_id}] = tid${_id};`);
       ctx.addLine(
         `this.constructor.subTemplates[tid${_id}] = this._compile(tname${_id}, {hasParent: true, defineKey: true});`

--- a/tests/qweb/__snapshots__/qweb.test.ts.snap
+++ b/tests/qweb/__snapshots__/qweb.test.ts.snap
@@ -1401,8 +1401,9 @@ exports[`t-call (template calling dynamic t-call 1`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     let tname2 = (scope['template']);
-    let tid2 = this.constructor.nextId++;
-    if (!(tname2 in this.subTemplates)) {
+    let tid2 = this.subTemplates[tname2];
+    if (!tid2) {
+        tid2 = this.constructor.nextId++;
         this.subTemplates[tname2] = tid2;
         this.constructor.subTemplates[tid2] = this._compile(tname2, {hasParent: true, defineKey: true});
     }
@@ -1425,8 +1426,34 @@ exports[`t-call (template calling dynamic t-call 2`] = `
     let c1 = [], p1 = {key:1};
     let vn1 = h('div', p1, c1);
     let tname2 = (scope['template']);
-    let tid2 = this.constructor.nextId++;
-    if (!(tname2 in this.subTemplates)) {
+    let tid2 = this.subTemplates[tname2];
+    if (!tid2) {
+        tid2 = this.constructor.nextId++;
+        this.subTemplates[tname2] = tid2;
+        this.constructor.subTemplates[tid2] = this._compile(tname2, {hasParent: true, defineKey: true});
+    }
+    let _origScope3 = scope;
+    scope = Object.create(scope);
+    scope.__access_mode__ = 'ro';
+    this.constructor.subTemplates[tid2].call(this, scope, Object.assign({}, extra, {parentNode: c1, parent: utils.getComponent(context), key: '__4__'}));
+    scope = _origScope3;
+    return vn1;
+}"
+`;
+
+exports[`t-call (template calling dynamic t-call 3`] = `
+"function anonymous(context, extra
+) {
+    // Template name: \\"main\\"
+    let utils = this.constructor.utils;
+    let scope = Object.create(context);
+    let h = this.h;
+    let c1 = [], p1 = {key:1};
+    let vn1 = h('div', p1, c1);
+    let tname2 = (scope['template']);
+    let tid2 = this.subTemplates[tname2];
+    if (!tid2) {
+        tid2 = this.constructor.nextId++;
         this.subTemplates[tname2] = tid2;
         this.constructor.subTemplates[tid2] = this._compile(tname2, {hasParent: true, defineKey: true});
     }

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -1111,6 +1111,9 @@ describe("t-call (template calling", () => {
     expect(renderToString(qweb, "main", { template: "foo", val: "foo" })).toBe(expected);
     const expected2 = "<div><bar>quux</bar></div>";
     expect(renderToString(qweb, "main", { template: "bar", val: "quux" })).toBe(expected2);
+    // duplicate call because there was a specific bug with some id that was
+    // incremented each rendering.
+    expect(renderToString(qweb, "main", { template: "bar", val: "quux" })).toBe(expected2);
   });
 });
 


### PR DESCRIPTION
The previous implementation generated an id each time the template was
rendered, instead of just once per new dynamic template found.