### PR TITLE
[IMP] components: add back style_class tests

### DIFF
--- a/tests/components/__snapshots__/style_class.test.ts.snap
+++ b/tests/components/__snapshots__/style_class.test.ts.snap
@@ -137,6 +137,21 @@ exports[`style and class handling can set style and class inside component 1`] =
 }"
 `;
 
+exports[`style and class handling class on components do not interfere with user defined classes 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  let block1 = createBlock(\`<div block-attribute-0=\\"class\\"/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = {c:ctx['state'].c};
+    return block1([d1]);
+  }
+}"
+`;
+
 exports[`style and class handling class on sub component, which is switched to another 1`] = `
 "function anonymous(bdom, helpers
 ) {
@@ -281,6 +296,33 @@ exports[`style and class handling component class and parent class combine toget
 }"
 `;
 
+exports[`style and class handling dynamic t-att-style is properly added and updated on widget root el 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  let block1 = createBlock(\`<div block-attribute-0=\\"style\\"/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = {'font-size':'20px',...ctx['props'].style};
+    return block1([d1]);
+  }
+}"
+`;
+
+exports[`style and class handling dynamic t-att-style is properly added and updated on widget root el 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`Child\`, {style: ctx['state'].style}, key + \`__1\`, node, ctx);
+  }
+}"
+`;
+
 exports[`style and class handling empty class attribute is not added on widget root el 1`] = `
 "function anonymous(bdom, helpers
 ) {
@@ -307,6 +349,34 @@ exports[`style and class handling empty class attribute is not added on widget r
   return function template(ctx, node, key = \\"\\") {
     let b2 = component(\`Child\`, {class: undefined}, key + \`__1\`, node, ctx);
     return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`style and class handling error in subcomponent with class 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  let block1 = createBlock(\`<div block-attribute-0=\\"class\\"><block-text-1/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = ctx['props'].class;
+    let d2 = this.will.crash;
+    return block1([d1, d2]);
+  }
+}"
+`;
+
+exports[`style and class handling error in subcomponent with class 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`Child\`, {class: 'a'}, key + \`__1\`, node, ctx);
   }
 }"
 `;
@@ -360,6 +430,33 @@ exports[`style and class handling no class is set is parent does not give it as 
   
   return function template(ctx, node, key = \\"\\") {
     return component(\`Child\`, {}, key + \`__1\`, node, ctx);
+  }
+}"
+`;
+
+exports[`style and class handling style is properly added on widget root el 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  let block1 = createBlock(\`<div block-attribute-0=\\"style\\"/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = ctx['props'].style;
+    return block1([d1]);
+  }
+}"
+`;
+
+exports[`style and class handling style is properly added on widget root el 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, shallowEqual } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`Child\`, {style: 'font-weight: bold;'}, key + \`__1\`, node, ctx);
   }
 }"
 `;


### PR DESCRIPTION
The tests have been adapted to the new way of doing things, some tests
are skipped because they rely on features that are not implemented yet