### PR TITLE
[FIX] slots: prevent infinite loop in some cases

### DIFF
--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -436,6 +436,7 @@ QWeb.addDirective({
               isInSubComponent = true;
               break;
             }
+            el = el.parentElement;
           }
           if (isInSubComponent) {
             continue;

--- a/tests/component/slots.test.ts
+++ b/tests/component/slots.test.ts
@@ -1052,4 +1052,37 @@ describe("t-slot directive", () => {
       "<div><child><p>Ablip</p>default2<child>default1<p>Bblip</p></child></child></div>"
     );
   });
+
+  test("named slot inside slot, part 3", async () => {
+    class Child extends Component {
+      static template = xml`
+        <div>
+          <t t-slot="brol"/>
+          <t t-slot="default"/>
+        </div>`;
+    }
+    class Parent extends Component {
+      static template = xml`
+        <div>
+          <Child>
+            <t t-set-slot="brol">
+              <p>A<t t-esc="value"/></p>
+            </t>
+            <Child>
+              <t>
+                <t t-set-slot="brol">
+                  <p>B<t t-esc="value"/></p>
+                </t>
+              </t>
+            </Child>
+          </Child>
+        </div>`;
+      static components = { Child };
+      value = "blip";
+    }
+    const parent = new Parent();
+    await parent.mount(fixture);
+
+    expect(fixture.innerHTML).toBe("<div><div><p>Ablip</p><div><p>Bblip</p></div></div></div>");
+  });
 });

--- a/tools/release.js
+++ b/tools/release.js
@@ -87,7 +87,7 @@ async function startRelease() {
 
   // ---------------------------------------------------------------------------
 
-  log('Step 7/${STEPS}: Creating the release...');
+  log(`Step 7/${STEPS}: Creating the release...`);
   const relaseResult = await execCommand(`gh release create v${next} dist/*.js ${draft} -F release-notes.md`);
   if (relaseResult !== 0) {
     log("github release failed. Aborting.");


### PR DESCRIPTION
The reviewer for the commit on named slots inside named slots did not
notice that there was an infinite loop.  Because of his sloppiness, Owl
could block in an infinite loop when a named t-slots was defined inside
a subcomponent, but not as a direct child.