### PR TITLE
[FIX] extensions: guarantee to call transitionend callback

### DIFF
--- a/doc/reference/config.md
+++ b/doc/reference/config.md
@@ -6,6 +6,7 @@ global `config` object. It provides two settings:
 
 - [`mode`](#mode) (default value: `prod`),
 - [`enableTransitions`](#enabletransitions) (default value: `true`).
+- [`guaranteeTransitionEnd`](#guaranteetransitionend) (default value: `false`).
 
 ## Mode
 
@@ -42,3 +43,15 @@ owl.config.enableTransitions = false;
 
 Note that it suffers from the same drawback as the "dev" mode: all compiled
 templates, if any, will keep their current behaviours.
+
+## `guaranteeTransitionEnd`
+
+This is applicable to elements/components having the `t-transition` directive.
+
+Setting this value to `true` ensures that the callback for `transitionend` event
+will be called even if the `transitionend` event failed to trigger at the end of
+transition.
+
+```js
+owl.config.guaranteeTransitionEnd = true;
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import { QWeb } from "./qweb/index";
 interface Config {
   mode: string;
   enableTransitions: boolean;
+  guaranteeTransitionEnd: boolean;
 }
 
 export const config = {} as Config;
@@ -36,5 +37,14 @@ Object.defineProperty(config, "enableTransitions", {
   },
   set(value: boolean) {
     QWeb.enableTransitions = value;
+  },
+});
+
+Object.defineProperty(config, "guaranteeTransitionEnd", {
+  get() {
+    return QWeb.guaranteeTransitionEnd;
+  },
+  set(value: boolean) {
+    QWeb.guaranteeTransitionEnd = value;
   },
 });

--- a/src/qweb/extensions.ts
+++ b/src/qweb/extensions.ts
@@ -198,14 +198,18 @@ function whenTransitionEnd(elm: HTMLElement, cb) {
   const durations: Array<string> = (styles.transitionDuration || "").split(", ");
   const timeout: number = getTimeout(delays, durations);
   if (timeout > 0) {
-    const transitionEndCB = () => {
-      if (!elm.parentNode) return;
-      cb();
-      browser.clearTimeout(fallbackTimeout);
-      elm.removeEventListener('transitionend', transitionEndCB);
+    if (!QWeb.guaranteeTransitionEnd) {
+      elm.addEventListener("transitionend", cb, { once: true });
+    } else {
+      const transitionEndCB = () => {
+        if (!elm.parentNode) return;
+        cb();
+        browser.clearTimeout(fallbackTimeout);
+        elm.removeEventListener("transitionend", transitionEndCB);
+      };
+      elm.addEventListener("transitionend", transitionEndCB, { once: true });
+      const fallbackTimeout = browser.setTimeout(transitionEndCB, timeout + 50);
     }
-    elm.addEventListener("transitionend", transitionEndCB, { once: true });
-    const fallbackTimeout = browser.setTimeout(transitionEndCB, timeout + 50);
   } else {
     cb();
   }

--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -214,6 +214,7 @@ export class QWeb extends EventBus {
   // dev mode enables better error messages or more costly validations
   static dev: boolean = false;
   static enableTransitions: boolean = true;
+  static guaranteeTransitionEnd: boolean = false;
 
   // slots contains sub templates defined with t-set inside t-component nodes, and
   // are meant to be used by the t-slot directive.


### PR DESCRIPTION
There is a possibility that the transitionend event of an element/component
with t-transition directive won't trigger. Though this situation is
difficult to assert, it was observe in odoo runbot for the pos ui.

When the transitionend event is not fired, the callback that removes
the element from the dom won't be called, resulting to a corrupted view.
An example of which is the following:

```html
<div t-if="show" t-transition="fade">Hello</div>
```

If `show` is set to false by some ui action and by any chance the
transitionend event is not fired (perhaps because the transition didn't
actually start or because of completely unknown reason), the div element
will remain in the view -- and this is not desirable.

This commit patches this situation such that if after 50ms that the
transitionend event is supposed to be fired but the event isn't fired, we
force the callback using a setTimeout. This guarantees the call of the
callback that is suppose to remove the element from the view.