### PR TITLE
[IMP] directive: make props override t-props

### DIFF
--- a/src/component/directive.ts
+++ b/src/component/directive.ts
@@ -336,7 +336,7 @@ QWeb.addDirective({
     }
     if (hasDynamicProps) {
       const dynamicProp = ctx.formatExpression(node.getAttribute("t-props")!);
-      ctx.addLine(`let props${componentID} = Object.assign({${propStr}}, ${dynamicProp});`);
+      ctx.addLine(`let props${componentID} = Object.assign({}, ${dynamicProp}, {${propStr}});`);
     } else {
       ctx.addLine(`let props${componentID} = {${propStr}};`);
     }

--- a/tests/component/__snapshots__/component.test.ts.snap
+++ b/tests/component/__snapshots__/component.test.ts.snap
@@ -467,7 +467,7 @@ exports[`dynamic t-props basic use 1`] = `
     let vn1 = h('div', p1, c1);
     // Component 'Child'
     let w2 = '__3__' in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap['__3__']] : false;
-    let props2 = Object.assign({}, scope['some'].obj);
+    let props2 = Object.assign({}, scope['some'].obj, {});
     if (w2 && w2.__owl__.currentFiber && !w2.__owl__.vnode) {
         w2.destroy();
         w2 = false;

--- a/tests/component/component.test.ts
+++ b/tests/component/component.test.ts
@@ -4040,6 +4040,30 @@ describe("dynamic t-props", () => {
     expect(fixture.innerHTML).toBe("<div><span>3</span></div>");
     expect(env.qweb.templates[Parent.template].fn.toString()).toMatchSnapshot();
   });
+
+  test("t-props with props", async () => {
+    expect.assertions(1);
+
+    class Child extends Component {
+      static template = xml`<div />`;
+      setup() {
+        expect(this.props).toEqual({ a: 1, b: 2, c: "c" });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`
+        <div>
+            <Child t-props="props" a="1" b="2" />
+        </div>
+      `;
+      static components = { Child };
+
+      props = { a: "a", c: "c" };
+    }
+
+    const widget = new Parent();
+    await widget.mount(fixture);
+  });
 });
 
 describe("support svg components", () => {

--- a/tests/router/__snapshots__/route_component.test.ts.snap
+++ b/tests/router/__snapshots__/route_component.test.ts.snap
@@ -18,7 +18,7 @@ exports[`RouteComponent can render simple cases 1`] = `
             let w4 = k5 in parent.__owl__.cmap ? parent.__owl__.children[parent.__owl__.cmap[k5]] : false;
             let vn6 = {};
             result = vn6;
-            let props4 = Object.assign({}, scope['env'].router.currentParams);
+            let props4 = Object.assign({}, scope['env'].router.currentParams, {});
             if (w4 && w4.__owl__.currentFiber && !w4.__owl__.vnode) {
                 w4.destroy();
                 w4 = false;


### PR DESCRIPTION
Before this commit, props and t-props were computed like
`Object.assign(props, t_props)`.
Now, it computes like `Object.assign(t_props, props)` so props will
override t-props.

closes https://github.com/odoo/owl/issues/886