### PR TITLE
[IMP] release: add version number on App

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,6 @@ if (pkg.module !== ES_FILENAME || pkg.main !== CJS_FILENAME) {
 }  
 
 const outro = `
-__info__.version = '${pkg.version}';
 __info__.date = '${new Date().toISOString()}';
 __info__.hash = '${git.short()}';
 __info__.url = 'https://github.com/odoo/owl';

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,3 +1,4 @@
+import { version } from "../version";
 import { Component, ComponentConstructor, Props } from "./component";
 import { ComponentNode } from "./component_node";
 import { nodeErrorHandlers, OwlError, handleError } from "./error_handling";
@@ -53,6 +54,7 @@ export class App<
   E = any
 > extends TemplateSet {
   static validateTarget = validateTarget;
+  static version = version;
 
   Root: ComponentConstructor<P, E>;
   props: P;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,3 +1,4 @@
+import { App } from "./app";
 import {
   config,
   createBlock,
@@ -56,4 +57,6 @@ export {
 export { validate } from "./validation";
 export { OwlError } from "./error_handling";
 
-export const __info__ = {};
+export const __info__ = {
+  version: App.version,
+};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+// do not modify manually. This value is updated by the release script.
+export const version = "2.0.7";

--- a/tools/release.js
+++ b/tools/release.js
@@ -86,6 +86,7 @@ async function startRelease() {
   // ---------------------------------------------------------------------------
   log(`Step 3/${STEPS}: updating package.json...`);
   await replaceInFile("./package.json", current, next);
+  await replaceInFile("./src/version.ts", current, next);
 
   // ---------------------------------------------------------------------------
   log(`Step 4/${STEPS}: creating git commit...`);


### PR DESCRIPTION
Before this commit, the version number was added by the rollup configuration script. It worked, but it meant that there was no robust way to access the version number in many case. For example, what if I have a page with two different version of owl? Or what if one of them uses the ESM module system, and does not export owl as a global object?

This is not really a big deal, but accessing the version number is useful for tooling purpose, so this commit makes it possible to read the version number on each individual App, as a static property.