### PR TITLE
[FIX] compiler: allow t-out on component tag

### DIFF
--- a/tests/compiler/parser.test.ts
+++ b/tests/compiler/parser.test.ts
@@ -1569,6 +1569,12 @@ describe("qweb parser", () => {
     );
   });
 
+  test("component with t-out", async () => {
+    expect(parse(`<MyComponent t-out="someValue"/>`)).toEqual(
+      parse(`<MyComponent><t t-out="someValue"/></MyComponent>`)
+    );
+  });
+
   test("component with t-esc and content", async () => {
     expect(() => parse(`<MyComponent t-esc="someValue">Some content</MyComponent>`)).toThrow(
       "Cannot have t-esc on a component that already has content"


### PR DESCRIPTION
Before this commit, the template parser would allow using t-esc on a component tag (<MyComponent t-esc="expr"/>) but would incorrectly ignore the component when parsing a t-out: <MyComponent t-out="expr"/> would be parsed as <t t-out="expr"/>

This commit solves the issue, and also, moves the `t-out` parsing code next to `t-esc` so they have the same priority relatively to other directives.

closes #1483