### PR TITLE
[FIX] component: force mounting subcomponents with shouldUpdate

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -333,7 +333,7 @@ export class Component<Props extends {} = any, T extends Env = Env> {
       message += `\nMaybe the DOM is not ready yet? (in that case, you can use owl.utils.whenReady)`;
       throw new Error(message);
     }
-    const fiber = new Fiber(null, this, false, target, position);
+    const fiber = new Fiber(null, this, true, target, position);
     fiber.shouldPatch = false;
     if (!__owl__.vnode) {
       this.__prepareAndRender(fiber, () => {});


### PR DESCRIPTION
Components can implement shouldUpdate to return false.  In that case,
renderings coming from above should be ignored.

However, if the component was unmounted and is remounted, we actually
need to force a rerendering in that case, so it is mounted, otherwise
the subcomponent is left in unmounted state, which means that rendering
are ignored.

closes #800