### PR TITLE
[FIX] qweb: renderToString should not escape twice text content

### DIFF
--- a/src/qweb/qweb.ts
+++ b/src/qweb/qweb.ts
@@ -1,7 +1,7 @@
 import { EventBus } from "../core/event_bus";
 import { h, patch, VNode } from "../vdom/index";
 import { CompilationContext } from "./compilation_context";
-import { shallowEqual, escape } from "../utils";
+import { shallowEqual } from "../utils";
 import { addNS } from "../vdom/vdom";
 
 /**
@@ -425,17 +425,8 @@ export class QWeb extends EventBus {
       return vnode.text!;
     }
     const node = document.createElement(vnode.sel);
-    const elem = patch(node, vnode).elm as HTMLElement;
-    function escapeTextNodes(node) {
-      if (node.nodeType === 3) {
-        node.textContent = escape(node.textContent);
-      }
-      for (let n of node.childNodes) {
-        escapeTextNodes(n);
-      }
-    }
-    escapeTextNodes(elem);
-    return elem.outerHTML;
+    const result = patch(node, vnode);
+    return (result.elm as HTMLElement).outerHTML;
   }
 
   /**

--- a/tests/qweb/qweb.test.ts
+++ b/tests/qweb/qweb.test.ts
@@ -163,7 +163,7 @@ describe("t-esc", () => {
   test("escaping", () => {
     qweb.addTemplate("test", `<span><t t-esc="var"/></span>`);
     expect(renderToString(qweb, "test", { var: "<ok>abc</ok>" })).toBe(
-      "<span>&amp;lt;ok&amp;gt;abc&amp;lt;/ok&amp;gt;</span>"
+      "<span>&lt;ok&gt;abc&lt;/ok&gt;</span>"
     );
   });
 


### PR DESCRIPTION
Since commit
https://github.com/odoo/owl/commit/b2f12a111524f37348b142ac248813f9cb25ca2e,
Owl escape text content twice. It seems that it was done to prevent
security issues, but without realizing that the standard t-esc method
already escapes.

closes #708