### PR TITLE
[FIX] reactivity: don't subscribe to keys when making reactive

### DIFF
--- a/src/runtime/reactivity.ts
+++ b/src/runtime/reactivity.ts
@@ -28,7 +28,7 @@ const COLLECTION_RAWTYPES = new Set(["Set", "Map", "WeakMap"]);
  * @returns the raw type of the object
  */
 function rawType(obj: any) {
-  return objectToString.call(obj).slice(8, -1);
+  return objectToString.call(toRaw(obj)).slice(8, -1);
 }
 /**
  * Checks whether a given value can be made into a reactive object.


### PR DESCRIPTION
When attempting to create a reactive object, we first check if the target can be made reactive, this is done with Object.toString, which internally reads the Symbol.toStringTag on the underlying object. When trying to make a reactive object from another, for example when reobserving a reactive or when reading a reactive object from the context of another, this would read the subscribe the original object to the Symbol.toStringTag property.

This commit fixes that by calling Object.toString on the underlying target object where applicable.