### PR TITLE
[IMP] component: display nice error for wrong child component

### DIFF
--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -10,6 +10,7 @@ interface StaticComponentProperties {
   template: string;
   defaultProps?: any;
   props?: any;
+  components?: { [componentName: string]: ComponentConstructor };
 }
 
 export type ComponentConstructor<P extends Props = any, E = any> = (new (

--- a/src/component/component_node.ts
+++ b/src/component/component_node.ts
@@ -107,6 +107,8 @@ export function component<P extends object>(
       C = parent.constructor.components[name as any];
       if (!C) {
         throw new Error(`Cannot find the definition of component "${name}"`);
+      } else if (!(C.prototype instanceof Component)) {
+        throw new Error(`"${name}" is not a Component. It must inherit from the Component class`);
       }
     }
     node = new ComponentNode(C, props, ctx.app, ctx, key);

--- a/tests/components/__snapshots__/error_handling.test.ts.snap
+++ b/tests/components/__snapshots__/error_handling.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basics display a nice error if a component is not a component 1`] = `
+"function anonymous(bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, component, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return component(\`SomeComponent\`, {}, key + \`__1\`, node, ctx);
+  }
+}"
+`;
+
 exports[`basics display a nice error if it cannot find component (in dev mode) 1`] = `
 "function anonymous(bdom, helpers
 ) {

--- a/tests/components/error_handling.test.ts
+++ b/tests/components/error_handling.test.ts
@@ -102,6 +102,25 @@ describe("basics", () => {
     expect(mockConsoleWarn).toBeCalledTimes(1);
   });
 
+  test("display a nice error if a component is not a component", async () => {
+    function notAComponentConstructor() {}
+    class Parent extends Component {
+      static template = xml`<SomeComponent />`;
+      static components = { SomeComponent: notAComponentConstructor };
+    }
+    let error: Error;
+    try {
+      // @ts-expect-error
+      await mount(Parent, fixture);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error!).toBeDefined();
+    expect(error!.message).toBe(
+      '"SomeComponent" is not a Component. It must inherit from the Component class'
+    );
+  });
+
   test("simple catchError", async () => {
     class Boom extends Component {
       static template = xml`<div t-esc="a.b.c"/>`;


### PR DESCRIPTION
If you declare a child component which is not actually a Component,
the error message is not very friendly and not very helpfull to find
what happens and which child component is wrong.

```js
const ChildComponent = "not a component constructor";

class MyComponent extends Component {
    static components = { ChildComponent };
}
```

This commit improves the type declaration for those working with Typescript
and adds a runtime check for javascript codebases