### PR TITLE
[FIX] hooks: fix useRef in Firefox 109+

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -104,10 +104,18 @@ export function useRef<C extends Component = Component>(name: string): Ref<C> {
   return {
     get el(): HTMLElement | null {
       const val = __owl__.refs && __owl__.refs[name];
+      if (val instanceof Component) {
+        return val.el;
+      }
       if (val instanceof HTMLElement) {
         return val;
-      } else if (val instanceof Component) {
-        return val.el;
+      }
+      // Extra check in case the app was created outside an iframe but mounted into one
+      // on Firefox 109+, the prototype of the element changes to use the iframe window's HTMLElement
+      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1813499
+      const ownerWindow = (val as any)?.ownerDocument?.defaultView;
+      if (ownerWindow && (val as any) instanceof ownerWindow.HTMLElement) {
+        return val;
       }
       return null;
     },


### PR DESCRIPTION
[FIX] hooks: fix useRef in Firefox 109+

Since Firefox 109, appending an HTMLElement into an iframe changes the
prototype of that element from the HTMLElement of the window where it
was created to the HTMLElement of the window of the iframe into which it
is appended. This causes the `instanceof HTMLElement` check in `useRef`
to fail, as `HTMLElement` refers to the window in which owl is declared.

This commit fixes that by adding an extra `instanceof` check that uses
the element's ownerDocument window.