### PR TITLE
[IMP] devtools: patch app methods only when needed

### DIFF
--- a/tools/devtools/src/devtools_app/store/store.js
+++ b/tools/devtools/src/devtools_app/store/store.js
@@ -410,12 +410,7 @@ export const store = reactive({
         if (!scriptsLoaded) {
           await loadScripts(frame);
         }
-        evalInWindow(
-          `__OWL__DEVTOOLS_GLOBAL_HOOK__.devtoolsId = ${
-            store.devtoolsId
-          }; __OWL__DEVTOOLS_GLOBAL_HOOK__.frame = ${JSON.stringify(frame)};`,
-          frame
-        );
+        evalFunctionInWindow("initDevtools", [frame], frame);
         if (!this.frameUrls.includes(frame)) {
           this.frameUrls = [...this.frameUrls, frame];
         }
@@ -635,7 +630,7 @@ init();
 async function init() {
   store.devtoolsId = await getTabURL();
 
-  evalInWindow("__OWL__DEVTOOLS_GLOBAL_HOOK__.devtoolsId = " + store.devtoolsId + ";");
+  evalFunctionInWindow("initDevtools", []);
 
   await loadSettings();
 
@@ -677,7 +672,7 @@ browserInstance.runtime.onConnect.addListener((port) => {
       if (msg.type === "Reload") {
         store.owlStatus = await evalInWindow("window.__OWL__DEVTOOLS_GLOBAL_HOOK__ !== undefined;");
         if (store.owlStatus) {
-          evalInWindow("__OWL__DEVTOOLS_GLOBAL_HOOK__.devtoolsId = " + store.devtoolsId + ";");
+          evalFunctionInWindow("initDevtools", []);
           await store.resetData();
         }
       }


### PR DESCRIPTION
This commit changes the moment when all methods that need patching to handle events are actually patched: the complete method of RootFiber is now patched at devtools startup (when the tab owl tab is opened) and every other method is patched at first activation of the event recording functionality. This makes sure that the devtools will have no impact on performance whatsoever when they are not directly put in use.