### PR TITLE
[FIX] handleError: handle case of empty fiber

### DIFF
--- a/src/runtime/error_handling.ts
+++ b/src/runtime/error_handling.ts
@@ -56,6 +56,9 @@ export function handleError(params: ErrorParams) {
   // resets the fibers on components if possible. This is important so that
   // new renderings can be properly included in the initial one, if any.
   let current: Fiber | null = fiber;
+  if (!current) {
+    return;
+  }
   do {
     current.node.fiber = current;
     current = current.parent;


### PR DESCRIPTION
This is my naive fix for the following error in Odoo v16:

In  DEBUG mode open `Apps > Apps Store` menu

> TypeError: Cannot read properties of null (reading 'node')

opw-3048806