### PR TITLE
[FIX] tutorial_todoapp: fix the final code mount issue

### DIFF
--- a/doc/learning/tutorial_todoapp.md
+++ b/doc/learning/tutorial_todoapp.md
@@ -770,10 +770,11 @@ For reference, here is the final code:
     <meta charset="UTF-8" />
     <title>OWL Todo App</title>
     <link rel="stylesheet" href="app.css" />
+  </head>
+  <body>
     <script src="owl.js"></script>
     <script src="app.js"></script>
-  </head>
-  <body></body>
+  </body>
 </html>
 ```
 


### PR DESCRIPTION
In app.js, `mount(Root, document.body, { dev: true, env });`  crash because `body` is not available yet. 
Therefore, moving the script into the body fix the issue.