### PR TITLE
[FIX] remove indeterminism in animation tests

### DIFF
--- a/tests/animations.test.ts
+++ b/tests/animations.test.ts
@@ -420,29 +420,29 @@ describe("animations", () => {
 
     widget.state.flag = true;
 
-    await nextFrame();
+    await nextFrame(3);
     widget.el!.querySelector("span")!.dispatchEvent(new Event("transitionend"));
     expect(fixture.innerHTML).toBe('<div><span class="">blue</span></div>');
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(1);
 
     widget.state.flag = false;
-    await nextFrame();
+    await nextFrame(3);
     expect(fixture.innerHTML).toBe(
       '<div><span class="chimay-leave-active chimay-leave-to" data-owl-key="__3__">blue</span></div>'
     );
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(1);
 
     widget.state.flag = true;
-    await nextFrame();
+    await nextFrame(3);
     expect(fixture.innerHTML).toBe(
       '<div><span class="chimay-enter-active chimay-enter-to" data-owl-key="__3__">blue</span></div>'
     );
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(2);
 
     widget.state.flag = false;
-    await nextFrame();
+    await nextFrame(3);
     widget.state.flag = true;
-    await nextFrame();
+    await nextFrame(3);
 
     expect(QWeb.utils.transitionInsert).toBeCalledTimes(3);
     widget.el!.querySelector("span")!.dispatchEvent(new Event("transitionend"));

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -41,9 +41,10 @@ export async function nextTick(): Promise<void> {
   await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
 }
 
-export async function nextFrame(): Promise<void> {
-  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
-  await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
+export async function nextFrame(numberOfAnimationFrames: number = 2): Promise<void> {
+  for (let i = 0; i < numberOfAnimationFrames; i++) {
+    await new Promise((resolve) => scheduler.requestAnimationFrame(resolve));
+  }
 }
 
 export function makeTestFixture() {


### PR DESCRIPTION
Animations have quite a few intricate calls to request next animation
frames. On quick devices, the helper method nextFrame made of 2
request of animation frames would not be enough and race condition
problems would rise.

The fix is simply to ask the nextFrame helper to do a third request
of animation frame in the animation tests, making the test deterministic
on a very fast device. Hopefully, this should be enough.