### PR TITLE
[FIX] blockdom: fix event_catcher traceback

### DIFF
--- a/src/runtime/blockdom/event_catcher.ts
+++ b/src/runtime/blockdom/event_catcher.ts
@@ -46,7 +46,7 @@ export function createCatcher(eventsSpec: EventsSpec): Catcher {
           const target = ev.target;
           let currentNode: any = self.child.firstNode();
           const afterNode = self.afterNode;
-          while (currentNode !== afterNode) {
+          while (currentNode && currentNode !== afterNode) {
             if (currentNode.contains(target)) {
               return origFn.call(this, ev);
             }

--- a/tests/components/__snapshots__/t_on.test.ts.snap
+++ b/tests/components/__snapshots__/t_on.test.ts.snap
@@ -456,3 +456,43 @@ exports[`t-on t-on on t-slots 2`] = `
   }
 }"
 `;
+
+exports[`t-on t-on when first component child is an empty component 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { createCatcher } = helpers;
+  const comp1 = app.createComponent(\`Child\`, true, false, false, false);
+  const catcher1 = createCatcher({\\"click\\":0});
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const hdlr1 = [()=>{}, ctx];
+    const b2 = catcher1(comp1({list: []}, key + \`__1\`, node, this, null), [hdlr1]);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`t-on t-on when first component child is an empty component 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { prepareList, withKey } = helpers;
+  
+  let block2 = createBlock(\`<span/>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    const [k_block1, v_block1, l_block1, c_block1] = prepareList(ctx['props'].list);;
+    for (let i1 = 0; i1 < l_block1; i1++) {
+      ctx[\`c\`] = v_block1[i1];
+      ctx[\`c_index\`] = i1;
+      const key1 = ctx['c_index'];
+      c_block1[i1] = withKey(block2(), key1);
+    }
+    return list(c_block1);
+  }
+}"
+`;

--- a/tests/components/t_on.test.ts
+++ b/tests/components/t_on.test.ts
@@ -41,6 +41,21 @@ describe("t-on", () => {
     expect(steps).toEqual(["click"]);
   });
 
+  test("t-on when first component child is an empty component", async () => {
+    const consoleSpy = jest.spyOn(console, "error");
+    class Child extends Component {
+      static template = xml`<span t-foreach="props.list" t-as="c" t-key="c_index"/>`;
+    }
+    class Parent extends Component {
+      static template = xml`<div><Child list="[]" t-on-click="() => {}"/></div>`;
+      static components = { Child };
+    }
+    const parent = await mount(Parent, fixture);
+    const el = elem(parent);
+    el.click();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
   test("t-on expression in t-foreach", async () => {
     class Comp extends Component {
       static template = xml`


### PR DESCRIPTION
When a parent component has an empty child with a t-on
and an event is triggered inside the parent, blockdom
checks if there is an event_catcher to call.
Doing so, an empty child would cause an error.

This commit fixes that.