### PR TITLE
[FIX] compiler: fix issue with identifiers with same name

### DIFF
--- a/tests/components/__snapshots__/t_on.test.ts.snap
+++ b/tests/components/__snapshots__/t_on.test.ts.snap
@@ -121,6 +121,38 @@ exports[`t-on t-on method call in t-foreach 1`] = `
 }"
 `;
 
+exports[`t-on t-on on component next to t-on on div 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  let { createCatcher } = helpers;
+  const catcher1 = createCatcher({\\"click\\":0});
+  
+  let block1 = createBlock(\`<div><block-child-0/><p block-handler-0=\\"click\\">dec</p></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const hdlr1 = [ctx['increment'], ctx];
+    const b2 = catcher1(component(\`Child\`, {value: ctx['state'].value}, key + \`__1\`, node, ctx), [hdlr1]);
+    let hdlr2 = [ctx['decrement'], ctx];
+    return block1([hdlr2], [b2]);
+  }
+}"
+`;
+
+exports[`t-on t-on on component next to t-on on div 2`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  let block1 = createBlock(\`<button><block-text-0/></button>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let txt1 = ctx['props'].value;
+    return block1([txt1]);
+  }
+}"
+`;
+
 exports[`t-on t-on on components 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/t_on.test.ts
+++ b/tests/components/t_on.test.ts
@@ -197,6 +197,36 @@ describe("t-on", () => {
     expect(fixture.innerHTML).toBe("<div><span></span><button>2</button><p></p></div>");
   });
 
+  test("t-on on component next to t-on on div", async () => {
+    class Child extends Component {
+      static template = xml`<button t-esc="props.value"/>`;
+    }
+
+    class Parent extends Component {
+      static template = xml`
+        <div>
+          <Child t-on-click="increment" value="state.value"/>
+          <p t-on-click="decrement">dec</p>
+        </div>`;
+      static components = { Child };
+      state = useState({ value: 1 });
+      increment() {
+        this.state.value++;
+      }
+      decrement() {
+        this.state.value--;
+      }
+    }
+    await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<div><button>1</button><p>dec</p></div>");
+    fixture.querySelector("button")!.click();
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><button>2</button><p>dec</p></div>");
+    fixture.querySelector("p")!.click();
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div><button>1</button><p>dec</p></div>");
+  });
+
   test("t-on on t-slots", async () => {
     class Child extends Component {
       static template = xml`


### PR DESCRIPTION
Before this commit, there were 2 different ways of generating variable
identifiers. And it was possible to have a situation with two different
variable in a template with the same identifier, which caused a crash.

This commit ensures that we go through a unique helper method, so this
cannot occur anymore. Also, the code is slightly simpler.