### PR TITLE
[IMP] lazy reactive computed value

### DIFF
--- a/src/runtime/computed.ts
+++ b/src/runtime/computed.ts
@@ -1,0 +1,79 @@
+import { Reactive, Target, multiReactive, toRaw } from "./reactivity";
+
+/**
+ * Creates a lazy reactive computed value.
+ *
+ * Calling the resulting function on the target not only returns the computed value,
+ * it also caches the result in the target. As a result, succeeding function calls
+ * will not trigger recalculation. And because of the reactivity system, the cached
+ * value will be invalidated when any of the dependencies of the compute function
+ * changes.
+ *
+ * Aside from caching, the computation is part of the reactivity system. This means
+ * that it plays well with rerendering. For example, having the following tree,
+ * `<Root><A/><B/></Root>`, where `A` reads from a computed value, when the computed
+ * value changes (or the dependencies of the computed value changes), only the
+ * components that read from the computed value will rerender. In this case, only
+ * `A` will rerender.
+ *
+ * Note that this is only valid for one target and one compute function.
+ * Use `computed` for shared compute functions.
+ */
+export function defineComputed(compute: (target: any) => any, name?: string) {
+  // This is the key that will be used to store the compute value in the target.
+  const cacheKey = name ? Symbol(name) : Symbol();
+  let isValid = false;
+  const invalidate = () => (isValid = false);
+  return (target: any) => {
+    if (isValid) {
+      // Return the cached value if it is still valid.
+      // This will subscribe the target's reactive directly to the cached value.
+      return target[cacheKey];
+    } else {
+      // Create a target with multiple reactives.
+      // - First is the original target's reactive.
+      // - Second is the invalidate function.
+      // This means that when any of the dependencies of the compute function changes,
+      // the invalidate function and the original target's reactive will be notified.
+      const mTarget = multiReactive(target, invalidate);
+      // Call the compute function on the multi-reactive target.
+      // This will subscribe the reactives to the dependencies of the compute function.
+      const value = compute(mTarget);
+      isValid = true;
+      try {
+        return value;
+      } finally {
+        // Right after return, the value is cached in the target.
+        // This will notify the subscribers of this computed value.
+        target[cacheKey] = value;
+      }
+    }
+  };
+}
+
+// map: target -> compute -> cached compute
+const t2c2cc = new WeakMap();
+
+/**
+ * This allows sharing of a declared computed such that for each target-compute
+ * combination, there is a corresponding cached computed function.
+ */
+export function computed<T extends Target, R>(
+  compute: (target: T | Reactive<T>) => R,
+  name?: string
+) {
+  return (target: T | Reactive<T>): R => {
+    const raw = toRaw(target);
+    let c2cc = t2c2cc.get(raw);
+    if (!c2cc) {
+      c2cc = new Map();
+      t2c2cc.set(raw, c2cc);
+    }
+    let cachedCompute = c2cc.get(compute);
+    if (!cachedCompute) {
+      cachedCompute = defineComputed(compute, name);
+      c2cc.set(compute, cachedCompute);
+    }
+    return cachedCompute(target);
+  };
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -40,6 +40,7 @@ export type { ComponentConstructor } from "./component";
 export { useComponent, useState } from "./component_node";
 export { status } from "./status";
 export { reactive, markRaw, toRaw } from "./reactivity";
+export { computed } from "./computed";
 export { useEffect, useEnv, useExternalListener, useRef, useChildSubEnv, useSubEnv } from "./hooks";
 export { EventBus, whenReady, loadFile, markup } from "./utils";
 export {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,5 +1,5 @@
 import { OwlError } from "../common/owl_error";
-export type Callback = () => void;
+export type Callback = (() => void) | [first: Callback, second: Callback];
 
 /**
  * Creates a batched version of a callback so that all calls to it in the same
@@ -8,9 +8,9 @@ export type Callback = () => void;
  * @param callback the callback to batch
  * @returns a batched version of the original callback
  */
-export function batched(callback: Callback): Callback {
+export function batched<Args extends any[]>(callback: (...args: Args) => any) {
   let scheduled = false;
-  return async (...args) => {
+  return async (...args: Args) => {
     if (!scheduled) {
       scheduled = true;
       await Promise.resolve();

--- a/tests/computed.test.ts
+++ b/tests/computed.test.ts
@@ -1,0 +1,460 @@
+import { reactive, computed, mount, Component, useState, onRendered, xml } from "../src";
+import { batched } from "../src/runtime/utils";
+import { makeTestFixture, nextMicroTick, nextTick } from "./helpers";
+
+function effect<T extends object>(dep: T, fn: (o: T) => void) {
+  const r: any = reactive(dep, () => fn(r));
+  fn(r);
+}
+
+describe("computed - with effect", () => {
+  let orderComputeCounts = { itemTotal: 0, orderTotal: 0 };
+  const resetOrderComputeCounts = () => {
+    orderComputeCounts.itemTotal = 0;
+    orderComputeCounts.orderTotal = 0;
+  };
+
+  const expectOrderComputeCounts = (expected: { itemTotal: number; orderTotal: number }) => {
+    expect(orderComputeCounts).toEqual(expected);
+    resetOrderComputeCounts();
+  };
+
+  beforeEach(() => {
+    resetOrderComputeCounts();
+  });
+
+  type Product = { unitPrice: number };
+  type OrderItem = { product: Product; quantity: number };
+  type Order = { items: OrderItem[]; discount: number };
+
+  const createProduct = (unitPrice: number): Product => {
+    return reactive({ unitPrice });
+  };
+
+  const createOrderItem = (product: Product, quantity: number) => {
+    return reactive({ product, quantity });
+  };
+
+  const createOrder = (): Order => {
+    return reactive({ items: [], discount: 0 });
+  };
+
+  const getItemTotal = computed((item: OrderItem) => {
+    orderComputeCounts.itemTotal++;
+
+    return item.product.unitPrice * item.quantity;
+  });
+
+  const getOrderTotal = computed((order: Order) => {
+    orderComputeCounts.orderTotal++;
+
+    let result = 0;
+    for (let item of order.items) {
+      result += getItemTotal(item);
+    }
+    return result * (1 - order.discount / 100);
+  });
+
+  test("effect depends on getter", () => {
+    let distanceComputeCount = 0;
+    const expectDistanceComputeCount = (expected: number) => {
+      expect(distanceComputeCount).toBe(expected);
+      distanceComputeCount = 0;
+    };
+
+    // point <- computed distance <- computed deepComputedVal
+    const point = reactive({ x: 0, y: 0 });
+    const distance = computed((p: typeof point) => {
+      distanceComputeCount++;
+      return Math.sqrt(Math.pow(p.x, 2) + Math.pow(p.y, 2));
+    });
+    const deepComputedVal = computed((p: typeof point) => {
+      // absurd computation to test that the getter is not recomputed
+      let result = 0;
+      for (let i = 0; i < 5; i++) {
+        result += distance(p);
+      }
+      return result;
+    });
+
+    let val = 0;
+    effect(point, (p) => {
+      // Notice that in this effect, only the `deepComputedVal` is directly used.
+      // It is indirectly dependent on the `x` and `y` of `p`.
+      // Nevertheless, mutating `x` or `y` should trigger this effect.
+      val = deepComputedVal(p);
+    });
+
+    expect(val).toEqual(0);
+    expectDistanceComputeCount(1);
+    expect(distance(point)).toEqual(0);
+    // No recomputation even after the previous `distance` call.
+    expectDistanceComputeCount(0);
+
+    point.x = 3;
+    expect(val).toEqual(15);
+    expectDistanceComputeCount(1);
+    expect(distance(point)).toEqual(3);
+    // No recomputation even after the previous `distance` call.
+    expectDistanceComputeCount(0);
+
+    point.y = 4;
+    expect(val).toEqual(25);
+    expectDistanceComputeCount(1);
+    expect(distance(point)).toEqual(5);
+    // No recomputation even after the previous `distance` call.
+    expectDistanceComputeCount(0);
+  });
+
+  test("can depend on network of objects", () => {
+    const p1 = createProduct(10);
+    const p2 = createProduct(20);
+    const p3 = createProduct(30);
+    const o = createOrder();
+    o.items.push(createOrderItem(p1, 1));
+    o.items.push(createOrderItem(p2, 2));
+    o.items.push(createOrderItem(p3, 3));
+
+    let orderTotal = 0;
+    effect(o, (o) => {
+      orderTotal = getOrderTotal(o);
+    });
+
+    expect(orderTotal).toEqual(140);
+
+    p1.unitPrice = 11;
+    expect(orderTotal).toEqual(141);
+
+    o.items[1].quantity = 4;
+    expect(orderTotal).toEqual(181);
+
+    o.items.push(createOrderItem(createProduct(40), 1));
+    expect(orderTotal).toEqual(221);
+  });
+
+  test("batched effect", async () => {
+    const p1 = createProduct(10);
+    const p2 = createProduct(20);
+    const p3 = createProduct(30);
+    const o = createOrder();
+    o.items.push(createOrderItem(p1, 1));
+    o.items.push(createOrderItem(p2, 2));
+    o.items.push(createOrderItem(p3, 3));
+
+    let orderTotal = 0;
+    effect(
+      o,
+      batched((o) => {
+        orderTotal = getOrderTotal(o);
+      })
+    );
+
+    await nextMicroTick();
+
+    expect(orderTotal).toEqual(140);
+    expectOrderComputeCounts({ itemTotal: 3, orderTotal: 1 });
+
+    p1.unitPrice = 11;
+    await nextMicroTick();
+
+    expect(orderTotal).toEqual(141);
+    expectOrderComputeCounts({ itemTotal: 1, orderTotal: 1 });
+
+    o.items[1].quantity = 4;
+    p3.unitPrice = 31;
+    await nextMicroTick();
+
+    expect(orderTotal).toEqual(184);
+    expectOrderComputeCounts({ itemTotal: 2, orderTotal: 1 });
+
+    o.items.push(createOrderItem(createProduct(40), 1));
+    o.items[0].quantity = 5;
+    p2.unitPrice = 21;
+    await nextMicroTick();
+
+    expect(orderTotal).toEqual(272);
+    expectOrderComputeCounts({ itemTotal: 3, orderTotal: 1 });
+    expect(getOrderTotal(o)).toEqual(272);
+    // No recomputation even after the previous `getOrderTotal` call.
+    expectOrderComputeCounts({ itemTotal: 0, orderTotal: 0 });
+
+    o.discount = 10;
+    await nextMicroTick();
+    expect(orderTotal).toEqual(244.8);
+    expectOrderComputeCounts({ itemTotal: 0, orderTotal: 1 });
+  });
+});
+
+describe("computed - with components", () => {
+  type State = { a: number; b: number };
+
+  let fixture: HTMLElement;
+  let computeCounts = { c: 0, d: 0, e: 0, f: 0 };
+
+  const expectComputeCounts = (expected: { c: number; d: number; e: number; f: number }) => {
+    expect(computeCounts).toEqual(expected);
+    computeCounts = { c: 0, d: 0, e: 0, f: 0 };
+  };
+
+  beforeEach(() => {
+    fixture = makeTestFixture();
+    computeCounts = { c: 0, d: 0, e: 0, f: 0 };
+  });
+
+  const c = computed((self: State) => {
+    computeCounts.c++;
+    return self.a + self.b;
+  });
+  const d = computed((self: State) => {
+    computeCounts.d++;
+    return 2 * self.a;
+  });
+  const e = computed((self: State) => {
+    computeCounts.e++;
+    let result = 0;
+    for (let i = 0; i < 5; i++) {
+      result += c(self) + d(self);
+    }
+    return result;
+  });
+  const f = computed((self: State) => {
+    computeCounts.f++;
+    let result = 0;
+    for (let i = 0; i < 10; i++) {
+      result += d(self);
+    }
+    return result;
+  });
+
+  const updateA = (self: State, by: number) => {
+    self.a += by;
+  };
+  const updateB = (self: State, by: number) => {
+    self.b += by;
+  };
+
+  const createComponents = (state: State) => {
+    let renderCounts = { App: 0, C: 0, D: 0, E: 0, F: 0 };
+    const expectRenderCounts = (expected: {
+      App: number;
+      C: number;
+      D: number;
+      E: number;
+      F: number;
+    }) => {
+      expect(renderCounts).toEqual(expected);
+      renderCounts = { App: 0, C: 0, D: 0, E: 0, F: 0 };
+    };
+
+    class BaseComp extends Component {
+      state = useState(state);
+      setup() {
+        Object.assign(this, { c, d, e, f });
+        onRendered(() => {
+          const name = (this.constructor as any).name as keyof typeof renderCounts;
+          renderCounts[name]++;
+        });
+      }
+    }
+    class C extends BaseComp {
+      static components = {};
+    }
+    class D extends BaseComp {
+      static components = {};
+    }
+    class E extends BaseComp {
+      static components = {};
+    }
+    class F extends BaseComp {
+      static components = {};
+    }
+    class App extends BaseComp {
+      static components = {};
+    }
+    return { App, C, D, E, F, expectRenderCounts };
+  };
+
+  test("number of rerendering - sibling components", async () => {
+    const state = reactive({ a: 1, b: 1 });
+    const { App, C, D, E, F, expectRenderCounts } = createComponents(state);
+
+    C.template = xml`<p t-out="c(state)" />`;
+
+    D.template = xml`<p t-out="d(state)" />`;
+
+    E.template = xml`<p t-out="e(state)" />`;
+
+    F.template = xml`<p t-out="f(state)" />`;
+
+    App.template = xml`<div><C /><D /><E /><F /></div>`;
+    App.components = { C, D, E, F };
+
+    await mount(App, fixture);
+    expectRenderCounts({ App: 1, C: 1, D: 1, E: 1, F: 1 });
+
+    updateA(state, 1);
+    await nextTick();
+    // App doesn't depend on the state, therefore it doesn't re-render
+    expectRenderCounts({ App: 0, C: 1, D: 1, E: 1, F: 1 });
+
+    updateB(state, 1);
+    await nextTick();
+    // changing b doesn't affect d
+    expectRenderCounts({ App: 0, C: 1, D: 0, E: 1, F: 0 });
+
+    // Multiple changes should only render once.
+    for (let i = 0; i < 10; i++) {
+      updateA(state, 1);
+    }
+    await nextTick();
+    expectRenderCounts({ App: 0, C: 1, D: 1, E: 1, F: 1 });
+  });
+
+  test("number of rerenderings - nested components", async () => {
+    const state = reactive({ a: 1, b: 1 });
+    const { App, C, D, E, F, expectRenderCounts } = createComponents(state);
+
+    F.template = xml`<p t-out="f(state)" />`;
+
+    E.template = xml`<div><p t-out="e(state)" /><F /></div>`;
+    E.components = { F };
+
+    D.template = xml`<div><p t-out="d(state)" /><E /></div>`;
+    D.components = { E };
+
+    C.template = xml`<div><p t-out="c(state)" /><D /></div>`;
+    C.components = { D };
+
+    App.template = xml`<div><C /></div>`;
+    App.components = { C };
+
+    await mount(App, fixture);
+    expectRenderCounts({ App: 1, C: 1, D: 1, E: 1, F: 1 });
+
+    updateA(state, 1);
+    await nextTick();
+    // App doesn't depend on the state, therefore it doesn't re-render
+    expectRenderCounts({ App: 0, C: 1, D: 1, E: 1, F: 1 });
+
+    updateB(state, 1);
+    await nextTick();
+    // changing b doesn't affect d
+    expectRenderCounts({ App: 0, C: 1, D: 0, E: 1, F: 0 });
+
+    // Multiple changes should only render once.
+    for (let i = 0; i < 10; i++) {
+      updateA(state, 1);
+    }
+    await nextTick();
+    expectRenderCounts({ App: 0, C: 1, D: 1, E: 1, F: 1 });
+  });
+
+  test("number of compute calls in components", async () => {
+    const state = reactive({ a: 1, b: 1 });
+    const { App, C, D, E, F } = createComponents(state);
+
+    C.template = xml`<p t-out="c(state)" />`;
+
+    D.template = xml`<p t-out="d(state)" />`;
+
+    E.template = xml`<p t-out="e(state)" />`;
+
+    F.template = xml`<p t-out="f(state)" />`;
+
+    App.template = xml`<div><C /><D /><E /><F /></div>`;
+    App.components = { C, D, E, F };
+
+    await mount(App, fixture);
+    expectComputeCounts({ c: 1, d: 1, e: 1, f: 1 });
+
+    updateA(state, 1);
+    await nextTick();
+    // everything will be re-computed
+    expectComputeCounts({ c: 1, d: 1, e: 1, f: 1 });
+
+    updateB(state, 1);
+    await nextTick();
+    // only c and e will be re-computed
+    expectComputeCounts({ c: 1, d: 0, e: 1, f: 0 });
+
+    // update both
+    updateA(state, 1);
+    updateB(state, 1);
+    await nextTick();
+    // all will be re-computed and only once
+    expectComputeCounts({ c: 1, d: 1, e: 1, f: 1 });
+  });
+
+  test("more complicated compute tree", async () => {
+    const state = reactive({ x: 3, y: 2 });
+    const b = computed((self: typeof state) => {
+      return self.x + self.y;
+    }, "computed b");
+    const e = computed((self: typeof state) => {
+      return b(self) * self.x;
+    }, "computed e");
+    const f = computed((self: typeof state) => {
+      return e(self) + b(self);
+    }, "computed f");
+
+    const renderCounts = { A: 0, C: 0 };
+    const expectRenderCounts = (expected: { A: number; C: number }) => {
+      expect(renderCounts).toEqual(expected);
+      renderCounts.A = 0;
+      renderCounts.C = 0;
+    };
+
+    class BaseComp extends Component {
+      state = useState(state);
+      setup() {
+        Object.assign(this, { b, e, f });
+      }
+    }
+    class A extends BaseComp {
+      static components = {};
+      static template = xml`<p id="A" t-out="f(state)" />`;
+      setup() {
+        super.setup();
+        onRendered(() => {
+          renderCounts.A++;
+        });
+      }
+    }
+    class C extends BaseComp {
+      static components = {};
+      static template = xml`<p id="C" t-out="f(state)" />`;
+      setup() {
+        super.setup();
+        onRendered(() => {
+          renderCounts.C++;
+        });
+      }
+    }
+    class App extends Component {
+      static components = { A, C };
+      static template = xml`<div><A /><C /></div>`;
+    }
+
+    await mount(App, fixture);
+    expect(fixture.innerHTML).toEqual('<div><p id="A">20</p><p id="C">20</p></div>');
+    expectRenderCounts({ A: 1, C: 1 });
+
+    state.x = 4;
+    await nextTick();
+    expect(fixture.innerHTML).toEqual('<div><p id="A">30</p><p id="C">30</p></div>');
+    expectRenderCounts({ A: 1, C: 1 });
+
+    // Mutating both should also result to just one re-rendering.
+    state.x = 10;
+    state.y = 20;
+    await nextTick();
+    expect(fixture.innerHTML).toEqual('<div><p id="A">330</p><p id="C">330</p></div>');
+    expectRenderCounts({ A: 1, C: 1 });
+
+    // Setting without change of value should not re-render.
+    state.x = 10;
+    await nextTick();
+    expect(fixture.innerHTML).toEqual('<div><p id="A">330</p><p id="C">330</p></div>');
+    expectRenderCounts({ A: 0, C: 0 });
+  });
+});


### PR DESCRIPTION
**Problem:** Prior to this commit, existing implementations of computed values
are eager. An example is the `withComputedProperties` in odoo's web addon, see:
[^1]. It has an issue such that it can lead to triggering of the compute
function even if the target is still in invalid state -- e.g. removing an item
in an array. This can be solved by batching the recomputation with `batched`.
But once the compute is batched, the computed value can't be used by other
computed values, because it won't recompute until the next tick -- it's not part
of the same synchronous context.

**Proposed solution:** This commit introduces a implementation of computed value
that is pull-based -- it only recomputes when it's needed. The main logic is the
following:

- A computed value is declared with a single-parameter function wrapped with
  `computed`.
- The compute function has a cache that stores the result of the computation.
- The cached value is invalidated when one of the dependencies of the compute
  function changes.
  - During invalidation, the cache is only marked as invalid and the
    recomputation is not made.
- A dependent computation such as an effect may indirectly depend in the
  dependencies of a computed value[^2]. This is an important detail because
  without this, the 'laziness' of the computed value won't trigger the dependent
  effect.
  - This indirect dependency tracking is achieved by using the introduced notion
    of multi-reactive target where a target can have multiple callbacks linked
    to it.
  - During recomputation of the computed value, both the target's reactive and
    the invalidation callback are subscribed to the dependencies of the computed
    value. But when the value is cached, only the target's reactive callback is
    subscribed.

With this implementation, we achieve a lazy computed value that plays well with
the existing reactive system.

---

Here's an illustration on how the computed values interact with the rendering.
[Source](https://drive.google.com/file/d/1mk8PoWq18NtNoMw6gQgjugMLDtqaf48Z/view?usp=sharing)

![computed drawio](https://github.com/odoo/owl/assets/3245568/a12a1dea-68c8-4c48-afdb-ba28dbcb5c62)

---

[^1]: https://github.com/odoo/odoo/blob/15d7cf12b98bf0223371b8cca91ef6f79c60ee31/addons/web/static/src/core/utils/reactive.js#L58
[^2]: It's possible that in the dependency graph, an effect is affected by
invalidation. This effect will be triggered which will potentially ask for the
value of the computed value which will trigger the recomputation.