### PR TITLE
[FIX] fiber, lifecycle: trigger a render during the fiber.complete

### DIFF
--- a/src/component/component_node.ts
+++ b/src/component/component_node.ts
@@ -136,13 +136,19 @@ export class ComponentNode<T extends typeof Component = typeof Component>
   }
 
   async render() {
-    const current = this.fiber;
+    let current = this.fiber;
+    if (current && current.root.locked) {
+      await Promise.resolve();
+      // situation may have changed after the microtask tick
+      current = this.fiber;
+    }
     if (current && !current.bdom && !fibersInError.has(current)) {
       return;
     }
     if (!this.bdom && !current) {
       return;
     }
+
     const fiber = makeRootFiber(this);
     this.fiber = fiber;
     this.app.scheduler.addFiber(fiber);

--- a/tests/components/__snapshots__/concurrency.test.ts.snap
+++ b/tests/components/__snapshots__/concurrency.test.ts.snap
@@ -1148,11 +1148,12 @@ exports[`two renderings initiated between willPatch and patched 1`] = `
 ) {
   let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
   
-  let block1 = createBlock(\`<abc><block-text-0/></abc>\`);
+  let block1 = createBlock(\`<abc><block-text-0/><block-text-1/></abc>\`);
   
   return function template(ctx, node, key = \\"\\") {
     let d1 = ctx['props'].val;
-    return block1([d1]);
+    let d2 = ctx['mounted'];
+    return block1([d1, d2]);
   }
 }"
 `;

--- a/tests/components/__snapshots__/lifecycle.test.ts.snap
+++ b/tests/components/__snapshots__/lifecycle.test.ts.snap
@@ -562,6 +562,48 @@ exports[`lifecycle hooks patched hook is called after updating State 1`] = `
 }"
 `;
 
+exports[`lifecycle hooks render in mounted 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  let block1 = createBlock(\`<span><block-text-0/></span>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = ctx['patched'];
+    return block1([d1]);
+  }
+}"
+`;
+
+exports[`lifecycle hooks render in patched 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  let block1 = createBlock(\`<span><block-text-0/></span>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = ctx['patched'];
+    return block1([d1]);
+  }
+}"
+`;
+
+exports[`lifecycle hooks render in willPatch 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  let block1 = createBlock(\`<span><block-text-0/></span>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let d1 = ctx['patched'];
+    return block1([d1]);
+  }
+}"
+`;
+
 exports[`lifecycle hooks sub widget (inside sub node): hooks are correctly called 1`] = `
 "function anonymous(bdom, helpers
 ) {


### PR DESCRIPTION
Have a component which does a render in its onWillPatch, onPatched, onMounted hooks.

Before this commit, the result was incorrect: the second rendering was not taken into account.

After this commit, those renderings are correctly applied.