### PR TITLE
[IMP] router: allow query string in paths

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -125,7 +125,10 @@ export class Router {
     const initialParams = this.currentParams;
     const result = await this.matchAndApplyRules(path);
     if (result.type === "match") {
-      const finalPath = this.routeToPath(result.route, result.params);
+      let finalPath = this.routeToPath(result.route, result.params);
+      if (path.indexOf('?') > -1) {
+        finalPath += '?' + path.split('?')[1]
+      }
       const isPopStateEvent = ev && ev instanceof PopStateEvent;
       if (!isPopStateEvent) {
         this.setUrlFromPath(finalPath);
@@ -238,6 +241,9 @@ export class Router {
   private getRouteParams(route: Route, path: string): RouteParams | false {
     if (route.path === "*") {
       return {};
+    }
+    if (path.indexOf('?') > -1) {
+      path = path.split('?')[0];
     }
     if (path.startsWith("#")) {
       path = path.slice(1);

--- a/tests/router/router.test.ts
+++ b/tests/router/router.test.ts
@@ -60,6 +60,13 @@ describe("router miscellaneous", () => {
     await router.navigate({ to: "users", params: { id: 3 } });
     expect(window.location.href).toBe("http://localhost/test.html#/users/3");
   });
+
+  test("navigate using path and query string should preserve query string", async () => {
+    router = new TestRouter(env, [{ name: "users", path: "/users/{{id}}" }]);
+    await router.navigate({ path: "/users/3?test=1" });
+    expect(window.location.pathname).toBe("/users/3");
+    expect(window.location.search).toBe("?test=1");
+  });
 });
 
 describe("routeToPath", () => {
@@ -115,6 +122,13 @@ describe("getRouteParams", () => {
 
     // fallback route
     expect(getRouteParams({ path: "*" }, "somepath")).toEqual({});
+  });
+
+  test("properly match routes with query params", () => {
+
+    expect(getRouteParams({ path: "/home" }, "/home?test=1")).toEqual({});
+    expect(getRouteParams({ path: "/home" }, "/home?test1=1&test2=2")).toEqual({});
+
   });
 
   test("properly match simple routes, mode hash", () => {


### PR DESCRIPTION
We're starting to use OWL for modern front-end development, however the router did not allow navigating to paths with a query string in the URL, e.g.

```js
router.navigate({ path: '/tasks/search?query=test&count=20' })
```
did not match the `/tasks/search` path.

Now it does :)

I've added tests. Let me know if you need anything further.