### PR TITLE
[FIX] qweb: properly parse short object description

### DIFF
--- a/tests/qweb/qweb_expressions.test.ts
+++ b/tests/qweb/qweb_expressions.test.ts
@@ -200,4 +200,10 @@ describe("expression evaluation", () => {
   test("works with builtin properties", () => {
     expect(compileExpr("state.constructor.name", {})).toBe("scope['state'].constructor.name");
   });
+
+  test("works with shortcut object key description", () => {
+    expect(compileExpr("{a}", {})).toBe("{a:scope['a']}");
+    expect(compileExpr("{a,b}", {})).toBe("{a:scope['a'],b:scope['b']}");
+    expect(compileExpr("{a,b:3,c}", {})).toBe("{a:scope['a'],b:3,c:scope['c']}");
+  });
 });


### PR DESCRIPTION
Before this commit, using an expression such as "{machin}" was compiled
in qweb into "{scope['machin']}" which is not valid.

With this commit, we instead transform it into "{machin:
scope['machin']}".

closes #885