### PR TITLE
[FIX] tools: allow to pre-compile templates with - in their name

### DIFF
--- a/tools/compile_xml.js
+++ b/tools/compile_xml.js
@@ -48,7 +48,7 @@ function writeToFile(filepath, data) {
 }
 
 // adapted from https://medium.com/@mhagemann/the-ultimate-way-to-slugify-a-url-string-in-javascript-b8e4a0d849e1
-const a = "·_,:;";
+const a = "·-_,:;";
 const p = new RegExp(a.split("").join("|"), "g");
 
 function slugify(str) {


### PR DESCRIPTION
Compiling a template with a dash ("-") in its name generates an invalid function name in the compiled code.

A template named `"my-component"` leads to the function `function my-component(app, bdom, helpers) { ... }` which has an invalid name.

closes #1333