### PR TITLE
simplify (?) multiple ref checking

### DIFF
--- a/src/compiler/code_generator.ts
+++ b/src/compiler/code_generator.ts
@@ -192,6 +192,7 @@ class CodeTarget {
   hasCache = false;
   shouldProtectScope: boolean = false;
   on: EventHandlers | null;
+  hasRefWrapper: boolean = false;
 
   constructor(name: string, on?: EventHandlers | null) {
     this.name = name;
@@ -213,6 +214,9 @@ class CodeTarget {
     if (this.shouldProtectScope) {
       result.push(`  ctx = Object.create(ctx);`);
       result.push(`  ctx[isBoundary] = 1`);
+    }
+    if (this.hasRefWrapper) {
+      result.push(`  let refWrapper = makeRefWrapper(this.__owl__);`);
     }
     if (this.hasCache) {
       result.push(`  let cache = ctx.cache || {};`);
@@ -689,12 +693,20 @@ export class CodeGenerator {
 
     // t-ref
     if (ast.ref) {
+      if (this.dev) {
+        this.helpers.add("makeRefWrapper");
+        this.target.hasRefWrapper = true;
+      }
       const isDynamic = INTERP_REGEXP.test(ast.ref);
       let name = `\`${ast.ref}\``;
       if (isDynamic) {
         name = replaceDynamicParts(ast.ref, (expr) => this.captureExpression(expr, true));
       }
-      const idx = block!.insertData(`(el) => this.__owl__.setRef((${name}), el)`, "ref");
+      let setRefStr = `(el) => this.__owl__.setRef((${name}), el)`;
+      if (this.dev) {
+        setRefStr = `refWrapper(${name}, ${setRefStr})`;
+      }
+      const idx = block!.insertData(setRefStr, "ref");
       attrs["block-ref"] = String(idx);
     }
 

--- a/src/runtime/template_helpers.ts
+++ b/src/runtime/template_helpers.ts
@@ -5,6 +5,7 @@ import { isOptional, validateSchema } from "./validation";
 import type { ComponentConstructor } from "./component";
 import { markRaw } from "./reactivity";
 import { OwlError } from "./error_handling";
+import type { ComponentNode } from "./component_node";
 
 const ObjectCreate = Object.create;
 /**
@@ -232,6 +233,19 @@ export function validateProps<P>(name: string | ComponentConstructor<P>, props: 
   }
 }
 
+function makeRefWrapper(node: ComponentNode) {
+  let refNames: Set<String> = new Set();
+  return (name: string, fn: Function) => {
+    if (refNames.has(name)) {
+      throw new OwlError(
+        `Cannot set the same ref more than once in the same component, ref "${name}" was set multiple times in ${node.name}`
+      );
+    }
+    refNames.add(name);
+    return fn;
+  };
+}
+
 export const helpers = {
   withDefault,
   zero: Symbol("zero"),
@@ -250,4 +264,5 @@ export const helpers = {
   createCatcher,
   markRaw,
   OwlError,
+  makeRefWrapper,
 };

--- a/tests/components/__snapshots__/refs.test.ts.snap
+++ b/tests/components/__snapshots__/refs.test.ts.snap
@@ -139,14 +139,16 @@ exports[`refs throws if there are 2 same refs at the same time 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { makeRefWrapper } = helpers;
   
   let block2 = createBlock(\`<div block-ref=\\"0\\"/>\`);
   let block3 = createBlock(\`<span block-ref=\\"0\\"/>\`);
   
   return function template(ctx, node, key = \\"\\") {
-    let ref1 = (el) => this.__owl__.setRef((\`coucou\`), el);
+    let refWrapper = makeRefWrapper(this.__owl__);
+    let ref1 = refWrapper(\`coucou\`, (el) => this.__owl__.setRef((\`coucou\`), el));
     const b2 = block2([ref1]);
-    let ref2 = (el) => this.__owl__.setRef((\`coucou\`), el);
+    let ref2 = refWrapper(\`coucou\`, (el) => this.__owl__.setRef((\`coucou\`), el));
     const b3 = block3([ref2]);
     return multi([b2, b3]);
   }

--- a/tests/components/refs.test.ts
+++ b/tests/components/refs.test.ts
@@ -126,10 +126,10 @@ describe("refs", () => {
 
     const app = new App(Test, { test: true });
     const mountProm = expect(app.mount(fixture)).rejects.toThrowError(
-      'Cannot set the same ref more than once in the same component, ref "coucou" was set 2 times in Test'
+      'Cannot set the same ref more than once in the same component, ref "coucou" was set multiple times in Test'
     );
     await expect(nextAppError(app)).resolves.toThrow(
-      'Cannot set the same ref more than once in the same component, ref "coucou" was set 2 times in Test'
+      'Cannot set the same ref more than once in the same component, ref "coucou" was set multiple times in Test'
     );
     await mountProm;
     expect(console.warn).toBeCalledTimes(1);


### PR DESCRIPTION
- perform the check at render time instead of patch time => no need to register lifecycle hooks
- zero cost abstraction in prod mode