### PR TITLE
[FIX] qweb: prevent issue with builtin object properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "github-api": "^3.3.0",
     "jest": "^23.6.0",
     "jest-environment-jsdom": "^24.7.1",
-    "live-server": "^1.2.3",
+    "live-server": "^1.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
     "rollup": "^1.6.0",

--- a/src/qweb/expression_parser.ts
+++ b/src/qweb/expression_parser.ts
@@ -29,14 +29,14 @@ const RESERVED_WORDS = "true,false,NaN,null,undefined,debugger,console,window,in
   ","
 );
 
-const WORD_REPLACEMENT = {
+const WORD_REPLACEMENT = Object.assign(Object.create(null), {
   and: "&&",
   or: "||",
   gt: ">",
   gte: ">=",
   lt: "<",
   lte: "<=",
-};
+});
 
 export interface QWebVar {
   id: string; // foo
@@ -69,7 +69,7 @@ interface Token {
   varName?: string;
 }
 
-const STATIC_TOKEN_MAP: { [key: string]: TKind } = {
+const STATIC_TOKEN_MAP: { [key: string]: TKind } = Object.assign(Object.create(null), {
   "{": "LEFT_BRACE",
   "}": "RIGHT_BRACE",
   "[": "LEFT_BRACKET",
@@ -78,7 +78,7 @@ const STATIC_TOKEN_MAP: { [key: string]: TKind } = {
   ",": "COMMA",
   "(": "LEFT_PAREN",
   ")": "RIGHT_PAREN",
-};
+});
 
 // note that the space after typeof is relevant. It makes sure that the formatted
 // expression has a space after typeof

--- a/tests/qweb/qweb_expressions.test.ts
+++ b/tests/qweb/qweb_expressions.test.ts
@@ -196,4 +196,8 @@ describe("expression evaluation", () => {
     expect(compileExpr("f(...state.list)", {})).toBe("scope['f'](...scope['state'].list)");
     expect(compileExpr("f([...list])", {})).toBe("scope['f']([...scope['list']])");
   });
+
+  test("works with builtin properties", () => {
+    expect(compileExpr("state.constructor.name", {})).toBe("scope['state'].constructor.name");
+  });
 });


### PR DESCRIPTION
The QWeb expression parser use an object as a mapping between some
strings and the desired output in the compiled template.  However, as we
should all know, objects are not Maps, they have some additional
properties, such as "constructor" or "hasOwnProperty".

The simple solution is to make sure the mapping object does not have
anything in its prototype chain to pollute its purpose.

closes #835