### PR TITLE
[IMP] config: add enableTransitions flag to config

### DIFF
--- a/doc/reference/config.md
+++ b/doc/reference/config.md
@@ -2,9 +2,10 @@
 
 The Owl framework is designed to work in many situations. However, it is
 sometimes necessary to customize some behaviour. This is done by using the
-global `config` object. It currently has one key:
+global `config` object. It provides two settings:
 
-- [`mode`](#mode).
+- [`mode`](#mode) (default value: `prod`),
+- [`enableTransitions`](#enabletransitions) (default value: `true`).
 
 ## Mode
 
@@ -25,3 +26,19 @@ So, changing this setting is best done at startup.
 
 An important job done by the `dev` mode is to validate props for each component
 creation and update. Also, extra props will cause an error.
+
+## `enableTransitions`
+
+Transitions are usually nice, but they can cause issues in some specific cases,
+such as automated tests. It is uncomfortable having to wait for a transition
+to end before moving to the next step.
+
+To solve this issue, Owl can be configured to ignore the `t-transition` directive.
+To do that, one only needs to set the `enableTransitions` flag to false:
+
+```js
+owl.config.enableTransitions = false;
+```
+
+Note that it suffers from the same drawback as the "dev" mode: all compiled
+templates, if any, will keep their current behaviours.

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ import { QWeb } from "./qweb/index";
 
 interface Config {
   mode: string;
+  enableTransitions: boolean;
 }
 
 export const config = {} as Config;
@@ -26,5 +27,14 @@ Object.defineProperty(config, "mode", {
     } else {
       console.log(`Owl is now running in 'prod' mode.`);
     }
+  },
+});
+
+Object.defineProperty(config, "enableTransitions", {
+  get() {
+    return QWeb.enableTransitions;
+  },
+  set(value: boolean) {
+    QWeb.enableTransitions = value;
   },
 });

--- a/src/qweb/extensions.ts
+++ b/src/qweb/extensions.ts
@@ -205,6 +205,9 @@ QWeb.addDirective({
   name: "transition",
   priority: 96,
   atNodeCreation({ ctx, value, addNodeHook }) {
+    if (!QWeb.enableTransitions) {
+      return;
+    }
     ctx.rootContext.shouldDefineUtils = true;
     let name = value;
     const hooks = {

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -212,6 +212,7 @@ export class QWeb extends EventBus {
   h = h;
   // dev mode enables better error messages or more costly validations
   static dev: boolean = false;
+  static enableTransitions: boolean = true;
 
   // slots contains sub templates defined with t-set inside t-component nodes, and
   // are meant to be used by the t-slot directive.


### PR DESCRIPTION
It is useful to be able to disable the t-transition directive for
testing purposes.  This commit introduces a global config flag to do
just that.

closes #768