### PR TITLE
[FIX] runtime: do not crash when capturing context with getter

### DIFF
--- a/tests/components/__snapshots__/t_call.test.ts.snap
+++ b/tests/components/__snapshots__/t_call.test.ts.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`t-call component with an enumerable getter, t-call inside slot 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { capture, markRaw } = helpers;
+  const callTemplate_1 = app.getTemplate(\`sub\`);
+  const comp1 = app.createComponent(\`Child\`, true, true, false, []);
+  
+  function slot1(ctx, node, key = \\"\\") {
+    return callTemplate_1.call(this, ctx, node, key + \`__1\`);
+  }
+  
+  return function template(ctx, node, key = \\"\\") {
+    const ctx1 = capture(ctx);
+    return comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx1}})}, key + \`__2\`, node, this, null);
+  }
+}"
+`;
+
+exports[`t-call component with an enumerable getter, t-call inside slot 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block1 = createBlock(\`<div><block-text-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let txt1 = ctx['foo'];
+    return block1([txt1]);
+  }
+}"
+`;
+
+exports[`t-call component with an enumerable getter, t-call inside slot 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { callSlot } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return callSlot(ctx, node, key, 'default', false, {});
+  }
+}"
+`;
+
 exports[`t-call dynamic t-call 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/components/t_call.test.ts
+++ b/tests/components/t_call.test.ts
@@ -425,4 +425,26 @@ describe("t-call", () => {
     await nextTick();
     expect(fixture.innerHTML).toBe("Bchild");
   });
+
+  test("component with an enumerable getter, t-call inside slot", async () => {
+    class Child extends Component {
+      static template = xml`<t t-slot="default"/>`;
+    }
+    class Parent extends Component {
+      static components = { Child };
+      static template = xml`<Child><t t-call="sub"/></Child>`;
+    }
+    // simulate adding a getter with patch in odoo: getter will be enumarable
+    Object.defineProperty(Parent.prototype, "foo", {
+      get() {
+        return 1;
+      },
+      enumerable: true,
+    });
+    const app = new App(Parent);
+    app.addTemplate("sub", `<div t-esc="foo"/>`);
+
+    await app.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div>1</div>");
+  });
 });


### PR DESCRIPTION
When attempting to capture a rendering context that contains an enumerable getter, there is a crash because we attempt to write a value on the getter. This commit fixes that by manually climbing the prototype chain to copy the values instead, and ignoring getters.

closes https://github.com/odoo/owl/issues/1446