### PR TITLE
[FIX] devtools: Fix crash when no root node

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -1519,8 +1519,9 @@
           }
         }
       }
-      // If nothing was found, return the first app's root component path
-      return ["0", "root"];
+      // If nothing was found, return the path of the first root component found in the apps
+      const appIndex = [...this.apps].findIndex((app) => app.root);
+      return [appIndex.toString(), "root"];
     }
     // Returns the tree of components of the inspected page in a parsed format
     // Use inspectedPath to specify the path of the selected component


### PR DESCRIPTION
This commit fixes a crash in the retrieval of the components tree which happened when the first app did not contain a root node. The default inspected component is now set to be the first root component found in the apps.