### PR TITLE
[FIX] component: propagate correct info when reusing fibers

### DIFF
--- a/doc/reference/component.md
+++ b/doc/reference/component.md
@@ -10,13 +10,21 @@
   - [Static Properties](#static-properties)
   - [Methods](#methods)
   - [Lifecycle](#lifecycle)
+    - [`constructor(parent, props)`](#constructorparent-props)
+    - [`willStart()`](#willstart)
+    - [`mounted()`](#mounted)
+    - [`willUpdateProps(nextProps)`](#willupdatepropsnextprops)
+    - [`willPatch()`](#willpatch)
+    - [`patched(snapshot)`](#patchedsnapshot)
+    - [`willUnmount()`](#willunmount)
+    - [`catchError(error)`](#catcherrorerror)
   - [Root Component](#root-component)
   - [Composition](#composition)
   - [Form Input Bindings](#form-input-bindings)
   - [References](#references)
   - [Dynamic sub components](#dynamic-sub-components)
   - [Functional Components](#functional-components)
-  - [SVG components](#svg-components)
+  - [SVG Components](#svg-components)
 
 ## Overview
 
@@ -289,8 +297,13 @@ We explain here all the public methods of the `Component` class.
   are updated. It returns a boolean, which indicates if the component should
   ignore a props update. If it returns false, then `willUpdateProps` will not
   be called, and no rendering will occur. Its default implementation is to
-  always return true. This is an optimization, similar to React's `shouldComponentUpdate`. Most of the time, this should not be used, but it
-  can be useful if we are handling large number of components.
+  always return true. Note that this is an optimization, similar to React's `shouldComponentUpdate`. Most of the time, this should not be used, but it
+  can be useful if we are handling large number of components. Since this is an
+  optimization, Owl has the freedom to ignore the result of `shouldUpdate` in
+  some cases (for example, if a component is remounted, or if we want to force
+  a full rerender of the UI). However, if `shouldUpdate` returns true, then Owl
+  provides the guarantee that the component will be rendered at some point in
+  the future (except if the component is destroyed or if some part of the UI crashes).
 
 * **`destroy()`**. As its name suggests, this method will remove the component,
   and perform all necessary cleanup, such as unmounting the component, its children,

--- a/src/component/fiber.ts
+++ b/src/component/fiber.ts
@@ -82,6 +82,7 @@ export class Fiber {
 
     let oldFiber = __owl__.currentFiber;
     if (oldFiber && !oldFiber.isCompleted) {
+      this.force = true;
       if (oldFiber.root === oldFiber && !parent) {
         // both oldFiber and this fiber are root fibers
         this._reuseFiber(oldFiber);


### PR DESCRIPTION
In some cases, a rendering initiated in some component is then remapped
into a larger rendering initiated by some parent.

If we have some components which implement shouldUpdate to return false,
then the following scenario can happen:

- some parent component is mounted (which triggers a rendering with
force: true => bypass the shouldUpdate)
- some sub component is updated and rerendered, AFTER the previous
rendering goes through it
- the sub component notices that there is an ongoing rendering, and
  remaps itself in the parent rendering

Before this commit, the new fiber in the subcomponent does not have
force flag set to true, so the new rendering for the subcomponent does
not go through its own children (if they have shouldUpdate=false)

With this commit, we make sure that the flag of the new fiber is set to
true.

closes #818