### PR TITLE
[FIX] config: make enableTransitions work on components

### DIFF
--- a/doc/reference/event_handling.md
+++ b/doc/reference/event_handling.md
@@ -85,8 +85,9 @@ Note that if you work with Typescript, the `trigger` method is generic on the ty
 You can then describe the type of the event, so you will see typing errors...
 
 ```typescript
-this.trigger<MyCustomPayload>('my-custom-event', payload);
+this.trigger<MyCustomPayload>("my-custom-event", payload);
 ```
+
 ```typescript
 myCustomEventHandler(ev: OwlEvent<MyCustomPayload>) { ... }
 ```

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -433,7 +433,7 @@ export class Component<Props extends {} = any, T extends Env = Env> {
    * up to the parent DOM nodes. Thus, it must be called between mounted() and
    * willUnmount().
    */
-  trigger<T=any>(eventType: string, payload?: T) {
+  trigger<T = any>(eventType: string, payload?: T) {
     this.__trigger<T>(this, eventType, payload);
   }
 

--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -227,7 +227,9 @@ QWeb.addDirective({
       if (name.startsWith("t-on-")) {
         events.push([name, value]);
       } else if (name === "t-transition") {
-        transition = value;
+        if (QWeb.enableTransitions) {
+          transition = value;
+        }
       } else if (!name.startsWith("t-")) {
         if (name !== "class" && name !== "style") {
           // this is a prop!


### PR DESCRIPTION
Fun: the transition is handled at two different places, once for dom
nodes, once for components.  Obviously, I only applied the change to the
first case and forgot about the second.