### PR TITLE
[FIX] app: sync destroy everythig when app is destroyed

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -136,8 +136,8 @@ export class App<
 
   destroy() {
     if (this.root) {
-      this.scheduler.flush();
       this.root.destroy();
+      this.scheduler.processTasks();
     }
     window.__OWL_DEVTOOLS__.apps.delete(this);
   }

--- a/tests/app/__snapshots__/app.test.ts.snap
+++ b/tests/app/__snapshots__/app.test.ts.snap
@@ -15,6 +15,34 @@ exports[`app App supports env with getters/setters 1`] = `
 }"
 `;
 
+exports[`app app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`B\`, true, false, false, []);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let b2,b3;
+    b2 = text(\`A\`);
+    if (ctx['state'].value) {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`app app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(\`B\`);
+  }
+}"
+`;
+
 exports[`app can configure an app with props 1`] = `
 "function anonymous(app, bdom, helpers
 ) {


### PR DESCRIPTION
Before this commit, the App destroy method would not destroy everything synchronously. The code scheduled a flush, which is asynchronous, to finally clean up the task lists, and destroy the cancelled nodes. But this is not really good for tests: we need a stronger guarantee that nothing will happen after the destroy.

With this commit, we simply call the processTask method immediately after destroying the root component, so all cancelled nodes will be destroyed immediately.