### PR TITLE
[FIX] store: properly render, even if shouldupdate is implemented

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -115,16 +115,6 @@ export function useContextWithCB(ctx: Context, component: Component, method): an
     __owl__.observer = new Observer();
     __owl__.observer.notifyCB = component.render.bind(component);
   }
-  const currentCB = __owl__.observer.notifyCB;
-  __owl__.observer.notifyCB = function () {
-    if (ctx.rev > mapping[id]) {
-      // in this case, the context has been updated since we were rendering
-      // last, and we do not need to render here with the observer. A
-      // rendering is coming anyway, with the correct props.
-      return;
-    }
-    currentCB();
-  };
 
   mapping[id] = 0;
   const renderFn = __owl__.renderFn;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,4 @@
-import { Component } from "./component/component";
-import { Env } from "./component/component";
+import { Component, Env } from "./component/component";
 import { Context, useContextWithCB } from "./context";
 import { onWillUpdateProps } from "./hooks";
 

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -289,7 +289,26 @@ describe("Context", () => {
     expect(testContext.subscriptions.update.length).toBe(0);
   });
 
-  test("concurrent renderings", async () => {
+  test.skip("concurrent renderings", async () => {
+    /**
+     * Note: this test is interesting, but sadly just an incomplete attempt at
+     * protecting users against themselves.  With the context API, it is not
+     * possible for the framework to protect completely against crashes.  Maybe
+     * like in this case, when a component is in a simple hierarchy where all
+     * renderings come from the context changes, but in a real case, where some
+     * code can trigger a rendering independently, it is insufficient.
+     *
+     * The main problem is that the sub component depends on some external state,
+     * which may be modified, and then incompatible with the component actual
+     * state (for example, if the sub component has an id key related to some
+     * object that has been removed from the context).
+     *
+     * For now, sadly, the only solution is that components that depends on external
+     * state should guarantee their own integrity themselves. Then maybe this
+     * could be solved at the level of a state management solution that has a
+     * more advanced API, to let components determine if they should be updated
+     * or not (so, something slightly more advanced that the useStore hook).
+     */
     const testContext = new Context({ x: { n: 1 }, key: "x" });
     const def = makeDeferred();
     let stateC;


### PR DESCRIPTION
Before this commit, an unwanted behaviour happened when using components
with shouldUpdate implemented, and store/state.

The actual problem is the following: the sub component is using a store,
and shouldupdate.  Whenever the component is rendered, it checks if there is an incoming
rendering from the context.  If that is the case, it skips the
rendering, because we actually only want to be rendered by the store
rendering (otherwise, we may run into issue with inconsistent data (more
recent data from the context, older data in the component).

However, if shouldUpdate is implemented, then the rendering coming from
the context simply does not arrive.  To fix this, we just force these
renderings to go through all children, regardless of their shouldUpdate
status.

closes #799