### PR TITLE
[FIX] properly translate terms surrounded by spaces

### DIFF
--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -496,7 +496,8 @@ export class QWeb extends EventBus {
       }
       if (this.translateFn) {
         if ((node.parentNode as any).getAttribute("t-translation") !== "off") {
-          text = this.translateFn(text);
+          let match = /^(\s*)([\s\S]+?)(\s*)$/.exec(text);
+          text = match[1] + this.translateFn(match[2]) + match[3];
         }
       }
       if (ctx.parentNode) {


### PR DESCRIPTION
This reimplements logic from Odoo v13 [1], i.e. if we have a text that follows
by space e.g. "This database will expire in " [2], then we want get translation
for the term without that space and add the space manually. This way we can
export trimmed terms and don't miss the space, when atranslator forget to add it
at the end of translation

[1] https://github.com/odoo/odoo/blob/26927417e2957acba6fb79446c2520107daa7eea/addons/web/static/src/js/core/qweb.js#L46
[2] https://github.com/odoo/enterprise/blob/ab0e893493f909ec3033e8a1cf6c141ea9375587/web_enterprise/static/src/xml/base.xml#L21

---

opw-2410708