### PR TITLE
[IMP] runtime: do not check template equality outside dev mode

### DIFF
--- a/src/runtime/template_set.ts
+++ b/src/runtime/template_set.ts
@@ -66,6 +66,10 @@ export class TemplateSet {
 
   addTemplate(name: string, template: string | Element) {
     if (name in this.rawTemplates) {
+      // this check can be expensive, just silently ignore double definitions outside dev mode
+      if (!this.dev) {
+        return;
+      }
       const rawTemplate = this.rawTemplates[name];
       const currentAsString =
         typeof rawTemplate === "string"

--- a/tests/compiler/validation.test.ts
+++ b/tests/compiler/validation.test.ts
@@ -11,13 +11,20 @@ describe("basic validation", () => {
     expect(() => context.getTemplate("invalidname")).toThrow("Missing template");
   });
 
-  test("cannot add a different template with the same name", () => {
-    const context = new TemplateSet();
+  test("cannot add a different template with the same name in dev mode", () => {
+    const context = new TemplateSet({ dev: true });
     context.addTemplate("test", `<t/>`);
     // Same template with the same name is fine
     expect(() => context.addTemplate("test", "<t/>")).not.toThrow();
     // Different template with the same name crashes
     expect(() => context.addTemplate("test", "<div/>")).toThrow("already defined");
+  });
+
+  test("adding different template with same name outside dev mode silently ignores it", () => {
+    const context = new TemplateSet({ dev: false });
+    context.addTemplate("test", `<t/>`);
+    expect(() => context.addTemplate("test", "<div/>")).not.toThrow();
+    expect(context.rawTemplates.test).toBe("<t/>");
   });
 
   test("invalid xml", () => {


### PR DESCRIPTION
When defining a template with a name that the template set already contains, we currently always check whether the template is the same and throw an error when it's not. This is potentially expensive as it can involve serializing a pretty large XML document. This check is only supposed to help during development so this commit disables this check outside dev mode.