### PR TITLE
[FIX] t-out: does not crash when outputting null

### DIFF
--- a/src/runtime/template_helpers.ts
+++ b/src/runtime/template_helpers.ts
@@ -134,7 +134,7 @@ class LazyValue {
  * Safely outputs `value` as a block depending on the nature of `value`
  */
 export function safeOutput(value: any, defaultValue?: any): ReturnType<typeof toggler> {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return defaultValue ? toggler("default", defaultValue) : toggler("undefined", text(""));
   }
   let safeKey;

--- a/tests/compiler/__snapshots__/t_out.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_out.test.ts.snap
@@ -434,6 +434,18 @@ exports[`t-out t-out with the 0 number, in a p 1`] = `
 }"
 `;
 
+exports[`t-out top level t-out with null 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return safeOutput(ctx['var']);
+  }
+}"
+`;
+
 exports[`t-out top level t-out with undefined 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/compiler/t_out.test.ts
+++ b/tests/compiler/t_out.test.ts
@@ -62,6 +62,11 @@ describe("t-out", () => {
     expect(renderToString(template, { var: undefined })).toBe("");
   });
 
+  test("top level t-out with null", () => {
+    const template = `<t t-out="var"/>`;
+    expect(renderToString(template, { var: null })).toBe("");
+  });
+
   test("with an extended String class", () => {
     class LoveString extends String {
       valueOf(): string {


### PR DESCRIPTION
Before this commit, doing `t-out="null"` would crash, since the safeOutput function would assume that it is a block, thanks to the fact that `typeof null === 'object'`.

We handle here the null value just as if it was undefined: it outputs an empty string.