### PR TITLE
[FIX] hooks: useSubEnv and useChildSubEnv should apply on prototype chain

### DIFF
--- a/src/runtime/hooks.ts
+++ b/src/runtime/hooks.ts
@@ -36,8 +36,15 @@ export function useEnv<E extends Env>(): E {
 
 function extendEnv(currentEnv: Object, extension: Object): Object {
   const env = Object.create(currentEnv);
-  const descrs = Object.getOwnPropertyDescriptors(extension);
-  return Object.freeze(Object.defineProperties(env, descrs));
+  while (extension !== Object.prototype) {
+    const descrs = Object.getOwnPropertyDescriptors(extension);
+    Object.defineProperties(env, descrs);
+    for (const key in descrs) {
+      descrs[key].configurable = true;
+    }
+    extension = Object.getPrototypeOf(extension);
+  }
+  return Object.freeze(env);
 }
 
 /**

--- a/tests/components/__snapshots__/hooks.test.ts.snap
+++ b/tests/components/__snapshots__/hooks.test.ts.snap
@@ -361,6 +361,34 @@ exports[`hooks useRef hook: basic use 1`] = `
 }"
 `;
 
+exports[`hooks useSubEnv applies on prototype chain 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comp1({}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`hooks useSubEnv applies on prototype chain 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block3 = createBlock(\`<div><block-text-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const b2 = text(ctx['env'].valueA);
+    let txt1 = ctx['env'].valueB;
+    const b3 = block3([txt1]);
+    return multi([b2, b3]);
+  }
+}"
+`;
+
 exports[`hooks useSubEnv modifies user env 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/components/hooks.test.ts
+++ b/tests/components/hooks.test.ts
@@ -285,6 +285,26 @@ describe("hooks", () => {
     expect(fixture.innerHTML).toBe("<div>brain maggot</div>");
   });
 
+  test("useSubEnv applies on prototype chain", async () => {
+    expect.assertions(3);
+    class Child extends Component {
+      static template = xml`<t t-esc="env.valueA"/><div><t t-esc="env.valueB"/></div>`;
+      setup() {
+        useSubEnv(Object.create({ valueA: "foo" }));
+        useSubEnv(Object.create({ valueB: "bar" }));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child/>`;
+      static components = { Child }
+      setup() {
+        useSubEnv(Object.create({ valueA: "far" }));
+      }
+    }
+    await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("foo<div>bar</div>");
+  });
+
   test("can use useComponent", async () => {
     expect.assertions(2);
     class Test extends Component {


### PR DESCRIPTION
Before this commit:
When using useSubEnv or useChildSubEnv, only owned properties of the extensions are assigned to the new env.

After this commit:
Properties from the whole prototype chain of the extension are assigned to the env.