### PR TITLE
[FIX] blockdom: prevent side effects at block compilation

### DIFF
--- a/src/runtime/blockdom/block_compiler.ts
+++ b/src/runtime/blockdom/block_compiler.ts
@@ -157,6 +157,15 @@ function buildTree(
           : document.createElement(tagName);
       }
       if (el instanceof Element) {
+        if (!domParentTree) {
+          // some html elements may have side effects when setting their attributes.
+          // For example, setting the src attribute of an <img/> will trigger a
+          // request to get the corresponding image. This is something that we
+          // don't want at compile time. We avoid that by putting the content of
+          // the block in a <template/> element
+          const fragment = document.createElement("template").content;
+          fragment.appendChild(el);
+        }
         for (let i = 0; i < attrs.length; i++) {
           const attrName = attrs[i].name;
           const attrValue = attrs[i].value;


### PR DESCRIPTION
When creating the template node for a block, we create htmlelements and set their (static) attributes.  But this can have side effects. For example, setting the src attribute for an img element will trigger a request to fetch the image.

We avoid that issue by simply setting the html element template node inside a <template/> element.

Note that I don't really see how to test this fix in jest: we don't have a real browser, and no real way to check for this side effect.

closes #1257