### PR TITLE
[FIX] props validation: do not subscribe to props keys

### DIFF
--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -1,4 +1,5 @@
 import { OwlError } from "./error_handling";
+import { toRaw } from "./reactivity";
 
 type BaseType =
   | typeof String
@@ -84,6 +85,7 @@ export function validateSchema(obj: { [key: string]: any }, schema: Schema): str
   if (Array.isArray(schema)) {
     schema = toSchema(schema);
   }
+  obj = toRaw(obj);
   let errors = [];
   // check if each value in obj has correct shape
   for (let key in obj) {

--- a/tests/components/__snapshots__/props_validation.test.ts.snap
+++ b/tests/components/__snapshots__/props_validation.test.ts.snap
@@ -841,6 +841,33 @@ exports[`props validation props are validated whenever component is updated 2`] 
 }"
 `;
 
+exports[`props validation props validation does not cause additional subscription 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`Child\`, true, false, false, false);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const props1 = {obj: ctx['obj']};
+    helpers.validateProps(\`Child\`, props1, this);
+    const b2 = comp1(props1, key + \`__1\`, node, this, null);
+    const b3 = text(ctx['obj'].otherValue);
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`props validation props validation does not cause additional subscription 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(ctx['props'].obj.value);
+  }
+}"
+`;
+
 exports[`props validation props: list of strings 1`] = `
 "function anonymous(app, bdom, helpers
 ) {


### PR DESCRIPTION
In dev mode, owl inserts an additional props validation step. Before this commit, the validation would iterate on all key/value pairs of each props. If the props is reactive, this has the unfortunate side effect of subscribing the component to each of the keys, even though it should not be.

This commit avoids the issue by only validating the raw object.