### PR TITLE
[REF] app: move app specific error handling code

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -213,6 +213,16 @@ export class App<
   handleError(...args: Parameters<typeof handleError>) {
     return handleError(...args);
   }
+
+  onUnhandledError(error: Error) {
+    console.warn(`[Owl] Unhandled error. Destroying the root component`);
+    try {
+      this.destroy();
+    } catch (e) {
+      console.error(e);
+    }
+    throw error;
+  }
 }
 
 export async function mount<

--- a/src/runtime/error_handling.ts
+++ b/src/runtime/error_handling.ts
@@ -65,12 +65,6 @@ export function handleError(params: ErrorParams) {
 
   const handled = _handleError(node, error);
   if (!handled) {
-    console.warn(`[Owl] Unhandled error. Destroying the root component`);
-    try {
-      node.app.destroy();
-    } catch (e) {
-      console.error(e);
-    }
-    throw error;
+    node.app.onUnhandledError(error);
   }
 }


### PR DESCRIPTION
It was before in the generic error handling file. However, since it is there, it is not possible to modify this behaviour by subclassing App. Another usecase would be for the devtools extension: with this commit, it is now easily able to listen to app destruction events.