### PR TITLE
[IMP] .gitignore: ignore tools/devtools build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules
 
 # Extras temp file
 /tools/owl.js
+/tools/devtools/build
 
 release-notes.md
 


### PR DESCRIPTION
Otherwise, it is annoying to have build files that should never be committed anyway