### PR TITLE
[IMP] qweb/components: remove t-ref on components

### DIFF
--- a/src/qweb/compiler.ts
+++ b/src/qweb/compiler.ts
@@ -257,8 +257,7 @@ export class QWebCompiler {
     return block;
   }
 
-  insertBlock(expression: string, block: BlockDescription, ctx: Context): string | null {
-    let id: string | null = null;
+  insertBlock(expression: string, block: BlockDescription, ctx: Context): void {
     let blockExpr = block.generateExpr(expression);
     const tKeyExpr = ctx.tKeyExpr;
     if (block.parentVar) {
@@ -267,7 +266,7 @@ export class QWebCompiler {
         keyArg = `${tKeyExpr} + ${keyArg}`;
       }
       this.addLine(`${block.parentVar}[${ctx.index}] = withKey(${blockExpr}, ${keyArg});`);
-      return id;
+      return;
     }
 
     if (tKeyExpr) {
@@ -279,7 +278,6 @@ export class QWebCompiler {
     } else {
       this.addLine(`let ${block.varName} = ${blockExpr};`);
     }
-    return id;
   }
 
   generateCode(): string {

--- a/src/qweb/compiler.ts
+++ b/src/qweb/compiler.ts
@@ -1016,7 +1016,6 @@ export class QWebCompiler {
         const subCtx: Context = createContext(ctx);
         this.compileAST(ast.slots[slotName], subCtx);
         if (this.hasRef) {
-          slot.signature = "ctx => node => {";
           slot.code.unshift(`  const refs = ctx.__owl__.refs`);
           slotStr.push(`'${slotName}': ${name}(${ctxStr})`);
         } else {

--- a/src/qweb/inline_expressions.ts
+++ b/src/qweb/inline_expressions.ts
@@ -25,9 +25,10 @@
 // Misc types, constants and helpers
 //------------------------------------------------------------------------------
 
-const RESERVED_WORDS = "true,false,NaN,null,undefined,debugger,console,window,in,instanceof,new,function,return,this,eval,void,Math,RegExp,Array,Object,Date".split(
-  ","
-);
+const RESERVED_WORDS =
+  "true,false,NaN,null,undefined,debugger,console,window,in,instanceof,new,function,return,this,eval,void,Math,RegExp,Array,Object,Date".split(
+    ","
+  );
 
 const WORD_REPLACEMENT: { [key: string]: string } = Object.assign(Object.create(null), {
   and: "&&",

--- a/src/qweb/parser.ts
+++ b/src/qweb/parser.ts
@@ -296,11 +296,8 @@ function parseDOMNode(node: Element, ctx: ParsingContext): AST | null {
   if (tagName === "pre") {
     ctx = { inPreTag: true };
   }
-  let ref = null;
-  if (node.hasAttribute("t-ref")) {
-    ref = node.getAttribute("t-ref");
-    node.removeAttribute("t-ref");
-  }
+  const ref = node.getAttribute("t-ref");
+  node.removeAttribute("t-ref");
 
   for (let child of node.childNodes) {
     const ast = parseNode(child, ctx);

--- a/src/qweb/template_helpers.ts
+++ b/src/qweb/template_helpers.ts
@@ -18,7 +18,7 @@ function callSlot(
   name: string,
   defaultSlot?: (ctx: any, key: string) => BDom,
   dynamic?: boolean
-): BDom | null {
+): BDom {
   const slots = ctx.__owl__.slots;
   const slotFn = slots[name];
   const slotBDom = slotFn ? slotFn(parent, key) : null;
@@ -33,7 +33,7 @@ function callSlot(
     }
     return multi([child1, child2]);
   }
-  return slotBDom;
+  return slotBDom || text("");
 }
 
 function capture(ctx: any): any {

--- a/src/refs.ts
+++ b/src/refs.ts
@@ -2,35 +2,17 @@
 // useRef
 // -----------------------------------------------------------------------------
 
-import type { Component } from "./component/component";
 import { getCurrent } from "./component/component_node";
 
 /**
  * The purpose of this hook is to allow components to get a reference to a sub
  * html node or component.
  */
-interface Ref<C extends Component = Component> {
-  el: HTMLElement | null;
-  comp: C | null;
-}
-
-export function useRef<C extends Component = Component>(name: string): Ref<C> {
+export function useRef<T extends HTMLElement = HTMLElement>(name: string): { el: T | null } {
   const node = getCurrent()!;
   return {
-    get el(): HTMLElement | null {
-      const val = node.refs[name];
-      return val || null;
-      // if (val instanceof HTMLElement) {
-      //   return val;
-      // } else if (val instanceof Component) {
-      //   return val.el;
-      // }
-      // return null;
-    },
-    get comp(): C | null {
-      return null;
-      // const val = node.refs && node.refs[name];
-      // return val instanceof Component ? (val as C) : null;
+    get el(): T | null {
+      return node.refs[name] || null;
     },
   };
 }

--- a/tests/components/__snapshots__/refs.test.ts.snap
+++ b/tests/components/__snapshots__/refs.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refs basic use 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  
+  let block1 = createBlock(\`<div block-ref=\\"0\\"/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const refs = ctx.__owl__.refs;
+    let d1 = (el) => refs[\`div\`] = el;
+    return block1([d1]);
+  }
+}"
+`;
+
 exports[`refs refs are properly bound in slots 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/__snapshots__/refs.test.ts.snap
+++ b/tests/components/__snapshots__/refs.test.ts.snap
@@ -41,7 +41,7 @@ exports[`refs refs are properly bound in slots 2`] = `
   let block1 = createBlock(\`<div><span class=\\"counter\\"><block-text-0/></span><block-child-0/></div>\`);
   let block2 = createBlock(\`<button block-handler-0=\\"click\\" block-ref=\\"1\\">do something</button>\`);
   
-  const slot3 = ctx => node => {
+  const slot3 = ctx => (node, key) => {
     const refs = ctx.__owl__.refs
     let d2 = [ctx, 'doSomething'];
     let d3 = (el) => refs[\`myButton\`] = el;

--- a/tests/components/__snapshots__/slots.test.ts.snap
+++ b/tests/components/__snapshots__/slots.test.ts.snap
@@ -43,6 +43,42 @@ exports[`slots can define and call slots 2`] = `
 }"
 `;
 
+exports[`slots can render node with t-ref and Component in same slot 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return callSlot(ctx, node, key, 'default');
+  }
+}"
+`;
+
+exports[`slots can render node with t-ref and Component in same slot 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  let assign = Object.assign;
+  
+  let block2 = createBlock(\`<div block-ref=\\"0\\"/>\`);
+  
+  const slot2 = ctx => (node, key) => {
+    const refs = ctx.__owl__.refs
+    let d1 = (el) => refs[\`div\`] = el;
+    let b2 = block2([d1]);
+    let b3 = component(\`Child\`, {}, key + \`__3\`, node, ctx);
+    return multi([b2, b3]);
+  }
+  
+  return function template(ctx, node, key = \\"\\") {
+    const refs = ctx.__owl__.refs;
+    return assign(component(\`Child\`, {}, key + \`__1\`, node, ctx), {slots: {'default': slot2(ctx)}});
+  }
+}"
+`;
+
 exports[`slots can render only empty slot 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/__snapshots__/slots.test.ts.snap
+++ b/tests/components/__snapshots__/slots.test.ts.snap
@@ -43,6 +43,18 @@ exports[`slots can define and call slots 2`] = `
 }"
 `;
 
+exports[`slots can render only empty slot 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return callSlot(ctx, node, key, 'default');
+  }
+}"
+`;
+
 exports[`slots content is the default slot (variation) 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/__snapshots__/style_class.test.ts.snap
+++ b/tests/components/__snapshots__/style_class.test.ts.snap
@@ -490,3 +490,30 @@ exports[`style and class handling t-att-class is properly added/removed on widge
   }
 }"
 `;
+
+exports[`style and class handling t-att-class is properly added/removed on widget root el (v3) 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  
+  let block1 = createBlock(\`<span class=\\"c\\" block-attribute-0=\\"class\\"/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = {d:ctx['state'].d,...ctx['props'].class};
+    return block1([d1]);
+  }
+}"
+`;
+
+exports[`style and class handling t-att-class is properly added/removed on widget root el (v3) 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component } = bdom;
+  let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`Child\`, {class: {a:true,b:ctx['state'].b}}, key + \`__1\`, node, ctx);
+  }
+}"
+`;

--- a/tests/components/error_handling.test.ts
+++ b/tests/components/error_handling.test.ts
@@ -43,7 +43,8 @@ describe("basics", () => {
     expect(fixture.innerHTML).toBe("");
     expect(status(parent)).toBe("destroyed");
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'this'\)|Cannot read property 'this' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'this'\)|Cannot read property 'this' of undefined/g;
     expect(error.message).toMatch(regexp);
   });
 
@@ -112,7 +113,8 @@ describe.skip("errors and promises", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
     expect(error.message).toMatch(regexp);
 
     expect(console.error).toBeCalledTimes(0);
@@ -225,7 +227,8 @@ describe.skip("errors and promises", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
     expect(error.message).toMatch(regexp);
 
     expect(console.error).toBeCalledTimes(0);
@@ -251,7 +254,8 @@ describe.skip("errors and promises", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
     expect(error.message).toMatch(regexp);
 
     expect(console.error).toBeCalledTimes(0);
@@ -274,7 +278,8 @@ describe.skip("errors and promises", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'y'\)|Cannot read property 'y' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'y'\)|Cannot read property 'y' of undefined/g;
     expect(error.message).toMatch(regexp);
   });
 

--- a/tests/components/hooks.test.ts
+++ b/tests/components/hooks.test.ts
@@ -34,7 +34,7 @@ describe("hooks", () => {
       }
       increment() {
         this.value++;
-        (this.button.el as HTMLButtonElement).innerHTML = String(this.value);
+        this.button.el!.innerHTML = String(this.value);
       }
     }
     const mounted = mount(Counter, fixture);

--- a/tests/components/refs.test.ts
+++ b/tests/components/refs.test.ts
@@ -10,6 +10,15 @@ beforeEach(() => {
 });
 
 describe("refs", () => {
+  test("basic use", async () => {
+    class Test extends Component {
+      static template = xml`<div t-ref="div"/>`;
+      button = useRef("div");
+    }
+    const test = await mount(Test, fixture);
+    expect(test.button.el).toBe(fixture.firstChild);
+  });
+
   test("refs are properly bound in slots", async () => {
     class Dialog extends Component {
       static template = xml`<span><t t-slot="footer"/></span>`;
@@ -43,105 +52,5 @@ describe("refs", () => {
     expect(fixture.innerHTML).toBe(
       '<div><span class="counter">1</span><span><button>do something</button></span></div>'
     );
-  });
-  // TODO: rename
-  test.skip("t-refs on widget are components", async () => {
-    class Child extends Component {
-      static template = xml`<div>b</div>`;
-    }
-    let parent: Parent;
-    class Parent extends Component {
-      static template = xml`<div class="outer-div">Hello<Child t-ref="mywidgetb" /></div>`;
-      static components = { Child };
-      ref = useRef<Child>("mywidgetb");
-      setup() {
-        parent = this;
-      }
-    }
-
-    const mounted = mount(Parent, fixture);
-    expect(parent!.ref.comp).toBe(null);
-    expect(parent!.ref.el).toBe(null);
-    await mounted;
-    expect(parent!.ref.comp).toBeInstanceOf(Child);
-    expect(parent!.ref.el).toEqual(fixture.querySelector(".outer-div > div"));
-  });
-
-  test.skip("t-refs are bound at proper timing", async () => {
-    expect.assertions(4);
-    class Child extends Component {
-      static template = xml`<div>widget</div>`;
-    }
-
-    class Parent extends Component {
-      static template = xml`
-        <div>
-          <Child t-foreach="state.list" t-as="elem" t-ref="child" t-key="elem"/>
-        </div>
-      `;
-      static components = { Child };
-      state = useState({ list: <any>[] });
-      child = useRef("child");
-      willPatch() {
-        expect(this.child.comp).toBeNull();
-      }
-      patched() {
-        expect(this.child.comp).not.toBeNull();
-      }
-    }
-
-    const parent = await mount(Parent, fixture);
-    parent.state.list.push(1);
-    await nextTick();
-  });
-
-  test.skip("t-refs are bound at proper timing (2)", async () => {
-    expect.assertions(10);
-    class Child extends Component {
-      static template = xml`<div>widget</div>`;
-    }
-    class Parent extends Component {
-      static template = xml`
-        <div>
-          <Child t-if="state.child1" t-ref="child1"/>
-          <Child t-if="state.child2" t-ref="child2"/>
-        </div>`;
-      static components = { Child };
-      state = useState({ child1: true, child2: false });
-      child1 = useRef("child1");
-      child2 = useRef("child2");
-      count = 0;
-      mounted() {
-        expect(this.child1.comp).toBeDefined();
-        expect(this.child2.comp).toBeNull();
-      }
-      willPatch() {
-        if (this.count === 0) {
-          expect(this.child1.comp).toBeDefined();
-          expect(this.child2.comp).toBeNull();
-        }
-        if (this.count === 1) {
-          expect(this.child1.comp).toBeDefined();
-          expect(this.child2.comp).toBeDefined();
-        }
-      }
-      patched() {
-        if (this.count === 0) {
-          expect(this.child1.comp).toBeDefined();
-          expect(this.child2.comp).toBeDefined();
-        }
-        if (this.count === 1) {
-          expect(this.child1.comp).toBeNull();
-          expect(this.child2.comp).toBeDefined();
-        }
-        this.count++;
-      }
-    }
-
-    const parent = await mount(Parent, fixture);
-    parent.state.child2 = true;
-    await nextTick();
-    parent.state.child1 = false;
-    await nextTick();
   });
 });

--- a/tests/components/slots.test.ts
+++ b/tests/components/slots.test.ts
@@ -1347,4 +1347,22 @@ describe("slots", () => {
     expect(error).toBeNull();
     expect(fixture.innerHTML).toEqual("");
   });
+
+  test("can render node with t-ref and Component in same slot", async () => {
+    class Child extends Component {
+      static template = xml`<t t-slot="default"/>`;
+    }
+
+    class Parent extends Component {
+      static template = xml`<Child><div t-ref="div"/><Child/></Child>`;
+      static components = { Child };
+    }
+    let error = null;
+    try {
+      await mount(Parent, fixture);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeNull();
+  });
 });

--- a/tests/components/slots.test.ts
+++ b/tests/components/slots.test.ts
@@ -1332,4 +1332,19 @@ describe("slots", () => {
 
     expect(fixture.innerHTML).toBe("<div><div><p>Ablip</p><div><p>Bblip</p></div></div></div>");
   });
+
+  test("can render only empty slot", async () => {
+    class Parent extends Component {
+      static template = xml`<t t-slot="default"/>`;
+    }
+
+    let error = null;
+    try {
+      await mount(Parent, fixture);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeNull();
+    expect(fixture.innerHTML).toEqual("");
+  });
 });

--- a/tests/misc/portal.test.ts
+++ b/tests/misc/portal.test.ts
@@ -405,7 +405,8 @@ describe("Portal", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    const regexp = /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
+    const regexp =
+      /Cannot read properties of undefined \(reading 'crash'\)|Cannot read property 'crash' of undefined/g;
     expect(error.message).toMatch(regexp);
   });
 


### PR DESCRIPTION
Refs to component expose a lot of implementation details that should be
private to parents. Parent to child communication should go through
props.