### PR TITLE
[FIX] code_generator: stop matching other variables prefix

### DIFF
--- a/src/compiler/code_generator.ts
+++ b/src/compiler/code_generator.ts
@@ -673,7 +673,7 @@ export class CodeGenerator {
         const children = block!.children.slice();
         let current = children.shift();
         for (let i = codeIdx; i < code.length; i++) {
-          if (code[i].trimStart().startsWith(`let ${current!.varName}`)) {
+          if (code[i].trimStart().startsWith(`let ${current!.varName} `)) {
             code[i] = code[i].replace(`let ${current!.varName}`, current!.varName);
             current = children.shift();
             if (!current) break;
@@ -768,7 +768,7 @@ export class CodeGenerator {
         const children = block!.children.slice();
         let current = children.shift();
         for (let i = codeIdx; i < code.length; i++) {
-          if (code[i].trimStart().startsWith(`let ${current!.varName}`)) {
+          if (code[i].trimStart().startsWith(`let ${current!.varName} `)) {
             code[i] = code[i].replace(`let ${current!.varName}`, current!.varName);
             current = children.shift();
             if (!current) break;
@@ -912,7 +912,7 @@ export class CodeGenerator {
           const children = block!.children.slice();
           let current = children.shift();
           for (let i = codeIdx; i < code.length; i++) {
-            if (code[i].trimStart().startsWith(`let ${current!.varName}`)) {
+            if (code[i].trimStart().startsWith(`let ${current!.varName} `)) {
               code[i] = code[i].replace(`let ${current!.varName}`, current!.varName);
               current = children.shift();
               if (!current) break;


### PR DESCRIPTION
Previously, we would replace block declarations in some contexts with
the variable alone, and decalres the variable higher in the generated
code. Issues arise because whe sometimes try to replace "let b2" with
"b2" but end up matching "let b20" which is incorrect.

This commit fixes that by adding a space to the text that we are trying
to match ("let b2 " won't match "let b20")