### PR TITLE
[FIX] devtools: fix symbols handling and display

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -117,6 +117,15 @@
             length += element.length;
             result.push(element);
           }
+          for (const key of Object.getOwnPropertySymbols(obj)) {
+            if (length > 25) {
+              result.push("...");
+              break;
+            }
+            const element = key.toString() + ": " + this.serializeItem(obj[key]);
+            length += element.length;
+            result.push(element);
+          }
           return "{" + result.join(", ") + "}";
         },
         map(obj) {
@@ -815,7 +824,8 @@
               break;
             case obj instanceof Object:
               child.contentType = "object";
-              child.hasChildren = Object.keys(obj).length > 0;
+              child.hasChildren =
+                Object.keys(obj).length || Object.getOwnPropertySymbols(obj).length;
               break;
             default:
               child.contentType = typeof obj;
@@ -1433,8 +1443,11 @@
           return;
         }
       }
-      const key = path.pop().value;
+      const item = path.pop();
       const obj = this.getObjectProperty(path);
+      const key = item.hasOwnProperty("symbolIndex")
+        ? Object.getOwnPropertySymbols(obj)[item.symbolIndex]
+        : item.value;
       if (!obj) {
         return;
       }


### PR DESCRIPTION
This commit fixes the three following issues:
- Symbols could never appear in shortened display of objects
- Objects which contained only symbols as keys would be considered to be empty and therefore not expandable
- Symbol value edition would create a new property on the object with the stringified symbol as key instead of updating its value 

closes https://github.com/odoo/owl/issues/1464