### PR TITLE
[IMP] tools: pull playground before trying to publish

### DIFF
--- a/tools/release.js
+++ b/tools/release.js
@@ -132,7 +132,7 @@ async function startRelease() {
   if (shouldUploadPlayground) {
     log(`Bonus step: publishing new release on playground...`);
     let owl_code = null;
-    status = 0
+    let status = 0
 
     try {
       owl_code = await readFile("dist/owl.iife.js");
@@ -142,7 +142,8 @@ async function startRelease() {
       return;
     }
 
-    status += await execCommand("git checkout gh-pages");
+    status |= await execCommand("git checkout gh-pages");
+    status |= await execCommand("git pull --rebase");
     
     if (status !== 0) {
       logError("Couldn't switch to gh-pages branch")
@@ -156,9 +157,9 @@ async function startRelease() {
       return;
     }
     
-    status += await execCommand(`git commit -am "[IMP] update owl to v${next}"`);
-    status += await execCommand(`git push origin gh-pages`);
-    status += await execCommand("git checkout -");
+    status |= await execCommand(`git commit -am "[IMP] update owl to v${next}"`);
+    status |= await execCommand(`git push origin gh-pages`);
+    status |= await execCommand("git checkout -");
     if (status !== 0) {
       logError("Something went wrong for the playground update.")
     }


### PR DESCRIPTION
Previously, if you were not the last person to publish to the playground, your playground branch would be behind the remote and trying to push to it would fail.

This commit attempts to pull the changes before updating owl so that even if you were not the last person to push to the playground, as long as the pull is a fast-forward, publishing to the playground won't fail.

This commit also adapts some of the status number manipulation to use bitwise or instead of addition, since return status code can be both positive or negative and may cancel one another. Using bitwise or ensures than any non-zero code will make the status non-zero and stay that way.