### PR TITLE
[FIX] components/fiber: Call patch only if target is valid

### DIFF
--- a/src/component/fiber.ts
+++ b/src/component/fiber.ts
@@ -243,8 +243,9 @@ export class Fiber {
         }
         component.__patch(target!, fiber.vnode!);
       } else {
-        if (fiber.shouldPatch) {
-          component.__patch(component.__owl__.vnode!, fiber.vnode!);
+        const vnode = component.__owl__.vnode;
+        if (fiber.shouldPatch && vnode) {
+          component.__patch(vnode, fiber.vnode!);
           // When updating a Component's props (in directive),
           // the component has a pvnode AND should be patched.
           // However, its pvnode.elm may have changed if it is a High Order Component


### PR DESCRIPTION
Currently in some cases, adding an attachment via lognote creates a traceback.
Error : shouldPatch is true while `vnode` is not defined, so `patch()` failed
This is a hotfix correcting this problem by calling `patch()` only if `shouldPatch` is true **and** the `vnode` is set.

opw-2645203