### PR TITLE
[IMP] validation: add support for value types

### DIFF
--- a/doc/reference/props.md
+++ b/doc/reference/props.md
@@ -159,6 +159,7 @@ For each key, a `prop` definition is either a boolean, a constructor, a list of 
 - a boolean: indicate that the props exists, and is mandatory.
 - a constructor: this should describe the type, for example: `id: Number` describe
   the props `id` as a number
+- an object describing a value as type. This is done by using the `value` key. For example, `{value: false}` specifies that the corresponding value should be equal to false.
 - a list of constructors. In that case, this means that we allow more than one
   type. For example, `id: [Number, String]` means that `id` can be either a string
   or a number.
@@ -240,6 +241,7 @@ class ComponentB extends owl.Component {
     size: {
       validate:  e => ["small", "medium", "large"].includes(e)
     },
+    someId: [Number, {value: false}], // either a number or false
   };
 ```
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -248,4 +248,30 @@ describe("validateSchema", () => {
     expect(validateSchema({ size: "sall" }, schema)).toEqual(["'size' is not valid"]);
     expect(validateSchema({ size: 1 }, schema)).toEqual(["'size' is not a string"]);
   });
+
+  test("value as type", () => {
+    expect(validateSchema({ a: false }, { a: { value: false } })).toEqual([]);
+    expect(validateSchema({ a: true }, { a: { value: false } })).toEqual([
+      "'a' is not equal to 'false'",
+    ]);
+  });
+
+  test("value as type (some other values)", () => {
+    expect(validateSchema({ a: null }, { a: { value: null } })).toEqual([]);
+    expect(validateSchema({ a: false }, { a: { value: null } })).toEqual([
+      "'a' is not equal to 'null'",
+    ]);
+    expect(validateSchema({ a: "hey" }, { a: { value: "hey" } })).toEqual([]);
+    expect(validateSchema({ a: true }, { a: { value: "hey" } })).toEqual([
+      "'a' is not equal to 'hey'",
+    ]);
+  });
+
+  test("value as type work in union type", () => {
+    expect(validateSchema({ a: false }, { a: [String, { value: false }] })).toEqual([]);
+    expect(validateSchema({ a: true }, { a: [String, { value: false }] })).toEqual([
+      "'a' is not a string or false",
+    ]);
+    expect(validateSchema({ a: "string" }, { a: [String, { value: false }] })).toEqual([]);
+  });
 });


### PR DESCRIPTION
This commit add supports for value types in prop validation. To describe
a value V type, one has to simply write {value: V}.

Note that this commit also improves the validation typing.

closes #1198
closes #910