### PR TITLE
[FIX] bind lifecycle callbacks to component

### DIFF
--- a/src/component/lifecycle_hooks.ts
+++ b/src/component/lifecycle_hooks.ts
@@ -7,44 +7,44 @@ import { nodeErrorHandlers } from "./error_handling";
 
 export function onWillStart(fn: () => Promise<void> | void | any) {
   const node = getCurrent()!;
-  node.willStart.push(fn);
+  node.willStart.push(fn.bind(node.component));
 }
 
 export function onWillUpdateProps(fn: (nextProps: any) => Promise<void> | void | any) {
   const node = getCurrent()!;
-  node.willUpdateProps.push(fn);
+  node.willUpdateProps.push(fn.bind(node.component));
 }
 
 export function onMounted(fn: () => void | any) {
   const node = getCurrent()!;
-  node.mounted.push(fn);
+  node.mounted.push(fn.bind(node.component));
 }
 
 export function onWillPatch(fn: () => Promise<void> | any | void) {
   const node = getCurrent()!;
-  node.willPatch.unshift(fn);
+  node.willPatch.unshift(fn.bind(node.component));
 }
 
 export function onPatched(fn: () => void | any) {
   const node = getCurrent()!;
-  node.patched.push(fn);
+  node.patched.push(fn.bind(node.component));
 }
 
 export function onWillUnmount(fn: () => Promise<void> | void | any) {
   const node = getCurrent()!;
-  node.willUnmount.unshift(fn);
+  node.willUnmount.unshift(fn.bind(node.component));
 }
 
 export function onWillDestroy(fn: () => Promise<void> | void | any) {
   const node = getCurrent()!;
-  node.willDestroy.push(fn);
+  node.willDestroy.push(fn.bind(node.component));
 }
 
 export function onWillRender(fn: () => void | any) {
   const node = getCurrent()!;
   const renderFn = node.renderFn;
   node.renderFn = () => {
-    fn();
+    fn.call(node.component);
     return renderFn();
   };
 }
@@ -54,7 +54,7 @@ export function onRendered(fn: () => void | any) {
   const renderFn = node.renderFn;
   node.renderFn = () => {
     const result = renderFn();
-    fn();
+    fn.call(node.component);
     return result;
   };
 }
@@ -67,5 +67,5 @@ export function onError(callback: OnErrorCallback) {
     handlers = [];
     nodeErrorHandlers.set(node, handlers);
   }
-  handlers.push(callback);
+  handlers.push(callback.bind(node.component));
 }

--- a/tests/components/__snapshots__/lifecycle.test.ts.snap
+++ b/tests/components/__snapshots__/lifecycle.test.ts.snap
@@ -187,6 +187,28 @@ exports[`lifecycle hooks hooks are called in proper order in widget creation/des
 }"
 `;
 
+exports[`lifecycle hooks lifecycle callbacks are bound to component 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`Test\`, {rev: ctx['rev']}, key + \`__1\`, node, ctx);
+  }
+}"
+`;
+
+exports[`lifecycle hooks lifecycle callbacks are bound to component 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(ctx['props'].rev);
+  }
+}"
+`;
+
 exports[`lifecycle hooks lifecycle semantics 1`] = `
 "function anonymous(bdom, helpers
 ) {


### PR DESCRIPTION
Before this commit, some of the callbacks were bound to the component
and some were not.
This commit makes all the callbacks bind to the component.