### PR TITLE
[FIX] reactivity: fix crash caused by rendering dead children

### DIFF
--- a/src/blockdom/block_compiler.ts
+++ b/src/blockdom/block_compiler.ts
@@ -524,6 +524,17 @@ function createBlockClass(template: HTMLElement, ctx: BlockCtx): BlockClass {
       this.el = el;
       this.parentEl = parent;
     }
+
+    *childNodes() {
+      if (this.children) {
+        for (const child of this.children) {
+          if (child) {
+            yield child;
+            yield* child.childNodes();
+          }
+        }
+      }
+    }
     patch(other: Block, withBeforeRemove: boolean) {}
   }
 

--- a/src/blockdom/event_catcher.ts
+++ b/src/blockdom/event_catcher.ts
@@ -81,6 +81,11 @@ export function createCatcher(eventsSpec: EventsSpec): Catcher {
     toString(): string {
       return this.child.toString();
     }
+
+    *childNodes() {
+      yield this.child;
+      yield* this.child.childNodes();
+    }
   }
 
   return function (child: VNode, handlers: any[]): VNode<VCatcher> {

--- a/src/blockdom/html.ts
+++ b/src/blockdom/html.ts
@@ -81,6 +81,8 @@ class VHtml {
   toString() {
     return this.html;
   }
+
+  *childNodes() {}
 }
 
 export function html(str: string): VNode<VHtml> {

--- a/src/blockdom/index.ts
+++ b/src/blockdom/index.ts
@@ -15,6 +15,7 @@ export interface VNode<T = any> {
   beforeRemove(): void;
   remove(): void;
   firstNode(): Node | undefined;
+  childNodes(): Iterable<VNode>;
 
   el?: undefined | HTMLElement | Text;
   parentEl?: undefined | HTMLElement;

--- a/src/blockdom/list.ts
+++ b/src/blockdom/list.ts
@@ -224,6 +224,13 @@ class VList {
   toString(): string {
     return this.children.map((c) => c!.toString()).join("");
   }
+
+  *childNodes() {
+    for (const child of this.children) {
+      yield child;
+      yield* child.childNodes();
+    }
+  }
 }
 
 export function list(children: VNode[]): VNode<VList> {

--- a/src/blockdom/multi.ts
+++ b/src/blockdom/multi.ts
@@ -127,6 +127,15 @@ export class VMulti {
   toString(): string {
     return this.children.map((c) => (c ? c!.toString() : "")).join("");
   }
+
+  *childNodes() {
+    for (const child of this.children) {
+      if (child) {
+        yield child;
+        yield* child.childNodes();
+      }
+    }
+  }
 }
 
 export function multi(children: (VNode | undefined)[]): VNode<VMulti> {

--- a/src/blockdom/text.ts
+++ b/src/blockdom/text.ts
@@ -41,6 +41,8 @@ abstract class VSimpleNode {
   toString() {
     return this.text;
   }
+
+  *childNodes() {}
 }
 
 class VText extends VSimpleNode {

--- a/src/blockdom/toggler.ts
+++ b/src/blockdom/toggler.ts
@@ -58,6 +58,11 @@ class VToggler {
   toString(): string {
     return this.child.toString();
   }
+
+  *childNodes() {
+    yield this.child;
+    yield* this.child.childNodes();
+  }
 }
 
 export function toggler(key: string, child: VNode): VNode<VToggler> {

--- a/src/component/fibers.ts
+++ b/src/component/fibers.ts
@@ -39,7 +39,7 @@ export function makeRootFiber(node: ComponentNode): Fiber {
 /**
  * @returns number of not-yet rendered fibers cancelled
  */
-function cancelFibers(fibers: Fiber[]): number {
+export function cancelFibers(fibers: Fiber[]): number {
   let result = 0;
   for (let fiber of fibers) {
     fiber.node.fiber = null;

--- a/src/component/scheduler.ts
+++ b/src/component/scheduler.ts
@@ -34,6 +34,10 @@ export class Scheduler {
     }
   }
 
+  get lowestLevel() {
+    return Math.min(...[...this.tasks].filter((f) => !f.bdom).map((f) => f.node.level));
+  }
+
   /**
    * Process all current tasks. This only applies to the fibers that are ready.
    * Other tasks are left unchanged.
@@ -54,7 +58,7 @@ export class Scheduler {
         return;
       }
 
-      if (fiber.counter === 0) {
+      if (fiber.counter === 0 && !fiber.node.dead) {
         if (!hasError) {
           fiber.complete();
         }

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -51,6 +51,13 @@ class VPortal extends VText implements Partial<VNode<VPortal>> {
       this.realBDom!.mount(this.target!, null);
     }
   }
+
+  *childNodes() {
+    if (this.realBDom) {
+      yield this.realBDom;
+      yield* this.realBDom.childNodes();
+    }
+  }
 }
 
 export class Portal extends Component {

--- a/tests/components/__snapshots__/reactivity.test.ts.snap
+++ b/tests/components/__snapshots__/reactivity.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`reactivity in lifecycle Child component doesn't render when state they depend on changes but their parent is about to unmount them 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    let b2;
+    if (ctx['state'].renderChild) {
+      b2 = component(\`Child\`, {state: ctx['state']}, key + \`__1\`, node, ctx);
+    }
+    return multi([b2]);
+  }
+}"
+`;
+
+exports[`reactivity in lifecycle Child component doesn't render when state they depend on changes but their parent is about to unmount them 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(ctx['props'].state.content.a);
+  }
+}"
+`;
+
 exports[`reactivity in lifecycle can use a state hook 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/concurrency.test.ts
+++ b/tests/components/concurrency.test.ts
@@ -40,6 +40,7 @@ Scheduler.prototype.addFiber = function (fiber: Fiber) {
 afterEach(() => {
   if (lastScheduler && lastScheduler.tasks.size > 0) {
     // we still clear the scheduler to prevent additional noise
+    console.log([...lastScheduler.tasks].map((t) => t.counter));
     lastScheduler.tasks.clear();
     throw new Error("we got a memory leak...");
   }
@@ -2715,11 +2716,11 @@ test("delay willUpdateProps", async () => {
   await nextTick();
   expect(fixture.innerHTML).toBe("0_0");
   expect([
-    "Child:willRender",
-    "Child:rendered",
     "Parent:willRender",
     "Child:willUpdateProps",
     "Parent:rendered",
+    "Child:willRender",
+    "Child:rendered",
   ]).toBeLogged();
 
   promise = makeDeferred();
@@ -2837,13 +2838,13 @@ test("delay willUpdateProps with rendering grandchild", async () => {
   await nextTick();
   expect(fixture.innerHTML).toBe("0_0<div></div>");
   expect([
-    "DelayedChild:willRender",
-    "DelayedChild:rendered",
     "GrandParent:willRender",
     "Parent:willUpdateProps",
     "GrandParent:rendered",
     "ReactiveChild:willRender",
     "ReactiveChild:rendered",
+    "DelayedChild:willRender",
+    "DelayedChild:rendered",
     "Parent:willRender",
     "DelayedChild:willUpdateProps",
     "ReactiveChild:willUpdateProps",


### PR DESCRIPTION
Previously, when causing a mutation on a state object that would cause both a
parent and a child to be rendered, in some cases, the new state will cause the
parent to no longer render the child. In those cases, it's not uncommon for the
part of the state to which the child is subscribed to be invalid/corrupt and
rendering the child with this state would cause it to crash. While in the
general case of asynchronous renderings, the child or state mutations should be
done in such a way that rendering the child with and "invalid" state will not
crash, we can, in owl, prevent the child from rendering completely when the
parent can be rendered synchronously or at least semi-synchronously (in the
same tick).

This commit will delay the rendering of components by as many microticks as
their depth in the component tree, causing renders that have been scheduled in
the same microtick to render in the order of their depth. Additionally, when a
component renders, it will pre-emptively take account of its children and mark
them as dead if they aren't going to be rendered again, so that we do not have
to wait for the patch to know that the child needs to be destroyed and avoid
the subsequent child render (which may crash).