### PR TITLE
Inform user to use http.server with python3

### DIFF
--- a/doc/learning/quick_start.md
+++ b/doc/learning/quick_start.md
@@ -145,7 +145,7 @@ a `.js` suffix, which is important. Most text editor can understand this syntax
 and will provide autocompletion.
 
 Now, to execute this code, we need to serve the `src` folder statically. A low
-tech way to do that is to use for example the python `SimpleHTTPServer` feature:
+tech way to do that is to use for example the python `SimpleHTTPServer` feature (if you're using python3, you will use `http.server` feature instead of `SimpleHTTPServer`):
 
 ```
 $ cd src


### PR DESCRIPTION
In python3, `SimpleHTTPServer` wasn't working for me so I had to use `http.server`. Source: https://www.journaldev.com/15915/python-simplehttpserver-http-server