### PR TITLE
[IMP] runtime: add support for strings in t-foreach

### DIFF
--- a/src/runtime/template_helpers.ts
+++ b/src/runtime/template_helpers.ts
@@ -78,6 +78,9 @@ function prepareList(collection: unknown): [unknown[], unknown[], number, undefi
       values = Object.values(collection);
       keys = Object.keys(collection);
     }
+  } else if (typeof collection === "string") {
+    keys = [...collection];
+    values = keys;
   } else {
     throw new OwlError(`Invalid loop expression: "${collection}" is not iterable`);
   }


### PR DESCRIPTION
c6b38bf55fa4d9246dfbbd7a5b669c6ef2b87c66 introduced support for iterables in t-foreach, but assumed that iterables are always objects, forgetting strings.

This commit adds the missing code to support strings in t-foreach.