### PR TITLE
[IMP] devtools: add svg elements detection

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -1396,7 +1396,7 @@
         return this.getDOMElementsRecursive(node.content);
       }
       if (node.hasOwnProperty("el")) {
-        if (node.el instanceof HTMLElement || node.el instanceof Text) {
+        if (node.el instanceof Element || node.el instanceof Text) {
           return [node.el];
         }
       }
@@ -1415,7 +1415,7 @@
         }
       }
       if (node.hasOwnProperty("parentEl")) {
-        if (node.parentEl instanceof HTMLElement) {
+        if (node.parentEl instanceof Element) {
           return [node.parentEl];
         }
       }


### PR DESCRIPTION
This commit extends the detection of component related dom elements to svg elements in the page so that they can be searched and highlighted correctly with the devtools.