### PR TITLE
[IMP] qweb: turn handlers into function expressions only

### DIFF
--- a/src/component/component_node.ts
+++ b/src/component/component_node.ts
@@ -89,7 +89,7 @@ export class ComponentNode<T extends typeof Component = any> implements VNode<Co
     this.app = app;
     applyDefaultProps(props, C);
     this.component = new C(props, app.env, this) as any;
-    this.renderFn = app.getTemplate(C.template).bind(null, this.component, this);
+    this.renderFn = app.getTemplate(C.template).bind(this.component, this.component, this);
     if (C.style) {
       applyStyles(C);
     }

--- a/src/component/handler.ts
+++ b/src/component/handler.ts
@@ -26,12 +26,11 @@ export const mainEventHandler = (data: any, ev: Event, currentTarget?: EventTarg
       }
     }
   }
-  if (typeof data[0] === "function") {
-    data[0](ev);
-  } else if (data[0].__owl__) {
-    const method = data[1];
-    const args = data[2] || [];
-    data[0].__owl__.component[method](...args, ev);
+  // If handler is empty, the array slot 0 will also be empty, and data will not have the property 0
+  // We check this rather than data[0] being truthy (or typeof function) so that it crashes
+  // as expected when there is a handler expression that evaluates to a falsy value
+  if (Object.hasOwnProperty.call(data, 0)) {
+    data[0].call(data[1] ? data[1].__owl__.component : null, ev);
   }
   return stopped;
 };

--- a/src/qweb/inline_expressions.ts
+++ b/src/qweb/inline_expressions.ts
@@ -70,6 +70,7 @@ interface Token {
   size?: number;
   varName?: string;
   replace?: Function;
+  isLocal?: boolean;
 }
 
 const STATIC_TOKEN_MAP: { [key: string]: TKind } = Object.assign(Object.create(null), {
@@ -324,6 +325,13 @@ export function compileExprToArray(expr: string): Token[] {
       }
     }
     i++;
+  }
+  // Mark all variables that have been used locally.
+  // This assumes the expression has only one scope (incorrect but "good enough for now")
+  for (const token of tokens) {
+    if (token.type === "SYMBOL" && localVars.has(token.value)) {
+      token.isLocal = true;
+    }
   }
   return tokens;
 }

--- a/tests/components/__snapshots__/basics.test.ts.snap
+++ b/tests/components/__snapshots__/basics.test.ts.snap
@@ -98,7 +98,7 @@ exports[`basics can be clicked on and updated 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let d1 = ctx['state'].counter;
     const v1 = ctx['state'];
-    let d2 = [(e) => {const res = (() => { return v1.counter++ })(); if (typeof res === 'function') { res(e) }}];
+    let d2 = [()=>v1.counter++, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -157,7 +157,7 @@ exports[`basics can inject values in tagged templates 2`] = `
   const callTemplate_2 = getTemplate(\`__template__9\`);
   
   return function template(ctx, node, key = \\"\\") {
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -599,7 +599,7 @@ exports[`basics rerendering a widget with a sub widget 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let d1 = ctx['state'].counter;
     const v1 = ctx['state'];
-    let d2 = [(e) => {const res = (() => { return v1.counter++ })(); if (typeof res === 'function') { res(e) }}];
+    let d2 = [()=>v1.counter++, ctx];
     return block1([d1, d2]);
   }
 }"

