### PR TITLE
Create cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+    
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'cla check' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.0.1-alpha
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with: 
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/odoo/odoo/blob/master/doc/cla/icla-1.0.md' # e.g. a CLA or a DCO document
+          branch: 'master'
+          allowlist: SimonGenin,brboi,kebeclibre,*-odoo,bot*
+          use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
+          
+         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)   
+          #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'


### PR DESCRIPTION
Add a github action to check sure the CLA of odoo has been signed.

How does it work: 
When a PR is created, the action check if the user has either signed the CLA or the user is in a whitelist (a few github names from the js team + every user name ending with "-odoo" + all the bots). 
If it's not the case, a comment will ask the user to add a comment looking like "I agree with the cla bla bla bla". When this comment is detected, a small commit is made to the project adding his signature inside the signature/cla.json file. 
There is also the possibility to relaunch the cla action by adding a comment "cla check". Useful if we add a person to the whitelist and want to make the action green after that.

There are a few options possible: original doc here : https://github.com/cla-assistant/github-action