### PR TITLE
[IMP] runtime: improve useExternalListener typing

### DIFF
--- a/src/runtime/hooks.ts
+++ b/src/runtime/hooks.ts
@@ -117,7 +117,7 @@ export function useEffect(effect: Effect, computeDependencies: () => any[] = () 
  *  `useExternalListener(window, 'click', this._doSomething);`
  * */
 export function useExternalListener(
-  target: HTMLElement | typeof window,
+  target: EventTarget,
   eventName: string,
   handler: EventListener,
   eventParams?: AddEventListenerOptions


### PR DESCRIPTION
Previously the type of the target for useExternalListener was HTMLElement or Window, this makes document an invalid target. Here there is no reason to use the EventTarget interface instead, as useExternalListener only uses methods from that interface and should work with any event target.

Closes odoo/owl#1323