### PR TITLE
[FIX] typescript: 2 typing issues

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -1,19 +1,18 @@
-import type { Env } from "../app/app";
 import type { ComponentNode } from "./component_node";
 
 // -----------------------------------------------------------------------------
 //  Component Class
 // -----------------------------------------------------------------------------
 
-export class Component {
+export class Component<Props = any, Env = any> {
   static template: string = "";
   static props?: any;
 
-  props: any;
+  props: Props;
   env: Env;
   __owl__: ComponentNode;
 
-  constructor(props: any, env: Env, node: ComponentNode) {
+  constructor(props: Props, env: Env, node: ComponentNode) {
     this.props = props;
     this.env = env;
     this.__owl__ = node;

--- a/tests/components/__snapshots__/t_props.test.ts.snap
+++ b/tests/components/__snapshots__/t_props.test.ts.snap
@@ -93,7 +93,7 @@ exports[`t-props t-props with props 1`] = `
   let block1 = createBlock(\`<div><block-child-0/></div>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let b2 = component(\`Child\`, Object.assign({}, ctx['props'], {a: 1,b: 2}), key + \`__1\`, node, ctx);
+    let b2 = component(\`Child\`, Object.assign({}, ctx['childProps'], {a: 1,b: 2}), key + \`__1\`, node, ctx);
     return block1([], [b2]);
   }
 }"

--- a/tests/components/t_props.test.ts
+++ b/tests/components/t_props.test.ts
@@ -95,12 +95,12 @@ describe("t-props", () => {
     class Parent extends Component {
       static template = xml`
           <div>
-              <Child t-props="props" a="1" b="2" />
+              <Child t-props="childProps" a="1" b="2" />
           </div>
         `;
       static components = { Child };
 
-      props = { a: "a", c: "c" };
+      childProps = { a: "a", c: "c" };
     }
 
     await mount(Parent, fixture);


### PR DESCRIPTION
- useState returned a Reactive, which is true, but in practice makes it
difficult to use outside of internal code for owl
- Component class was no longer generic, which prevented application
code to be properly typed