### PR TITLE
[FIX] blockdom: t-att- correcltly sets the value to zero

### DIFF
--- a/src/blockdom/attributes.ts
+++ b/src/blockdom/attributes.ts
@@ -139,7 +139,8 @@ export function updateClass(this: HTMLElement, val: any, oldVal: any) {
 
 export function makePropSetter(name: string): Setter<HTMLElement> {
   return function setProp(this: HTMLElement, value: any) {
-    (this as any)[name] = value || "";
+    // support 0, fallback to empty string for other falsy values
+    (this as any)[name] = value === 0 ? 0 : value || "";
   };
 }
 

--- a/tests/blockdom/block_attributes.test.ts
+++ b/tests/blockdom/block_attributes.test.ts
@@ -169,12 +169,24 @@ describe("properties", () => {
     expect(input.value).toBe("potato");
   });
 
-  test("input with value attribute, and undefined given", () => {
+  test("input with value attribute, and falsy value given", () => {
     const block = createBlock(`<input block-attribute-0="value"/>`);
 
     const tree = block([undefined]);
     mount(tree, fixture);
     const input = fixture.querySelector("input")!;
+    expect(input.value).toBe("");
+
+    patch(tree, block([null]));
+    expect(input.value).toBe("");
+
+    patch(tree, block([0]));
+    expect(input.value).toBe("0");
+
+    patch(tree, block([""]));
+    expect(input.value).toBe("");
+
+    patch(tree, block([false]));
     expect(input.value).toBe("");
   });
 


### PR DESCRIPTION
In 3536f41f001ea8a0ccb9114b7c2659e3627dadc6 we added a fallback when setting a
property to a falsy value so that the property was set to the empty string. The
objective being to not get the string "undefined"/"null"/"false" as property
value. However, using t-att- to set a property to 0 is perfectly reasonable and
in fact quite common.