### PR TITLE
[FIX] devtools: Fix first release's small bugs

### DIFF
--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
@@ -10,7 +10,7 @@
           <option t-att-selected="store.eventsTreeView" value="Tree">Tree view</option>
           <option t-att-selected="!store.eventsTreeView" value="List">Events log</option>
         </select>
-        <i title="Collapse All" class="fa fa-list me-1" t-on-click="() => this.store.collapseAll()"></i>
+        <i title="Collapse All" type="button" class="fa fa-list me-2" t-on-click="() => this.store.collapseAll()" t-attf-style="{{store.eventsTreeView ? '' : 'visibility: hidden;'}}"></i>
         <div class="icons-separator"/>
         <label class="mx-2 form-check-label pointer-icon" title="Trace renderings in console">
           <input type="checkbox" class="form-check-input me-1" t-att-checked="store.traceRenderings" t-on-input="() => this.store.toggleTracing()"/> Trace Renderings

--- a/tools/devtools/src/main.css
+++ b/tools/devtools/src/main.css
@@ -236,6 +236,7 @@
 .search-input {
   background-color: var(--background-color);
   color: var(--text-color);
+  padding: 0.4rem 0rem;
 }
 
 .search-icon {

--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -507,6 +507,7 @@
           highlight.style.left = `${left}px`;
           highlight.style.width = `${width}px`;
           highlight.style.height = `${height}px`;
+          highlight.style.boxSizing = "border-box";
           highlight.style.position = "fixed";
           highlight.style.backgroundColor = "rgba(15, 139, 245, 0.4)";
           highlight.style.borderStyle = "solid";
@@ -524,6 +525,7 @@
           highlightMargins.style.height = `${height + marginBottom + marginTop}px`;
           highlightMargins.style.position = "fixed";
           highlightMargins.style.borderStyle = "solid";
+          highlightMargins.style.boxSizing = "border-box";
           highlightMargins.style.borderWidth = `${marginTop}px ${marginRight}px ${marginBottom}px ${marginLeft}px`;
           highlightMargins.style.borderColor = "rgba(241, 179, 121, 0.4)";
           highlightMargins.style.zIndex = "10000";
@@ -537,6 +539,7 @@
           highlight.style.left = `${left}px`;
           highlight.style.width = `${width}px`;
           highlight.style.height = `${height}px`;
+          highlight.style.boxSizing = "border-box";
           highlight.style.position = "fixed";
           highlight.style.backgroundColor = "rgba(15, 139, 245, 0.4)";
           highlight.style.zIndex = "10000";


### PR DESCRIPTION
This PR address multiple small bugs that were detected in the early first release of the extension

The first commit adds box-sizing: border-box to the highlight elements created by the devtools on the page. This was making some of the boxes overflow on some pages (like on POS sessions) because the border-box box-sizing was not the default behavior on these pages.

The second commit hides the collapse all button when the profiler is in Events log mode since it doesn't do anything in this case.

The third commit increases the vertical padding of the search bar in order for it to be easier to click on.