### PR TITLE
[DOC] Fix a code bug in the example of slots

### DIFF
--- a/doc/reference/slots.md
+++ b/doc/reference/slots.md
@@ -175,7 +175,7 @@ class Notebook extends Component {
     <div class="notebook">
       <div class="tabs">
         <t t-foreach="tabNames" t-as="tab" t-key="tab_index">
-          <span t-att-class="{active:tab_index === activeTab}" t-on-click="() => state.activeTab=tab">
+          <span t-att-class="{active:tab_index === activeTab}" t-on-click="() => state.activeTab=tab_index">
             <t t-esc="props.slots[tab].title"/>
           </span>
         </t>


### PR DESCRIPTION
The value of activeTab should be tab_index rather than tab.