--- a/tests/components/__snapshots__/concurrency.test.ts.snap
+++ b/tests/components/__snapshots__/concurrency.test.ts.snap
@@ -1130,9 +1130,10 @@ exports[`rendering component again in next microtick 2`] = `
   
   return function template(ctx, node, key = \\"\\") {
     let b2;
-    let d1 = [ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
     if (ctx['env'].flag) {
-      b2 = component(\`Child\`, {}, key + \`__1\`, node, ctx);
+      b2 = component(\`Child\`, {}, key + \`__2\`, node, ctx);
     }
     return block1([d1], [b2]);
   }

--- a/tests/components/__snapshots__/event_handling.test.ts.snap
+++ b/tests/components/__snapshots__/event_handling.test.ts.snap
@@ -23,8 +23,9 @@ exports[`event handling handler receive the event as argument 2`] = `
   let block1 = createBlock(\`<span block-handler-0=\\"click\\"><block-child-0/><block-text-1/></span>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'inc'];
-    let b2 = component(\`Child\`, {}, key + \`__1\`, node, ctx);
+    const v1 = ctx['inc'];
+    let d1 = [v1, ctx];
+    let b2 = component(\`Child\`, {}, key + \`__2\`, node, ctx);
     let d2 = ctx['state'].value;
     return block1([d1, d2], [b2]);
   }
@@ -42,7 +43,7 @@ exports[`event handling support for callable expression in event handler 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let d1 = ctx['state'].value;
     const v1 = ctx['obj'];
-    let d2 = [(e) => {const res = (() => { return v1.onInput })(); if (typeof res === 'function') { res(e) }}];
+    let d2 = [v1.onInput, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -63,8 +64,9 @@ exports[`event handling t-on with handler bound to dynamic argument on a t-forea
     for (let i1 = 0; i1 < l_block2; i1++) {
       ctx[\`item\`] = v_block2[i1];
       let key1 = ctx['item'];
-      const arg1 = [ctx['item']];
-      let d1 = [ctx, 'onClick', arg1];
+      const v1 = ctx['onClick'];
+      const v2 = ctx['item'];
+      let d1 = [ev=>v1(v2,ev), ctx];
       c_block2[i1] = withKey(block3([d1]), key1);
     }
     let b2 = list(c_block2);

--- a/tests/components/__snapshots__/higher_order_component.test.ts.snap
+++ b/tests/components/__snapshots__/higher_order_component.test.ts.snap
@@ -130,7 +130,8 @@ exports[`basics sub widget is interactive 1`] = `
   let block1 = createBlock(\`<span><button block-handler-0=\\"click\\">click</button>child<block-text-1/></span>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'inc'];
+    const v1 = ctx['inc'];
+    let d1 = [v1, ctx];
     let d2 = ctx['state'].val;
     return block1([d1, d2]);
   }

--- a/tests/components/__snapshots__/lifecycle.test.ts.snap
+++ b/tests/components/__snapshots__/lifecycle.test.ts.snap
@@ -540,7 +540,8 @@ exports[`lifecycle hooks onRender 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\"><block-text-1/></button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'increment'];
+    const v1 = ctx['increment'];
+    let d1 = [v1, ctx];
     let d2 = ctx['state'].value;
     return block1([d1, d2]);
   }

--- a/tests/components/__snapshots__/refs.test.ts.snap
+++ b/tests/components/__snapshots__/refs.test.ts.snap
@@ -43,7 +43,8 @@ exports[`refs refs are properly bound in slots 2`] = `
   
   const slot3 = ctx => (node, key) => {
     const refs = ctx.__owl__.refs
-    let d2 = [ctx, 'doSomething'];
+    const v4 = ctx['doSomething'];
+    let d2 = [v4, ctx];
     let d3 = (el) => refs[\`myButton\`] = el;
     return block2([d2, d3]);
   }

--- a/tests/components/__snapshots__/slots.test.ts.snap
+++ b/tests/components/__snapshots__/slots.test.ts.snap
@@ -389,9 +389,10 @@ exports[`slots dynamic t-slot call 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\"><block-child-0/></button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'toggle'];
-    const slot1 = (ctx['current'].slot);
-    let b2 = toggler(slot1, callSlot(ctx, node, key, slot1));
+    const v1 = ctx['toggle'];
+    let d1 = [v1, ctx];
+    const slot2 = (ctx['current'].slot);
+    let b2 = toggler(slot2, callSlot(ctx, node, key, slot2));
     return block1([d1], [b2]);
   }
 }"
@@ -435,13 +436,14 @@ exports[`slots dynamic t-slot call with default 1`] = `
   
   let block1 = createBlock(\`<button block-handler-0=\\"click\\"><block-child-0/></button>\`);
   
-  const defaultSlot1 = ctx => {
+  const defaultSlot2 = ctx => {
     return text(\` owl \`);
   }
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'toggle'];
-    let b3 = callSlot(ctx, node, key, (ctx['current'].slot), defaultSlot1, true);
+    const v1 = ctx['toggle'];
+    let d1 = [v1, ctx];
+    let b3 = callSlot(ctx, node, key, (ctx['current'].slot), defaultSlot2, true);
     return block1([d1], [b3]);
   }
 }"
@@ -1124,7 +1126,7 @@ exports[`slots slot and (inline) t-call 3`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   const slot3 = ctx => (node, key) => {
-    return callTemplate_5(ctx, node, key + \`__4\`);
+    return callTemplate_5.call(this, ctx, node, key + \`__4\`);
   }
   
   return function template(ctx, node, key = \\"\\") {
@@ -1210,7 +1212,7 @@ exports[`slots slot and t-call 3`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   const slot3 = ctx => (node, key) => {
-    return callTemplate_5(ctx, node, key + \`__4\`);
+    return callTemplate_5.call(this, ctx, node, key + \`__4\`);
   }
   
   return function template(ctx, node, key = \\"\\") {
@@ -1295,14 +1297,15 @@ exports[`slots slot are properly rendered if inner props are changed 3`] = `
   
   let block1 = createBlock(\`<div><button block-handler-0=\\"click\\">Inc[<block-text-1/>]</button><block-child-0/></div>\`);
   
-  const slot2 = ctx => (node, key) => {
-    return component(\`SomeComponent\`, {val: ctx['state'].val}, key + \`__3\`, node, ctx);
+  const slot3 = ctx => (node, key) => {
+    return component(\`SomeComponent\`, {val: ctx['state'].val}, key + \`__4\`, node, ctx);
   }
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'inc'];
+    const v1 = ctx['inc'];
+    let d1 = [v1, ctx];
     let d2 = ctx['state'].val;
-    let b3 = assign(component(\`GenericComponent\`, {}, key + \`__1\`, node, ctx), {slots: {'default': slot2(ctx)}});
+    let b3 = assign(component(\`GenericComponent\`, {}, key + \`__2\`, node, ctx), {slots: {'default': slot3(ctx)}});
     return block1([d1, d2], [b3]);
   }
 }"
@@ -1333,7 +1336,8 @@ exports[`slots slot content is bound to caller 2`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">some text</button>\`);
   
   const slot2 = ctx => (node, key) => {
-    let d1 = [ctx, 'inc'];
+    const v3 = ctx['inc'];
+    let d1 = [v3, ctx];
     return block1([d1]);
   }
   
@@ -1434,7 +1438,7 @@ exports[`slots slot preserves properly parented relationship, even through t-cal
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   const slot3 = ctx => (node, key) => {
-    return callTemplate_5(ctx, node, key + \`__4\`);
+    return callTemplate_5.call(this, ctx, node, key + \`__4\`);
   }
   
   return function template(ctx, node, key = \\"\\") {
@@ -1503,7 +1507,8 @@ exports[`slots slots are rendered with proper context 2`] = `
   let block2 = createBlock(\`<button block-handler-0=\\"click\\">do something</button>\`);
   
   const slot3 = ctx => (node, key) => {
-    let d2 = [ctx, 'doSomething'];
+    const v4 = ctx['doSomething'];
+    let d2 = [v4, ctx];
     return block2([d2]);
   }
   
@@ -1984,7 +1989,7 @@ exports[`slots t-slot in recursive templates 2`] = `
         ctx[isBoundary] = 1;
         setContextValue(ctx, \\"name\\", ctx['item'].name);
         setContextValue(ctx, \\"items\\", ctx['item'].children);
-        b6 = callTemplate_5(ctx, node, key + \`__4__\${key1}\`);
+        b6 = callTemplate_5.call(this, ctx, node, key + \`__4__\${key1}\`);
         ctx = ctx.__proto__;
       }
       c_block3[i1] = withKey(multi([b5, b6]), key1);
@@ -2113,7 +2118,8 @@ exports[`slots t-slot scope context 2`] = `
   let block1 = createBlock(\`<div block-handler-0=\\"click\\"><block-child-0/></div>\`);
   
   const slot2 = ctx => (node, key) => {
-    let d1 = [ctx, 'onClick'];
+    const v3 = ctx['onClick'];
+    let d1 = [v3, ctx];
     let b2 = callSlot(ctx, node, key, 'default');
     return block1([d1], [b2]);
   }

--- a/tests/components/__snapshots__/t_call.test.ts.snap
+++ b/tests/components/__snapshots__/t_call.test.ts.snap
@@ -52,7 +52,8 @@ exports[`t-call handlers are properly bound through a t-call 1`] = `
   let block1 = createBlock(\`<p block-handler-0=\\"click\\">lucas</p>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'update'];
+    const v1 = ctx['update'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -68,7 +69,7 @@ exports[`t-call handlers are properly bound through a t-call 2`] = `
   let block1 = createBlock(\`<div><block-child-0/><block-text-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     let d1 = ctx['counter'];
     return block1([d1], [b2]);
   }
@@ -84,8 +85,8 @@ exports[`t-call handlers with arguments are properly bound through a t-call 1`] 
   let block1 = createBlock(\`<p block-handler-0=\\"click\\">lucas</p>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [ctx['a']];
-    let d1 = [ctx, 'update', arg1];
+    const v1 = ctx['a'];
+    let d1 = [()=>this.update(v1), ctx];
     return block1([d1]);
   }
 }"
@@ -101,7 +102,7 @@ exports[`t-call handlers with arguments are properly bound through a t-call 2`] 
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -143,7 +144,7 @@ exports[`t-call parent is set within t-call 3`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -183,7 +184,7 @@ exports[`t-call parent is set within t-call with no parentNode 3`] = `
   const callTemplate_2 = getTemplate(\`__template__9\`);
   
   return function template(ctx, node, key = \\"\\") {
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -216,9 +217,9 @@ exports[`t-call sub components in two t-calls 2`] = `
   return function template(ctx, node, key = \\"\\") {
     let b2,b3;
     if (ctx['state'].val===1) {
-      b2 = callTemplate_2(ctx, node, key + \`__1\`);
+      b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     } else {
-      let b4 = callTemplate_4(ctx, node, key + \`__3\`);
+      let b4 = callTemplate_4.call(this, ctx, node, key + \`__3\`);
       b3 = block3([], [b4]);
     }
     return multi([b2, b3]);
@@ -284,7 +285,7 @@ exports[`t-call t-call in t-foreach and children component 3`] = `
       ctx[\`val_index\`] = i1;
       ctx[\`val_value\`] = k_block2[i1];
       let key1 = ctx['val'];
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
     }
     let b2 = list(c_block2);
     return block1([], [b2]);

--- a/tests/components/__snapshots__/t_component.test.ts.snap
+++ b/tests/components/__snapshots__/t_component.test.ts.snap
@@ -139,7 +139,7 @@ exports[`t-component modifying a sub widget 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let d1 = ctx['state'].counter;
     const v1 = ctx['state'];
-    let d2 = [(e) => {const res = (() => { return v1.counter++ })(); if (typeof res === 'function') { res(e) }}];
+    let d2 = [()=>v1.counter++, ctx];
     return block1([d1, d2]);
   }
 }"

--- a/tests/components/__snapshots__/t_key.test.ts.snap
+++ b/tests/components/__snapshots__/t_key.test.ts.snap
@@ -177,12 +177,12 @@ exports[`t-key t-key on multiple Components with t-call 1 3`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"key\\", ctx['key1']);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     ctx = ctx.__proto__;
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"key\\", ctx['key2']);
-    let b3 = callTemplate_4(ctx, node, key + \`__3\`);
+    let b3 = callTemplate_4.call(this, ctx, node, key + \`__3\`);
     return block1([], [b2, b3]);
   }
 }"
@@ -229,7 +229,7 @@ exports[`t-key t-key on multiple Components with t-call 2 3`] = `
   let block1 = createBlock(\`<span><block-child-0/></span>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"

--- a/tests/components/__snapshots__/t_model.test.ts.snap
+++ b/tests/components/__snapshots__/t_model.test.ts.snap
@@ -117,10 +117,11 @@ exports[`t-model directive can also define t-on directive on same event, part 1 
   let block1 = createBlock(\`<div><input block-handler-0=\\"input\\" block-attribute-1=\\"value\\" block-handler-2=\\"input\\"/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onInput'];
-    const bExpr1 = ctx['state'];
+    const v1 = ctx['onInput'];
+    let d1 = [v1, ctx];
+    const bExpr2 = ctx['state'];
     let d2 = ctx['state']['text'];
-    let d3 = [(ev) => { bExpr1['text'] = ev.target.value; }];
+    let d3 = [(ev) => { bExpr2['text'] = ev.target.value; }];
     return block1([d1, d2, d3]);
   }
 }"
@@ -135,18 +136,21 @@ exports[`t-model directive can also define t-on directive on same event, part 2 
   let block1 = createBlock(\`<div><input type=\\"radio\\" id=\\"one\\" value=\\"One\\" block-handler-0=\\"click\\" block-attribute-1=\\"checked\\" block-handler-2=\\"click\\"/><input type=\\"radio\\" id=\\"two\\" value=\\"Two\\" block-handler-3=\\"click\\" block-attribute-4=\\"checked\\" block-handler-5=\\"click\\"/><input type=\\"radio\\" id=\\"three\\" value=\\"Three\\" block-handler-6=\\"click\\" block-attribute-7=\\"checked\\" block-handler-8=\\"click\\"/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onClick'];
-    const bExpr1 = ctx['state'];
-    let d2 = ctx['state']['choice'] === 'One';
-    let d3 = [(ev) => { bExpr1['choice'] = ev.target.value; }];
-    let d4 = [ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
     const bExpr2 = ctx['state'];
+    let d2 = ctx['state']['choice'] === 'One';
+    let d3 = [(ev) => { bExpr2['choice'] = ev.target.value; }];
+    const v3 = ctx['onClick'];
+    let d4 = [v3, ctx];
+    const bExpr4 = ctx['state'];
     let d5 = ctx['state']['choice'] === 'Two';
-    let d6 = [(ev) => { bExpr2['choice'] = ev.target.value; }];
-    let d7 = [ctx, 'onClick'];
-    const bExpr3 = ctx['state'];
+    let d6 = [(ev) => { bExpr4['choice'] = ev.target.value; }];
+    const v5 = ctx['onClick'];
+    let d7 = [v5, ctx];
+    const bExpr6 = ctx['state'];
     let d8 = ctx['state']['choice'] === 'Three';
-    let d9 = [(ev) => { bExpr3['choice'] = ev.target.value; }];
+    let d9 = [(ev) => { bExpr6['choice'] = ev.target.value; }];
     return block1([d1, d2, d3, d4, d5, d6, d7, d8, d9]);
   }
 }"

--- a/tests/components/__snapshots__/t_on.test.ts.snap
+++ b/tests/components/__snapshots__/t_on.test.ts.snap
@@ -20,7 +20,7 @@ exports[`t-on t-on expression captured in t-foreach 1`] = `
       let key1 = ctx['val'];
       const v1 = ctx['otherState'];
       const v2 = ctx['iter'];
-      let d1 = [(e) => {const res = (() => { return v1.vals.push(v2+'_'+v2) })(); if (typeof res === 'function') { res(e) }}];
+      let d1 = [()=>v1.vals.push(v2+'_'+v2), ctx];
       setContextValue(ctx, \\"iter\\", ctx['iter']+1);
       c_block2[i1] = withKey(block3([d1]), key1);
     }
@@ -50,7 +50,7 @@ exports[`t-on t-on expression in t-foreach 1`] = `
       let d2 = ctx['val']+'';
       const v1 = ctx['otherState'];
       const v2 = ctx['val'];
-      let d3 = [(e) => {const res = (() => { return v1.vals.push(v2) })(); if (typeof res === 'function') { res(e) }}];
+      let d3 = [()=>v1.vals.push(v2), ctx];
       c_block2[i1] = withKey(block3([d1, d2, d3]), key1);
     }
     let b2 = list(c_block2);
@@ -84,7 +84,7 @@ exports[`t-on t-on expression in t-foreach with t-set 1`] = `
       const v1 = ctx['otherState'];
       const v2 = ctx['val'];
       const v3 = ctx['bossa'];
-      let d3 = [(e) => {const res = (() => { return v1.vals.push(v2+'_'+v3) })(); if (typeof res === 'function') { res(e) }}];
+      let d3 = [()=>v1.vals.push(v2+'_'+v3), ctx];
       c_block2[i1] = withKey(block3([d1, d2, d3]), key1);
     }
     let b2 = list(c_block2);
@@ -111,8 +111,8 @@ exports[`t-on t-on method call in t-foreach 1`] = `
       let key1 = ctx['val'];
       let d1 = ctx['val_index'];
       let d2 = ctx['val']+'';
-      const arg1 = [ctx['val']];
-      let d3 = [ctx, 'addVal', arg1];
+      const v1 = ctx['val'];
+      let d3 = [()=>this.addVal(v1), ctx];
       c_block2[i1] = withKey(block3([d1, d2, d3]), key1);
     }
     let b2 = list(c_block2);
@@ -130,7 +130,8 @@ exports[`t-on t-on on destroyed components 1`] = `
   let block1 = createBlock(\`<div block-handler-0=\\"click\\"/>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"

--- a/tests/components/basics.test.ts
+++ b/tests/components/basics.test.ts
@@ -370,7 +370,7 @@ describe("basics", () => {
   test("can be clicked on and updated", async () => {
     class Counter extends Component {
       static template = xml`
-      <div><t t-esc="state.counter"/><button t-on-click="state.counter++">Inc</button></div>`;
+      <div><t t-esc="state.counter"/><button t-on-click="() => state.counter++">Inc</button></div>`;
       state = useState({
         counter: 0,
       });
@@ -387,7 +387,7 @@ describe("basics", () => {
   test("rerendering a widget with a sub widget", async () => {
     class Counter extends Component {
       static template = xml`
-      <div><t t-esc="state.counter"/><button t-on-click="state.counter++">Inc</button></div>`;
+      <div><t t-esc="state.counter"/><button t-on-click="() => state.counter++">Inc</button></div>`;
       state = useState({
         counter: 0,
       });

--- a/tests/components/event_handling.test.ts
+++ b/tests/components/event_handling.test.ts
@@ -52,22 +52,24 @@ describe("event handling", () => {
   });
 
   test("t-on with handler bound to dynamic argument on a t-foreach", async () => {
-    expect.assertions(3);
+    let onClickArgs: [number, MouseEvent] | null = null;
     class Parent extends Component {
       static template = xml`
         <div>
           <t t-foreach="items" t-as="item" t-key="item">
-            <div class="item" t-on-click="onClick(item)"/>
+            <div class="item" t-on-click="ev => onClick(item, ev)"/>
           </t>
         </div>`;
       items = [1, 2, 3, 4];
       onClick(n: number, ev: MouseEvent) {
-        expect(n).toBe(1);
-        expect(ev).toBeInstanceOf(MouseEvent);
+        onClickArgs = [n, ev];
       }
     }
 
     await mount(Parent, fixture);
+    expect(onClickArgs).toBeNull();
     (<HTMLElement>fixture.querySelector(".item")).click();
+    expect(onClickArgs![0]).toBe(1);
+    expect(onClickArgs![1]).toBeInstanceOf(MouseEvent);
   });
 });

--- a/tests/components/t_call.test.ts
+++ b/tests/components/t_call.test.ts
@@ -145,7 +145,7 @@ describe("t-call", () => {
   });
 
   test("handlers with arguments are properly bound through a t-call", async () => {
-    const sub = xml`<p t-on-click="update(a)">lucas</p>`;
+    const sub = xml`<p t-on-click="() => this.update(a)">lucas</p>`;
 
     let value: any = null;
 

--- a/tests/components/t_component.test.ts
+++ b/tests/components/t_component.test.ts
@@ -170,7 +170,7 @@ describe("t-component", () => {
   test("modifying a sub widget", async () => {
     class Counter extends Component {
       static template = xml`
-      <div><t t-esc="state.counter"/><button t-on-click="state.counter++">Inc</button></div>`;
+      <div><t t-esc="state.counter"/><button t-on-click="() => state.counter++">Inc</button></div>`;
       state = useState({
         counter: 0,
       });

--- a/tests/components/t_on.test.ts
+++ b/tests/components/t_on.test.ts
@@ -47,7 +47,7 @@ describe("t-on", () => {
           <div>
             <div t-foreach="state.values" t-as="val" t-key="val">
               <t t-esc="val_index"/>: <t t-esc="val + ''"/>
-              <button t-on-click="otherState.vals.push(val)">Expr</button>
+              <button t-on-click="() => otherState.vals.push(val)">Expr</button>
             </div>
           </div>
         `;
@@ -73,7 +73,7 @@ describe("t-on", () => {
             <div t-foreach="state.values" t-as="val" t-key="val">
               <t t-set="bossa" t-value="bossa + '_' + val_index" />
               <t t-esc="val_index"/>: <t t-esc="val + ''"/>
-              <button t-on-click="otherState.vals.push(val + '_' + bossa)">Expr</button>
+              <button t-on-click="() => otherState.vals.push(val + '_' + bossa)">Expr</button>
             </div>
           </div>
         `;
@@ -97,13 +97,14 @@ describe("t-on", () => {
           <div>
             <div t-foreach="state.values" t-as="val" t-key="val">
               <t t-esc="val_index"/>: <t t-esc="val + ''"/>
-              <button t-on-click="addVal(val)">meth call</button>
+              <button t-on-click="() => this.addVal(val)">meth call</button>
             </div>
           </div>
         `;
       state = useState({ values: ["a", "b"] });
       otherState = { vals: new Array<string>() };
       addVal(val: string) {
+        debugger;
         this.otherState.vals.push(val);
       }
     }
@@ -124,7 +125,7 @@ describe("t-on", () => {
           <div>
             <t t-set="iter" t-value="0" />
             <div t-foreach="arr" t-as="val" t-key="val">
-              <button t-on-click="otherState.vals.push(iter + '_' + iter)">expr</button>
+              <button t-on-click="() => otherState.vals.push(iter + '_' + iter)">expr</button>
               <t t-set="iter" t-value="iter + 1" />
             </div>
           </div>

--- a/tests/misc/__snapshots__/portal.test.ts.snap
+++ b/tests/misc/__snapshots__/portal.test.ts.snap
@@ -9,7 +9,8 @@ exports[`Portal Portal composed with t-slot 1`] = `
   let block1 = createBlock(\`<div block-handler-0=\\"custom\\"><span id=\\"childSpan\\">child2</span></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onCustom'];
+    const v1 = ctx['onCustom'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"

--- a/tests/qweb/__snapshots__/event_handling.test.ts.snap
+++ b/tests/qweb/__snapshots__/event_handling.test.ts.snap
@@ -9,7 +9,8 @@ exports[`t-on can bind event handler 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'add'];
+    const v1 = ctx['add'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -24,8 +25,8 @@ exports[`t-on can bind handlers with arguments 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [5];
-    let d1 = [ctx, 'add', arg1];
+    const v1 = ctx['add'];
+    let d1 = [()=>v1(5), ctx];
     return block1([d1]);
   }
 }"
@@ -40,8 +41,8 @@ exports[`t-on can bind handlers with empty  object 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [{}];
-    let d1 = [ctx, 'doSomething', arg1];
+    const v1 = ctx['doSomething'];
+    let d1 = [()=>v1({}), ctx];
     return block1([d1]);
   }
 }"
@@ -56,8 +57,8 @@ exports[`t-on can bind handlers with empty object (with non empty inner string) 
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [{}];
-    let d1 = [ctx, 'doSomething', arg1];
+    const v1 = ctx['doSomething'];
+    let d1 = [()=>v1({}), ctx];
     return block1([d1]);
   }
 }"
@@ -79,8 +80,9 @@ exports[`t-on can bind handlers with empty object (with non empty inner string) 
       ctx[\`action\`] = v_block2[i1];
       ctx[\`action_index\`] = i1;
       let key1 = ctx['action_index'];
-      const arg1 = [ctx['action']];
-      let d1 = [ctx, 'activate', arg1];
+      const v1 = ctx['activate'];
+      const v2 = ctx['action'];
+      let d1 = [()=>v1(v2), ctx];
       c_block2[i1] = withKey(block3([d1]), key1);
     }
     let b2 = list(c_block2);
@@ -98,8 +100,8 @@ exports[`t-on can bind handlers with object arguments 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [{val:5}];
-    let d1 = [ctx, 'add', arg1];
+    const v1 = ctx['add'];
+    let d1 = [()=>v1({val:5}), ctx];
     return block1([d1]);
   }
 }"
@@ -114,8 +116,10 @@ exports[`t-on can bind two event handlers 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\" block-handler-1=\\"dblclick\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'handleClick'];
-    let d2 = [ctx, 'handleDblClick'];
+    const v1 = ctx['handleClick'];
+    let d1 = [v1, ctx];
+    const v2 = ctx['handleDblClick'];
+    let d2 = [v2, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -130,7 +134,8 @@ exports[`t-on handler is bound to proper owner 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'add'];
+    const v1 = ctx['add'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -150,7 +155,8 @@ exports[`t-on handler is bound to proper owner, part 2 1`] = `
     for (let i1 = 0; i1 < l_block1; i1++) {
       ctx[\`value\`] = v_block1[i1];
       let key1 = ctx['value'];
-      let d1 = [ctx, 'add'];
+      const v1 = ctx['add'];
+      let d1 = [v1, ctx];
       c_block1[i1] = withKey(block2([d1]), key1);
     }
     return list(c_block1);
@@ -167,7 +173,8 @@ exports[`t-on handler is bound to proper owner, part 3 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'add'];
+    const v1 = ctx['add'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -181,7 +188,7 @@ exports[`t-on handler is bound to proper owner, part 3 2`] = `
   const callTemplate_2 = getTemplate(\`sub\`);
   
   return function template(ctx, node, key = \\"\\") {
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -195,7 +202,8 @@ exports[`t-on handler is bound to proper owner, part 4 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'add'];
+    const v1 = ctx['add'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -218,7 +226,7 @@ exports[`t-on handler is bound to proper owner, part 4 2`] = `
       ctx[\`value_index\`] = i1;
       ctx[\`value_value\`] = k_block1[i1];
       let key1 = ctx['value'];
-      c_block1[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block1[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
     }
     return list(c_block1);
   }
@@ -234,7 +242,8 @@ exports[`t-on receive event in first argument 1`] = `
   let block1 = createBlock(\`<button block-handler-0=\\"click\\">Click</button>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'add'];
+    const v1 = ctx['add'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -249,8 +258,10 @@ exports[`t-on t-on modifiers (native listener) basic support for native listener
   let block1 = createBlock(\`<div class=\\"myClass\\" block-handler-0=\\"click\\"><button block-handler-1=\\"click\\">Button</button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'divClicked'];
-    let d2 = [ctx, 'btnClicked'];
+    const v1 = ctx['divClicked'];
+    let d1 = [v1, ctx];
+    const v2 = ctx['btnClicked'];
+    let d2 = [v2, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -265,7 +276,8 @@ exports[`t-on t-on modifiers (native listener) t-on combined with t-esc 1`] = `
   let block1 = createBlock(\`<div><button block-handler-0=\\"click\\"><block-text-1/></button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
     let d2 = ctx['text'];
     return block1([d1, d2]);
   }
@@ -281,7 +293,8 @@ exports[`t-on t-on modifiers (native listener) t-on combined with t-raw 1`] = `
   let block1 = createBlock(\`<div><button block-handler-0=\\"click\\"><block-child-0/></button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
     let b2 = html(ctx['html']);
     return block1([d1], [b2]);
   }
@@ -297,8 +310,10 @@ exports[`t-on t-on modifiers (native listener) t-on with .capture modifier 1`] =
   let block1 = createBlock(\`<div block-handler-0=\\"click.capture\\"><button block-handler-1=\\"click\\">Button</button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"capture\\", ctx, 'onCapture'];
-    let d2 = [ctx, 'doSomething'];
+    const v1 = ctx['onCapture'];
+    let d1 = [\\"capture\\", v1, ctx];
+    const v2 = ctx['doSomething'];
+    let d2 = [v2, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -313,7 +328,7 @@ exports[`t-on t-on modifiers (native listener) t-on with empty handler (only mod
   let block1 = createBlock(\`<div><button block-handler-0=\\"click.prevent\\">Button</button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"prevent\\", (e) => {const res = (() => { return  })(); if (typeof res === 'function') { res(e) }}];
+    let d1 = [\\"prevent\\", , ctx];
     return block1([d1]);
   }
 }"
@@ -328,7 +343,8 @@ exports[`t-on t-on modifiers (native listener) t-on with prevent and self modifi
   let block1 = createBlock(\`<div><button block-handler-0=\\"click.prevent.self\\"><span>Button</span></button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"prevent\\",\\"self\\", ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [\\"prevent\\",\\"self\\", v1, ctx];
     return block1([d1]);
   }
 }"
@@ -343,9 +359,12 @@ exports[`t-on t-on modifiers (native listener) t-on with prevent and/or stop mod
   let block1 = createBlock(\`<div><button block-handler-0=\\"click.prevent\\">Button 1</button><button block-handler-1=\\"click.stop\\">Button 2</button><button block-handler-2=\\"click.prevent.stop\\">Button 3</button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"prevent\\", ctx, 'onClickPrevented'];
-    let d2 = [\\"stop\\", ctx, 'onClickStopped'];
-    let d3 = [\\"prevent\\",\\"stop\\", ctx, 'onClickPreventedAndStopped'];
+    const v1 = ctx['onClickPrevented'];
+    let d1 = [\\"prevent\\", v1, ctx];
+    const v2 = ctx['onClickStopped'];
+    let d2 = [\\"stop\\", v2, ctx];
+    const v3 = ctx['onClickPreventedAndStopped'];
+    let d3 = [\\"prevent\\",\\"stop\\", v3, ctx];
     return block1([d1, d2, d3]);
   }
 }"
@@ -366,8 +385,9 @@ exports[`t-on t-on modifiers (native listener) t-on with prevent modifier in t-f
     for (let i1 = 0; i1 < l_block2; i1++) {
       ctx[\`project\`] = v_block2[i1];
       let key1 = ctx['project'];
-      const arg1 = [ctx['project'].id];
-      let d1 = [\\"prevent\\", ctx, 'onEdit', arg1];
+      const v1 = ctx['onEdit'];
+      const v2 = ctx['project'];
+      let d1 = [\\"prevent\\", ev=>v1(v2.id,ev), ctx];
       let d2 = ctx['project'].name;
       c_block2[i1] = withKey(block3([d1, d2]), key1);
     }
@@ -386,7 +406,8 @@ exports[`t-on t-on modifiers (native listener) t-on with self and prevent modifi
   let block1 = createBlock(\`<div><button block-handler-0=\\"click.self.prevent\\"><span>Button</span></button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"self\\",\\"prevent\\", ctx, 'onClick'];
+    const v1 = ctx['onClick'];
+    let d1 = [\\"self\\",\\"prevent\\", v1, ctx];
     return block1([d1]);
   }
 }"
@@ -401,8 +422,10 @@ exports[`t-on t-on modifiers (native listener) t-on with self modifier 1`] = `
   let block1 = createBlock(\`<div><button block-handler-0=\\"click\\"><span>Button</span></button><button block-handler-1=\\"click.self\\"><span>Button</span></button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'onClick'];
-    let d2 = [\\"self\\", ctx, 'onClickSelf'];
+    const v1 = ctx['onClick'];
+    let d1 = [v1, ctx];
+    const v2 = ctx['onClickSelf'];
+    let d2 = [\\"self\\", v2, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -417,8 +440,10 @@ exports[`t-on t-on modifiers (synthetic listener) basic support for synthetic 1`
   let block1 = createBlock(\`<div block-handler-0=\\"click.synthetic\\"><button block-handler-1=\\"click.synthetic\\">Button</button></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [\\"synthetic\\", ctx, 'divClicked'];
-    let d2 = [\\"synthetic\\", ctx, 'btnClicked'];
+    const v1 = ctx['divClicked'];
+    let d1 = [\\"synthetic\\", v1, ctx];
+    const v2 = ctx['btnClicked'];
+    let d2 = [\\"synthetic\\", v2, ctx];
     return block1([d1, d2]);
   }
 }"
@@ -434,7 +459,7 @@ exports[`t-on t-on with inline statement (function call) 1`] = `
   
   return function template(ctx, node, key = \\"\\") {
     const v1 = ctx['state'];
-    let d1 = [(e) => {const res = (() => { return v1.incrementCounter(2) })(); if (typeof res === 'function') { res(e) }}];
+    let d1 = [()=>v1.incrementCounter(2), ctx];
     return block1([d1]);
   }
 }"
@@ -450,7 +475,7 @@ exports[`t-on t-on with inline statement 1`] = `
   
   return function template(ctx, node, key = \\"\\") {
     const v1 = ctx['state'];
-    let d1 = [(e) => {const res = (() => { return v1.counter++ })(); if (typeof res === 'function') { res(e) }}];
+    let d1 = [()=>v1.counter++, ctx];
     return block1([d1]);
   }
 }"
@@ -466,7 +491,7 @@ exports[`t-on t-on with inline statement, part 2 1`] = `
   
   return function template(ctx, node, key = \\"\\") {
     const v1 = ctx['state'];
-    let d1 = [(e) => {const res = (() => { return v1.flag=!v1.flag })(); if (typeof res === 'function') { res(e) }}];
+    let d1 = [()=>v1.flag=!v1.flag, ctx];
     return block1([d1]);
   }
 }"
@@ -483,7 +508,7 @@ exports[`t-on t-on with inline statement, part 3 1`] = `
   return function template(ctx, node, key = \\"\\") {
     const v1 = ctx['state'];
     const v2 = ctx['someFunction'];
-    let d1 = [(e) => {const res = (() => { return v1.n=v2(3) })(); if (typeof res === 'function') { res(e) }}];
+    let d1 = [()=>v1.n=v2(3), ctx];
     return block1([d1]);
   }
 }"
@@ -498,7 +523,8 @@ exports[`t-on t-on with t-call 1`] = `
   let block1 = createBlock(\`<p block-handler-0=\\"click\\">lucas</p>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let d1 = [ctx, 'update'];
+    const v1 = ctx['update'];
+    let d1 = [v1, ctx];
     return block1([d1]);
   }
 }"
@@ -514,7 +540,7 @@ exports[`t-on t-on with t-call 2`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -529,8 +555,8 @@ exports[`t-on t-on, with arguments and t-call 1`] = `
   let block1 = createBlock(\`<p block-handler-0=\\"click\\">lucas</p>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    const arg1 = [ctx['value']];
-    let d1 = [ctx, 'update', arg1];
+    const v1 = ctx['value'];
+    let d1 = [()=>this.update(v1), ctx];
     return block1([d1]);
   }
 }"
@@ -546,7 +572,7 @@ exports[`t-on t-on, with arguments and t-call 2`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"

--- a/tests/qweb/__snapshots__/misc.test.ts.snap
+++ b/tests/qweb/__snapshots__/misc.test.ts.snap
@@ -158,20 +158,20 @@ exports[`misc global 4`] = `
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"foo\\", 'aaa');
-      let b6 = callTemplate_2(ctx, node, key + \`__1__\${key1}\`);
+      let b6 = callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`);
       ctx = ctx.__proto__;
-      let b7 = callTemplate_4(ctx, node, key + \`__3__\${key1}\`);
+      let b7 = callTemplate_4.call(this, ctx, node, key + \`__3__\${key1}\`);
       setContextValue(ctx, \\"foo\\", 'bbb');
-      let b8 = callTemplate_6(ctx, node, key + \`__5__\${key1}\`);
+      let b8 = callTemplate_6.call(this, ctx, node, key + \`__5__\${key1}\`);
       let b5 = multi([b6, b7, b8]);
       ctx[zero] = b5;
-      let b9 = callTemplate_8(ctx, node, key + \`__7__\${key1}\`);
+      let b9 = callTemplate_8.call(this, ctx, node, key + \`__7__\${key1}\`);
       ctx = ctx.__proto__;
       c_block2[i1] = withKey(multi([b4, b9]), key1);
     }
     ctx = ctx.__proto__;
     let b2 = list(c_block2);
-    let b10 = callTemplate_10(ctx, node, key + \`__9\`);
+    let b10 = callTemplate_10.call(this, ctx, node, key + \`__9\`);
     return block1([], [b2, b10]);
   }
 }"
@@ -182,7 +182,7 @@ exports[`misc other complex template 1`] = `
 ) {
   let { text, createBlock, list, multi, html, toggler, component } = bdom;
   let { withDefault, getTemplate, prepareList, withKey, zero, call, callSlot, capture, isBoundary, shallowEqual, setContextValue, toNumber } = helpers;
-  const callTemplate_3 = getTemplate(\`LOAD_INFOS_TEMPLATE\`);
+  const callTemplate_14 = getTemplate(\`LOAD_INFOS_TEMPLATE\`);
   
   let block1 = createBlock(\`<div><header><nav class=\\"navbar navbar-expand-md navbar-light bg-light\\"><a block-attribute-0=\\"href\\"><b style=\\"color:#777;\\"><block-text-1/></b></a><button type=\\"button\\" class=\\"navbar-toggler\\" data-toggle=\\"collapse\\" data-target=\\"#top_menu_collapse\\"><span class=\\"navbar-toggler-icon\\"/></button><div class=\\"collapse navbar-collapse\\" id=\\"top_menu_collapse\\" aria-expanded=\\"false\\"><ul class=\\"nav navbar-nav ml-auto text-right\\" id=\\"top_menu\\"><block-child-0/><li class=\\"nav-item divider\\"/><block-child-1/></ul><div><div class=\\"input-group input-group-sm\\"><div class=\\"input-group-prepend input-group-sm\\"><button class=\\"btn btn-default fa fa-cog\\" title=\\"Settings\\" block-handler-2=\\"click\\"/><button class=\\"btn btn-default\\" block-handler-3=\\"click\\"> More </button><block-child-2/></div><input class=\\"form-control\\" type=\\"text\\" placeholder=\\"Search\\" aria-label=\\"Search\\" name=\\"search\\" block-attribute-4=\\"value\\" block-handler-5=\\"keyup\\" block-handler-6=\\"change\\" block-ref=\\"7\\"/><div class=\\"input-group-append\\"><button class=\\"btn btn-default fa fa-eraser\\" block-handler-8=\\"click\\"/></div></div></div></div></nav></header><div class=\\"container-fluid\\" block-ref=\\"9\\"><div class=\\"row\\"><!--div class=\\"form-group col-md-6\\">
                       <h5>Search options</h5>
@@ -223,8 +223,9 @@ exports[`misc other complex template 1`] = `
     for (let i1 = 0; i1 < l_block2; i1++) {
       ctx[\`project\`] = v_block2[i1];
       let key1 = ctx['project'].id;
-      const arg1 = [ctx['project']];
-      let d3 = [ctx, 'selectProject', arg1];
+      const v1 = ctx['selectProject'];
+      const v2 = ctx['project'];
+      let d3 = [v1(v2), ctx];
       let d4 = ctx['project'].name;
       c_block2[i1] = withKey(block3([d3, d4]), key1);
     }
@@ -256,8 +257,10 @@ exports[`misc other complex template 1`] = `
       }
       b4 = multi([b5, b6]);
     }
-    let d11 = [ctx, 'toggleSettingsMenu'];
-    let d12 = [ctx, 'toggleMore'];
+    const v3 = ctx['toggleSettingsMenu'];
+    let d11 = [v3, ctx];
+    const v4 = ctx['toggleMore'];
+    let d12 = [v4, ctx];
     if (ctx['categories']&&ctx['categories'].length>1) {
       ctx = Object.create(ctx);
       const [k_block15, v_block15, l_block15, c_block15] = prepareList(ctx['categories']);
@@ -274,10 +277,13 @@ exports[`misc other complex template 1`] = `
       b14 = block14([], [b15]);
     }
     let d16 = ctx['search'].value;
-    let d17 = [ctx, 'updateFilter'];
-    let d18 = [ctx, 'updateFilter'];
+    const v5 = ctx['updateFilter'];
+    let d17 = [v5, ctx];
+    const v6 = ctx['updateFilter'];
+    let d18 = [v6, ctx];
     let d19 = (el) => refs[\`search_input\`] = el;
-    let d20 = [ctx, 'clearSearch'];
+    const v7 = ctx['clearSearch'];
+    let d20 = [v7, ctx];
     let d21 = (el) => refs[\`settings_menu\`] = el;
     if (ctx['triggers']) {
       ctx = Object.create(ctx);
@@ -291,7 +297,8 @@ exports[`misc other complex template 1`] = `
           let d23 = \`trigger_\${ctx['trigger'].id}\`;
           let d24 = ctx['options'].trigger_display[ctx['trigger'].id];
           let d25 = ctx['trigger'].id;
-          let d26 = [ctx, 'updateTriggerDisplay'];
+          const v8 = ctx['updateTriggerDisplay'];
+          let d26 = [v8, ctx];
           let d27 = \`trigger_\${ctx['trigger'].id}\`;
           let d28 = ctx['trigger'].name;
           b20 = block20([d22, d23, d24, d25, d26, d27, d28]);
@@ -300,15 +307,19 @@ exports[`misc other complex template 1`] = `
       }
       ctx = ctx.__proto__;
       let b18 = list(c_block18);
-      let d29 = [ctx, 'triggerAll'];
-      let d30 = [ctx, 'triggerNone'];
-      let d31 = [ctx, 'triggerDefault'];
-      let d32 = [ctx, 'toggleSettingsMenu'];
+      const v9 = ctx['triggerAll'];
+      let d29 = [v9, ctx];
+      const v10 = ctx['triggerNone'];
+      let d30 = [v10, ctx];
+      const v11 = ctx['triggerDefault'];
+      let d31 = [v11, ctx];
+      const v12 = ctx['toggleSettingsMenu'];
+      let d32 = [v12, ctx];
       let b21 = block21([d29, d30, d31, d32]);
       b17 = multi([b18, b21]);
     }
     if (ctx['load_infos']) {
-      b22 = callTemplate_3(ctx, node, key + \`__2\`);
+      b22 = callTemplate_14.call(this, ctx, node, key + \`__13\`);
     }
     if (ctx['message']) {
       let d33 = ctx['message'];
@@ -317,8 +328,8 @@ exports[`misc other complex template 1`] = `
     if (!ctx['project']) {
       b24 = block24();
     } else {
-      let b26 = component(\`BundlesList\`, {bundles: ctx['bundles'].sticky,category_custom_views: ctx['category_custom_views'],search: ctx['search']}, key + \`__4\`, node, ctx);
-      let b27 = component(\`BundlesList\`, {bundles: ctx['bundles'].dev,search: ctx['search']}, key + \`__5\`, node, ctx);
+      let b26 = component(\`BundlesList\`, {bundles: ctx['bundles'].sticky,category_custom_views: ctx['category_custom_views'],search: ctx['search']}, key + \`__15\`, node, ctx);
+      let b27 = component(\`BundlesList\`, {bundles: ctx['bundles'].dev,search: ctx['search']}, key + \`__16\`, node, ctx);
       b25 = block25([], [b26, b27]);
     }
     return block1([d1, d2, d11, d12, d16, d17, d18, d19, d20, d21], [b2, b4, b14, b17, b22, b23, b24, b25]);

--- a/tests/qweb/__snapshots__/t_call.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_call.test.ts.snap
@@ -24,7 +24,7 @@ exports[`t-call (template calling) basic caller 2`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -52,7 +52,7 @@ exports[`t-call (template calling) basic caller, no parent node 2`] = `
   const callTemplate_2 = getTemplate(\`_basic-callee\`);
   
   return function template(ctx, node, key = \\"\\") {
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -91,7 +91,7 @@ exports[`t-call (template calling) call with several sub nodes on same line 2`] 
     let b5 = block5();
     let b2 = multi([b3, b4, b5]);
     ctx[zero] = b2;
-    let b6 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b6 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b6]);
   }
 }"
@@ -129,7 +129,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0' 2`] = `
     let b4 = html(ctx[zero]);
     let b2 = multi([b3, b4]);
     ctx[zero] = b2;
-    let b5 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b5 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b5]);
   }
 }"
@@ -152,7 +152,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0' 3`] = `
     let b4 = html(ctx[zero]);
     let b2 = multi([b3, b4]);
     ctx[zero] = b2;
-    let b5 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b5 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b5]);
   }
 }"
@@ -177,7 +177,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0' 4`] = `
     let b5 = block5();
     let b2 = multi([b3, b4, b5]);
     ctx[zero] = b2;
-    let b6 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b6 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b6]);
   }
 }"
@@ -215,7 +215,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0', without external 
     let b3 = html(ctx[zero]);
     let b1 = multi([b2, b3]);
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -236,7 +236,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0', without external 
     let b3 = html(ctx[zero]);
     let b1 = multi([b2, b3]);
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -259,7 +259,7 @@ exports[`t-call (template calling) cascading t-call t-raw='0', without external 
     let b4 = block4();
     let b1 = multi([b2, b3, b4]);
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -335,7 +335,7 @@ exports[`t-call (template calling) inherit context 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"foo\\", 1);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -353,7 +353,7 @@ exports[`t-call (template calling) recursive template, part 1 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let b2;
     if (false) {
-      b2 = callTemplate_2(ctx, node, key + \`__1\`);
+      b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     }
     return block1([], [b2]);
   }
@@ -375,7 +375,7 @@ exports[`t-call (template calling) recursive template, part 2 1`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"node\\", ctx['root']);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -406,7 +406,7 @@ exports[`t-call (template calling) recursive template, part 2 2`] = `
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"node\\", ctx['subtree']);
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
       ctx = ctx.__proto__;
     }
     let b2 = list(c_block2);
@@ -430,7 +430,7 @@ exports[`t-call (template calling) recursive template, part 3 1`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"node\\", ctx['root']);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -461,7 +461,7 @@ exports[`t-call (template calling) recursive template, part 3 2`] = `
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"node\\", ctx['subtree']);
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
       ctx = ctx.__proto__;
     }
     let b2 = list(c_block2);
@@ -486,7 +486,7 @@ exports[`t-call (template calling) recursive template, part 4: with t-set recurs
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"recursive_idx\\", 1);
     setContextValue(ctx, \\"node\\", ctx['root']);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -519,7 +519,7 @@ exports[`t-call (template calling) recursive template, part 4: with t-set recurs
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"node\\", ctx['subtree']);
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
       ctx = ctx.__proto__;
     }
     let b2 = list(c_block2);
@@ -555,7 +555,7 @@ exports[`t-call (template calling) scoped parameters 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"foo\\", 42);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     ctx = ctx.__proto__;
     let d1 = ctx['foo'];
     return block1([d1], [b2]);
@@ -591,7 +591,7 @@ exports[`t-call (template calling) scoped parameters, part 2 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"foo\\", 42);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     ctx = ctx.__proto__;
     let d1 = ctx['foo'];
     return block1([d1], [b2]);
@@ -609,7 +609,7 @@ exports[`t-call (template calling) t-call allowed on a non t node 1`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -658,7 +658,7 @@ exports[`t-call (template calling) t-call with body content as root of a templat
     ctx[isBoundary] = 1;
     let b1 = block1();
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -675,7 +675,7 @@ exports[`t-call (template calling) t-call with t-if 1`] = `
   return function template(ctx, node, key = \\"\\") {
     let b2;
     if (ctx['flag']) {
-      b2 = callTemplate_2(ctx, node, key + \`__1\`);
+      b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     }
     return block1([], [b2]);
   }
@@ -711,7 +711,7 @@ exports[`t-call (template calling) t-call with t-set inside and body text conten
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"val\\", \`yip yip\`);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -757,7 +757,7 @@ exports[`t-call (template calling) t-call with t-set inside and outside 1`] = `
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"val3\\", ctx['val']*3);
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
       ctx = ctx.__proto__;
     }
     let b2 = list(c_block2);
@@ -806,7 +806,7 @@ exports[`t-call (template calling) t-call with t-set inside and outside. 2 1`] =
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"val3\\", ctx['val']*3);
-      c_block2[i1] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}\`), key1);
+      c_block2[i1] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}\`), key1);
       ctx = ctx.__proto__;
     }
     let b2 = list(c_block2);
@@ -845,7 +845,7 @@ exports[`t-call (template calling) t-call with t-set inside and outside. 2 3`] =
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"w\\", 'fromwrapper');
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -896,12 +896,12 @@ exports[`t-call (template calling) t-call, conditional and t-set in t-call body 
     let b2,b3;
     setContextValue(ctx, \\"v1\\", 'elif');
     if (ctx['v1']==='if') {
-      b2 = callTemplate_2(ctx, node, key + \`__1\`);
+      b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     } else if (ctx['v1']==='elif') {
       ctx = Object.create(ctx);
       ctx[isBoundary] = 1;
       setContextValue(ctx, \\"v\\", 'success');
-      b3 = callTemplate_4(ctx, node, key + \`__3\`);
+      b3 = callTemplate_4.call(this, ctx, node, key + \`__3\`);
       ctx = ctx.__proto__;
     }
     return block1([], [b2, b3]);
@@ -922,7 +922,7 @@ exports[`t-call (template calling) t-esc inside t-call, with t-set outside 1`] =
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"v\\", \`Hi\`);
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"
@@ -969,7 +969,7 @@ exports[`t-call (template calling) with unused body 2`] = `
     ctx[isBoundary] = 1;
     let b1 = text(\`WHEEE\`);
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -1001,7 +1001,7 @@ exports[`t-call (template calling) with unused setbody 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"qux\\", 3);
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -1033,7 +1033,7 @@ exports[`t-call (template calling) with used body 2`] = `
     ctx[isBoundary] = 1;
     let b1 = text(\`ok\`);
     ctx[zero] = b1;
-    return callTemplate_2(ctx, node, key + \`__1\`);
+    return callTemplate_2.call(this, ctx, node, key + \`__1\`);
   }
 }"
 `;
@@ -1065,7 +1065,7 @@ exports[`t-call (template calling) with used setbody 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"foo\\", 'ok');
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"

--- a/tests/qweb/__snapshots__/t_debug_log.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_debug_log.test.ts.snap
@@ -46,7 +46,7 @@ exports[`debugging t-debug on sub template 2`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"

--- a/tests/qweb/__snapshots__/t_esc.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_esc.test.ts.snap
@@ -180,7 +180,7 @@ exports[`t-esc t-esc=0 is escaped 2`] = `
     ctx[isBoundary] = 1;
     let b2 = block2();
     ctx[zero] = b2;
-    let b3 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b3 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b3]);
   }
 }"

--- a/tests/qweb/__snapshots__/t_foreach.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_foreach.test.ts.snap
@@ -264,7 +264,7 @@ exports[`t-foreach t-call with body in t-foreach in t-foreach 2`] = `
         ctx = Object.create(ctx);
         ctx[isBoundary] = 1;
         setContextValue(ctx, \\"c\\", 'x'+'_'+ctx['a']+'_'+ctx['b']);
-        c_block4[i2] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}__\${key2}\`), key2);
+        c_block4[i2] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}__\${key2}\`), key2);
         ctx = ctx.__proto__;
       }
       ctx = ctx.__proto__;
@@ -334,7 +334,7 @@ exports[`t-foreach t-call without body in t-foreach in t-foreach 2`] = `
         ctx[\`b_index\`] = i2;
         ctx[\`b_value\`] = k_block4[i2];
         let key2 = ctx['b'];
-        c_block4[i2] = withKey(callTemplate_2(ctx, node, key + \`__1__\${key1}__\${key2}\`), key2);
+        c_block4[i2] = withKey(callTemplate_2.call(this, ctx, node, key + \`__1__\${key1}__\${key2}\`), key2);
       }
       ctx = ctx.__proto__;
       let b4 = list(c_block4);

--- a/tests/qweb/__snapshots__/t_raw.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_raw.test.ts.snap
@@ -58,7 +58,7 @@ exports[`t-raw multiple calls to t-raw 2`] = `
     ctx[isBoundary] = 1;
     let b2 = block2();
     ctx[zero] = b2;
-    let b3 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b3 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b3]);
   }
 }"

--- a/tests/qweb/__snapshots__/t_ref.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_ref.test.ts.snap
@@ -43,7 +43,7 @@ exports[`t-ref ref in a t-call 1`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     return block1([], [b2]);
   }
 }"

--- a/tests/qweb/__snapshots__/t_set.test.ts.snap
+++ b/tests/qweb/__snapshots__/t_set.test.ts.snap
@@ -216,7 +216,7 @@ exports[`t-set t-set can't alter from within callee 2`] = `
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"iter\\", 'source');
     let d1 = ctx['iter'];
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     let d2 = ctx['iter'];
     return block1([d1, d2], [b2]);
   }
@@ -259,7 +259,7 @@ exports[`t-set t-set can't alter in t-call body 2`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1;
     setContextValue(ctx, \\"iter\\", 'inCall');
-    let b2 = callTemplate_2(ctx, node, key + \`__1\`);
+    let b2 = callTemplate_2.call(this, ctx, node, key + \`__1\`);
     ctx = ctx.__proto__;
     let d2 = ctx['iter'];
     return block1([d1, d2], [b2]);

--- a/tests/qweb/event_handling.test.ts
+++ b/tests/qweb/event_handling.test.ts
@@ -60,7 +60,7 @@ describe("t-on", () => {
   });
 
   test("can bind handlers with arguments", () => {
-    const template = `<button t-on-click="add(5)">Click</button>`;
+    const template = `<button t-on-click="() => add(5)">Click</button>`;
     let a = 1;
     const fixture = mountToFixture(template, { add: (n: number) => (a = a + n) });
     expect(a).toBe(1);
@@ -69,7 +69,7 @@ describe("t-on", () => {
   });
 
   test("can bind handlers with object arguments", () => {
-    const template = `<button t-on-click="add({val: 5})">Click</button>`;
+    const template = `<button t-on-click="() => add({val: 5})">Click</button>`;
     let a = 1;
     const fixture = mountToFixture(template, { add: ({ val }: any) => (a = a + val) });
     expect(a).toBe(1);
@@ -79,7 +79,7 @@ describe("t-on", () => {
 
   test("can bind handlers with empty  object", () => {
     expect.assertions(2);
-    const template = `<button t-on-click="doSomething({})">Click</button>`;
+    const template = `<button t-on-click="() => doSomething({})">Click</button>`;
     const fixture = mountToFixture(template, {
       doSomething(arg: any) {
         expect(arg).toEqual({});
@@ -90,7 +90,7 @@ describe("t-on", () => {
 
   test("can bind handlers with empty object (with non empty inner string)", () => {
     expect.assertions(2);
-    const template = `<button t-on-click="doSomething({ })">Click</button>`;
+    const template = `<button t-on-click="() => doSomething({ })">Click</button>`;
     const fixture = mountToFixture(template, {
       doSomething(arg: any) {
         expect(arg).toEqual({});
@@ -104,7 +104,7 @@ describe("t-on", () => {
     const template = `
         <ul>
           <li t-foreach="['someval']" t-as="action" t-key="action_index">
-            <a t-on-click="activate(action)">link</a>
+            <a t-on-click="() => activate(action)">link</a>
           </li>
         </ul>`;
     const fixture = mountToFixture(template, {
@@ -190,7 +190,7 @@ describe("t-on", () => {
   });
 
   test("t-on with inline statement", () => {
-    const template = `<button t-on-click="state.counter++">Click</button>`;
+    const template = `<button t-on-click="() => state.counter++">Click</button>`;
     let owner = { state: { counter: 0 } };
     const fixture = mountToFixture(template, owner);
     expect(owner.state.counter).toBe(0);
@@ -199,7 +199,7 @@ describe("t-on", () => {
   });
 
   test("t-on with inline statement (function call)", () => {
-    const template = `<button t-on-click="state.incrementCounter(2)">Click</button>`;
+    const template = `<button t-on-click="() => state.incrementCounter(2)">Click</button>`;
     let owner = {
       state: {
         counter: 0,
@@ -215,7 +215,7 @@ describe("t-on", () => {
   });
 
   test("t-on with inline statement, part 2", () => {
-    const template = `<button t-on-click="state.flag = !state.flag">Toggle</button>`;
+    const template = `<button t-on-click="() => state.flag = !state.flag">Toggle</button>`;
     let owner = {
       state: {
         flag: true,
@@ -230,7 +230,7 @@ describe("t-on", () => {
   });
 
   test("t-on with inline statement, part 3", () => {
-    const template = `<button t-on-click="state.n = someFunction(3)">Toggle</button>`;
+    const template = `<button t-on-click="() => state.n = someFunction(3)">Toggle</button>`;
     let owner = {
       someFunction(n: number) {
         return n + 1;
@@ -272,7 +272,7 @@ describe("t-on", () => {
   test("t-on, with arguments and t-call", async () => {
     expect.assertions(4);
     const app = new TemplateSet();
-    const sub = `<p t-on-click="update(value)">lucas</p>`;
+    const sub = `<p t-on-click="() => this.update(value)">lucas</p>`;
     const main = `<div><t t-call="sub"/></div>`;
     app.addTemplate("sub", sub);
     app.addTemplate("main", main);
@@ -290,7 +290,7 @@ describe("t-on", () => {
 
     const fixture = makeTestFixture();
     const render = app.getTemplate("main");
-    const bdom = render(owner, node);
+    const bdom = render.call(owner, owner, node);
     mount(bdom, fixture);
     fixture.querySelector("p")!.click();
   });
@@ -433,7 +433,7 @@ describe("t-on", () => {
       expect.assertions(5);
       const template = `<div>
         <t t-foreach="projects" t-as="project" t-key="project">
-          <a href="#" t-on-click.prevent="onEdit(project.id)">
+          <a href="#" t-on-click.prevent="ev => onEdit(project.id, ev)">
             Edit <t t-esc="project.name"/>
           </a>
         </t>

--- a/tests/qweb/inline_expressions.test.ts
+++ b/tests/qweb/inline_expressions.test.ts
@@ -169,6 +169,11 @@ describe("expression evaluation", () => {
     expect(compileExpr("list.map((elem, index) => elem + index)")).toBe(
       "ctx['list'].map((elem,index)=>elem+index)"
     );
+    expect(compileExpr("(ev => ev)(e)")).toBe("(ev=>ev)(ctx['e'])");
+  });
+  test.skip("arrow functions: not yet supported", () => {
+    // e is added to localvars in inline_expression but not removed after the arrow func body
+    expect(compileExpr("(e => e)(e)")).toBe("(e=>e)(ctx['e'])");
   });
 
   test("assignation", () => {


### PR DESCRIPTION
For the sake of consistency with vanilla JS, and to allow some things
that were previously not possible.