### PR TITLE
[FIX] doc: error handling example

### DIFF
--- a/doc/reference/error_handling.md
+++ b/doc/reference/error_handling.md
@@ -51,8 +51,8 @@ that render its content, and a fallback if an error happened.
 ```js
 class ErrorBoundary extends Component {
   static template = xml`
-    <t t-if="error" t-slot="fallback">An error occurred</t>
-    <t t-else="" t-slot="content"`;
+    <t t-if="state.error" t-slot="fallback">An error occurred</t>
+    <t t-else="" t-slot="default"/>`;
 
   setup() {
     this.state = useState({ error: false });


### PR DESCRIPTION
A few corrections to make the example more realistic:
- The component has no `error` property, so the writer probably meant `state.error`.
- The "content" slot is not being set, and "default" does the job in this case.
- The closing tag was missing in the `ErrorBoundary`'s template.