### PR TITLE
[FIX] gh-page: fix 'unexpected token export' error on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="assets/milligram.css">
   <link rel="stylesheet" href="assets/highlight.tomorrow.css">
   <link rel="stylesheet" href="assets/main.css">
-  <script src="./owl.js"></script>
+  <script type="importmap">{ "imports": { "@odoo/owl": "./owl.js" } }</script>
 </head>
 <body>
   <header class="container">
@@ -68,7 +68,6 @@
     <p><a href=".">OWL</a> is licensed under LGPLv3.<br>Logo from <a href="https://github.com/googlefonts/noto-emoji">Google Noto Emoji Font</a>, licensed under Apache License 2.0</p>
   </footer>
   <script src="assets/highlight.pack.js"></script>
-  <script type="importmap">{ "imports": { "@odoo/owl": "./owl.js" } }</script>
   <script type="module" src="display_code.js"></script>
   <script type="module" src="counter.js"></script>
 </body>


### PR DESCRIPTION
When refactoring the playground to use es-modules, a script that loads owl as a non-module was forgotten in the head of the page and causes an error in the console, as the script is not declared as type="module" despite being an es-module. This script is also useless as owl is loaded by being imported by the counter component in the page.

The importmap has also been moved to the head because of a bug in firefox where importmaps can fail to be taken into account if they are after a script that is not of type="module", see:
https://bugzilla.mozilla.org/show_bug.cgi?id=1833371

Closes #1436