### PR TITLE
[IMP] devtools: Add blacklist to components toggle

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "1.0",
+  "version": "1.1",
   "manifest_version": 3,
   "description": "Chrome devtools extension for Odoo Owl framework",
   "icons": {

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
@@ -1,8 +1,10 @@
 /** @odoo-module **/
 
-import { isElementInCenterViewport, minimizeKey } from "../../../../utils";
+import { isElementInCenterViewport, minimizeKey, IS_FIREFOX } from "../../../../utils";
 import { useStore } from "../../../store/store";
 import { HighlightText } from "./highlight_text/highlight_text";
+
+const browserInstance = IS_FIREFOX ? browser : chrome;
 
 const { Component, useRef, useState, useEffect, onMounted } = owl;
 
@@ -103,6 +105,32 @@ export class TreeElement extends Component {
     }
     if (!this.props.component.selected) {
       this.store.selectComponent(this.props.component.path);
+    }
+  }
+
+  // Adds the component name to the components toggle blacklist if not already present
+  // Else, remove it from the blacklist
+  toggleComponentToBlacklist() {
+    if (this.store.settings.componentsToggleBlacklist.has(this.props.component.name)) {
+      if (!this.props.component.toggled) {
+        this.props.component.toggled = !this.props.component.toggled;
+      }
+      this.store.settings.componentsToggleBlacklist.delete(this.props.component.name);
+      browserInstance.storage.local.set({
+        owlDevtoolsComponentsToggleBlacklist: Array.from(
+          this.store.settings.componentsToggleBlacklist
+        ),
+      });
+    } else {
+      if (this.props.component.toggled) {
+        this.props.component.toggled = !this.props.component.toggled;
+      }
+      this.store.settings.componentsToggleBlacklist.add(this.props.component.name);
+      browserInstance.storage.local.set({
+        owlDevtoolsComponentsToggleBlacklist: Array.from(
+          this.store.settings.componentsToggleBlacklist
+        ),
+      });
     }
   }
 }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.xml
@@ -43,6 +43,10 @@
           <t t-else="">
             <li t-on-click.stop="() => this.store.logObjectInConsole([...props.component.path])" class="custom-menu-item py-1 px-4">Store as global variable</li>
           </t>
+          <li t-on-click.stop="() => this.toggleComponentToBlacklist()" class="custom-menu-item py-1 px-4">
+            <t t-if="store.settings.componentsToggleBlacklist.has(props.component.name)">Don't fold component by default</t>
+            <t t-else="">Fold component by default</t>
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This commit adds the functionnality to add components to the toggle blacklist so that it won't be expanded by default when launching or reloading the devtools components tree. Also change chrome devtools version to 1.1 for the webstore.