### PR TITLE
[IMP] tests: use inline snapshots for lifecycle checks

### DIFF
--- a/tests/app/__snapshots__/app.test.ts.snap
+++ b/tests/app/__snapshots__/app.test.ts.snap
@@ -32,7 +32,7 @@ exports[`app app: clear scheduler tasks and destroy cancelled nodes immediately 
 }"
 `;
 
-exports[`app app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 2`] = `
+exports[`app app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;

--- a/tests/app/app.test.ts
+++ b/tests/app/app.test.ts
@@ -8,6 +8,7 @@ import {
   useLogLifecycle,
   makeDeferred,
   nextMicroTick,
+  steps,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -123,23 +124,47 @@ describe("app", () => {
 
     const app = new App(A);
     const comp = await app.mount(fixture);
-    expect(["A:setup", "A:willStart", "A:willRender", "A:rendered", "A:mounted"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:setup",
+        "A:willStart",
+        "A:willRender",
+        "A:rendered",
+        "A:mounted",
+      ]
+    `);
 
     comp.state.value = true;
     await nextTick();
-    expect(["A:willRender", "B:setup", "B:willStart", "A:rendered"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:willRender",
+        "B:setup",
+        "B:willStart",
+        "A:rendered",
+      ]
+    `);
 
     // rerender to force the instantiation of a new B component (and cancelling the first)
     comp.render();
     await nextMicroTick();
-    expect(["A:willRender", "B:setup", "B:willStart", "A:rendered"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:willRender",
+        "B:setup",
+        "B:willStart",
+        "A:rendered",
+      ]
+    `);
 
     app.destroy();
-    expect([
-      "A:willUnmount",
-      "B:willDestroy",
-      "A:willDestroy",
-      "B:willDestroy", // make sure the 2 B instances have been destroyed synchronously
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:willUnmount",
+        "B:willDestroy",
+        "A:willDestroy",
+        "B:willDestroy",
+      ]
+    `);
   });
 });

--- a/tests/components/__snapshots__/concurrency.test.ts.snap
+++ b/tests/components/__snapshots__/concurrency.test.ts.snap
@@ -184,7 +184,7 @@ exports[`changing state before first render does not trigger a render (with pare
 }"
 `;
 
-exports[`changing state before first render does not trigger a render (with parent) 2`] = `
+exports[`changing state before first render does not trigger a render (with parent) 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -254,7 +254,7 @@ exports[`components are not destroyed between animation frame 1`] = `
 }"
 `;
 
-exports[`components are not destroyed between animation frame 2`] = `
+exports[`components are not destroyed between animation frame 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -268,7 +268,7 @@ exports[`components are not destroyed between animation frame 2`] = `
 }"
 `;
 
-exports[`components are not destroyed between animation frame 3`] = `
+exports[`components are not destroyed between animation frame 5`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -748,7 +748,7 @@ exports[`concurrent renderings scenario 10 2`] = `
 }"
 `;
 
-exports[`concurrent renderings scenario 10 3`] = `
+exports[`concurrent renderings scenario 10 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -993,7 +993,7 @@ exports[`concurrent renderings scenario 16 3`] = `
 }"
 `;
 
-exports[`concurrent renderings scenario 16 4`] = `
+exports[`concurrent renderings scenario 16 6`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1024,7 +1024,7 @@ exports[`creating two async components, scenario 1 1`] = `
 }"
 `;
 
-exports[`creating two async components, scenario 1 2`] = `
+exports[`creating two async components, scenario 1 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1038,7 +1038,7 @@ exports[`creating two async components, scenario 1 2`] = `
 }"
 `;
 
-exports[`creating two async components, scenario 1 3`] = `
+exports[`creating two async components, scenario 1 5`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1085,7 +1085,7 @@ exports[`creating two async components, scenario 2 2`] = `
 }"
 `;
 
-exports[`creating two async components, scenario 2 3`] = `
+exports[`creating two async components, scenario 2 5`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1133,7 +1133,7 @@ exports[`creating two async components, scenario 3 (patching in the same frame) 
 }"
 `;
 
-exports[`creating two async components, scenario 3 (patching in the same frame) 3`] = `
+exports[`creating two async components, scenario 3 (patching in the same frame) 5`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1308,7 +1308,7 @@ exports[`delayed render does not go through when t-component value changed 2`] =
 }"
 `;
 
-exports[`delayed render does not go through when t-component value changed 3`] = `
+exports[`delayed render does not go through when t-component value changed 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1617,7 +1617,7 @@ exports[`destroyed component causes other soon to be destroyed component to rere
 }"
 `;
 
-exports[`destroyed component causes other soon to be destroyed component to rerender, weird stuff happens 2`] = `
+exports[`destroyed component causes other soon to be destroyed component to rerender, weird stuff happens 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1628,7 +1628,7 @@ exports[`destroyed component causes other soon to be destroyed component to rere
 }"
 `;
 
-exports[`destroyed component causes other soon to be destroyed component to rerender, weird stuff happens 3`] = `
+exports[`destroyed component causes other soon to be destroyed component to rerender, weird stuff happens 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1656,7 +1656,7 @@ exports[`destroying/recreating a subcomponent, other scenario 1`] = `
 }"
 `;
 
-exports[`destroying/recreating a subcomponent, other scenario 2`] = `
+exports[`destroying/recreating a subcomponent, other scenario 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1685,7 +1685,7 @@ exports[`destroying/recreating a subwidget with different props (if start is not
 }"
 `;
 
-exports[`destroying/recreating a subwidget with different props (if start is not over) 2`] = `
+exports[`destroying/recreating a subwidget with different props (if start is not over) 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -1787,7 +1787,7 @@ exports[`rendering component again in next microtick 1`] = `
 }"
 `;
 
-exports[`rendering component again in next microtick 2`] = `
+exports[`rendering component again in next microtick 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;

--- a/tests/components/__snapshots__/error_handling.test.ts.snap
+++ b/tests/components/__snapshots__/error_handling.test.ts.snap
@@ -241,7 +241,7 @@ exports[`can catch errors an error in onWillDestroy, variation 1`] = `
 }"
 `;
 
-exports[`can catch errors an error in onWillDestroy, variation 2`] = `
+exports[`can catch errors an error in onWillDestroy, variation 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;

--- a/tests/components/__snapshots__/lifecycle.test.ts.snap
+++ b/tests/components/__snapshots__/lifecycle.test.ts.snap
@@ -92,7 +92,7 @@ exports[`lifecycle hooks component semantics 5`] = `
 }"
 `;
 
-exports[`lifecycle hooks component semantics 6`] = `
+exports[`lifecycle hooks component semantics 7`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -185,7 +185,7 @@ exports[`lifecycle hooks destroy new children before being mountged 1`] = `
 }"
 `;
 
-exports[`lifecycle hooks destroy new children before being mountged 2`] = `
+exports[`lifecycle hooks destroy new children before being mountged 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -291,7 +291,7 @@ exports[`lifecycle hooks lifecycle semantics, part 2 1`] = `
 }"
 `;
 
-exports[`lifecycle hooks lifecycle semantics, part 2 2`] = `
+exports[`lifecycle hooks lifecycle semantics, part 2 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -303,7 +303,7 @@ exports[`lifecycle hooks lifecycle semantics, part 2 2`] = `
 }"
 `;
 
-exports[`lifecycle hooks lifecycle semantics, part 2 3`] = `
+exports[`lifecycle hooks lifecycle semantics, part 2 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -348,7 +348,7 @@ exports[`lifecycle hooks lifecycle semantics, part 4 1`] = `
 }"
 `;
 
-exports[`lifecycle hooks lifecycle semantics, part 4 2`] = `
+exports[`lifecycle hooks lifecycle semantics, part 4 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -360,7 +360,7 @@ exports[`lifecycle hooks lifecycle semantics, part 4 2`] = `
 }"
 `;
 
-exports[`lifecycle hooks lifecycle semantics, part 4 3`] = `
+exports[`lifecycle hooks lifecycle semantics, part 4 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;

--- a/tests/components/__snapshots__/t_component.test.ts.snap
+++ b/tests/components/__snapshots__/t_component.test.ts.snap
@@ -180,7 +180,7 @@ exports[`t-component switching dynamic component 2`] = `
 }"
 `;
 
-exports[`t-component switching dynamic component 3`] = `
+exports[`t-component switching dynamic component 4`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;

--- a/tests/components/basics.test.ts
+++ b/tests/components/basics.test.ts
@@ -5,6 +5,7 @@ import {
   nextAppError,
   nextTick,
   snapshotEverything,
+  steps,
   useLogLifecycle,
 } from "../helpers";
 import { markup } from "../../src/runtime/utils";
@@ -868,19 +869,26 @@ describe("basics", () => {
 
     const parent = await mount(Parent, fixture);
     expect(Object.keys(parent.__owl__.children).length).toStrictEqual(1);
-    expect([
-      "Child:setup",
-      "Child:willStart",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:setup",
+        "Child:willStart",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+      ]
+    `);
 
     parent.ifVar = false;
     parent.render();
     await nextTick();
     expect(Object.keys(parent.__owl__.children).length).toStrictEqual(0);
-    expect(["Child:willUnmount", "Child:willDestroy"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willUnmount",
+        "Child:willDestroy",
+      ]
+    `);
   });
 
   test("component children doesn't leak (t-key case)", async () => {
@@ -899,27 +907,31 @@ describe("basics", () => {
 
     const parent = await mount(Parent, fixture);
     expect(Object.keys(parent.__owl__.children).length).toStrictEqual(1);
-    expect([
-      "Child:setup",
-      "Child:willStart",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:setup",
+        "Child:willStart",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+      ]
+    `);
 
     parent.keyVar = 2;
     parent.render();
     await nextTick();
     expect(Object.keys(parent.__owl__.children).length).toStrictEqual(1);
-    expect([
-      "Child:setup",
-      "Child:willStart",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Child:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:setup",
+        "Child:willStart",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Child:mounted",
+      ]
+    `);
   });
 
   test("GrandChild display is controlled by its GrandParent", async () => {
@@ -943,20 +955,27 @@ describe("basics", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<div></div>");
-    expect([
-      "GrandChild:setup",
-      "GrandChild:willStart",
-      "GrandChild:willRender",
-      "GrandChild:rendered",
-      "GrandChild:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "GrandChild:setup",
+        "GrandChild:willStart",
+        "GrandChild:willRender",
+        "GrandChild:rendered",
+        "GrandChild:mounted",
+      ]
+    `);
 
     parent.displayGrandChild = false;
     parent.render();
     await nextTick();
     expect(fixture.innerHTML).toBe("");
 
-    expect(["GrandChild:willUnmount", "GrandChild:willDestroy"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "GrandChild:willUnmount",
+        "GrandChild:willDestroy",
+      ]
+    `);
   });
 });
 

--- a/tests/components/error_handling.test.ts
+++ b/tests/components/error_handling.test.ts
@@ -19,6 +19,7 @@ import {
   snapshotEverything,
   useLogLifecycle,
   nextAppError,
+  steps,
 } from "../helpers";
 import { OwlError } from "../../src/common/owl_error";
 
@@ -948,26 +949,28 @@ describe("can catch errors", () => {
     }
     await mount(Root, fixture);
     expect(fixture.innerHTML).toBe("<div><div>Error handled</div></div>");
-    expect([
-      "Root:setup",
-      "Root:willStart",
-      "Root:willRender",
-      "ErrorBoundary:setup",
-      "ErrorBoundary:willStart",
-      "Root:rendered",
-      "ErrorBoundary:willRender",
-      "ErrorComponent:setup",
-      "ErrorComponent:willStart",
-      "ErrorBoundary:rendered",
-      "ErrorComponent:willRender",
-      "ErrorComponent:rendered",
-      "ErrorComponent:mounted",
-      "boom",
-      "ErrorBoundary:willRender",
-      "ErrorBoundary:rendered",
-      "ErrorBoundary:mounted",
-      "Root:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Root:setup",
+        "Root:willStart",
+        "Root:willRender",
+        "ErrorBoundary:setup",
+        "ErrorBoundary:willStart",
+        "Root:rendered",
+        "ErrorBoundary:willRender",
+        "ErrorComponent:setup",
+        "ErrorComponent:willStart",
+        "ErrorBoundary:rendered",
+        "ErrorComponent:willRender",
+        "ErrorComponent:rendered",
+        "ErrorComponent:mounted",
+        "boom",
+        "ErrorBoundary:willRender",
+        "ErrorBoundary:rendered",
+        "ErrorBoundary:mounted",
+        "Root:mounted",
+      ]
+    `);
     expect(mockConsoleError).toBeCalledTimes(0);
     expect(mockConsoleWarn).toBeCalledTimes(0);
   });
@@ -998,21 +1001,23 @@ describe("can catch errors", () => {
     }
     await mount(Root, fixture);
     expect(fixture.innerHTML).toBe("<div>Error handled</div>");
-    expect([
-      "Root:setup",
-      "Root:willStart",
-      "Root:willRender",
-      "ErrorComponent:setup",
-      "ErrorComponent:willStart",
-      "Root:rendered",
-      "ErrorComponent:willRender",
-      "ErrorComponent:rendered",
-      "ErrorComponent:mounted",
-      "boom",
-      "Root:willRender",
-      "Root:rendered",
-      "Root:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Root:setup",
+        "Root:willStart",
+        "Root:willRender",
+        "ErrorComponent:setup",
+        "ErrorComponent:willStart",
+        "Root:rendered",
+        "ErrorComponent:willRender",
+        "ErrorComponent:rendered",
+        "ErrorComponent:mounted",
+        "boom",
+        "Root:willRender",
+        "Root:rendered",
+        "Root:mounted",
+      ]
+    `);
     expect(mockConsoleError).toBeCalledTimes(0);
     expect(mockConsoleWarn).toBeCalledTimes(0);
   });
@@ -1059,31 +1064,33 @@ describe("can catch errors", () => {
     }
     await mount(A, fixture);
     expect(fixture.innerHTML).toBe("<div><div>Error handled</div></div>");
-    expect([
-      "A:setup",
-      "A:willStart",
-      "A:willRender",
-      "B:setup",
-      "B:willStart",
-      "A:rendered",
-      "B:willRender",
-      "C:setup",
-      "C:willStart",
-      "B:rendered",
-      "C:willRender",
-      "Boom:setup",
-      "Boom:willStart",
-      "C:rendered",
-      "Boom:willRender",
-      "Boom:rendered",
-      "Boom:mounted",
-      "boom",
-      "C:willRender",
-      "C:rendered",
-      "C:mounted",
-      "B:mounted",
-      "A:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:setup",
+        "A:willStart",
+        "A:willRender",
+        "B:setup",
+        "B:willStart",
+        "A:rendered",
+        "B:willRender",
+        "C:setup",
+        "C:willStart",
+        "B:rendered",
+        "C:willRender",
+        "Boom:setup",
+        "Boom:willStart",
+        "C:rendered",
+        "Boom:willRender",
+        "Boom:rendered",
+        "Boom:mounted",
+        "boom",
+        "C:willRender",
+        "C:rendered",
+        "C:mounted",
+        "B:mounted",
+        "A:mounted",
+      ]
+    `);
     expect(mockConsoleError).toBeCalledTimes(0);
     expect(mockConsoleWarn).toBeCalledTimes(0);
   });
@@ -1130,31 +1137,33 @@ describe("can catch errors", () => {
     }
     await mount(Root, fixture);
     expect(fixture.innerHTML).toBe("<div>OK<div>Error handled</div></div>");
-    expect([
-      "Root:setup",
-      "Root:willStart",
-      "Root:willRender",
-      "OK:setup",
-      "OK:willStart",
-      "ErrorBoundary:setup",
-      "ErrorBoundary:willStart",
-      "Root:rendered",
-      "OK:willRender",
-      "OK:rendered",
-      "ErrorBoundary:willRender",
-      "ErrorComponent:setup",
-      "ErrorComponent:willStart",
-      "ErrorBoundary:rendered",
-      "ErrorComponent:willRender",
-      "ErrorComponent:rendered",
-      "ErrorComponent:mounted",
-      "boom",
-      "ErrorBoundary:willRender",
-      "ErrorBoundary:rendered",
-      "ErrorBoundary:mounted",
-      "OK:mounted",
-      "Root:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Root:setup",
+        "Root:willStart",
+        "Root:willRender",
+        "OK:setup",
+        "OK:willStart",
+        "ErrorBoundary:setup",
+        "ErrorBoundary:willStart",
+        "Root:rendered",
+        "OK:willRender",
+        "OK:rendered",
+        "ErrorBoundary:willRender",
+        "ErrorComponent:setup",
+        "ErrorComponent:willStart",
+        "ErrorBoundary:rendered",
+        "ErrorComponent:willRender",
+        "ErrorComponent:rendered",
+        "ErrorComponent:mounted",
+        "boom",
+        "ErrorBoundary:willRender",
+        "ErrorBoundary:rendered",
+        "ErrorBoundary:mounted",
+        "OK:mounted",
+        "Root:mounted",
+      ]
+    `);
     expect(mockConsoleError).toBeCalledTimes(0);
     expect(mockConsoleWarn).toBeCalledTimes(0);
   });
@@ -1481,35 +1490,39 @@ describe("can catch errors", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("1<div>abc</div>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
     parent.state.hasChild = false;
     await nextTick();
     await nextTick();
     await nextTick();
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("2");
   });
 
@@ -1542,13 +1555,15 @@ describe("can catch errors", () => {
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("1");
 
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = true;
     await nextMicroTick();
@@ -1556,26 +1571,35 @@ describe("can catch errors", () => {
     await nextMicroTick();
     await nextMicroTick();
     await nextMicroTick();
-    expect([
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+      ]
+    `);
     parent.state.hasChild = false;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Child:willDestroy",
-      "Parent:willRender",
-      "Parent:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Child:willDestroy",
+        "Parent:willRender",
+        "Parent:rendered",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("1");
     await nextTick();
-    expect(["Parent:willPatch", "Parent:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("2");
   });
 });

--- a/tests/components/lifecycle.test.ts
+++ b/tests/components/lifecycle.test.ts
@@ -17,6 +17,7 @@ import {
   nextMicroTick,
   nextTick,
   snapshotEverything,
+  steps,
   useLogLifecycle,
 } from "../helpers";
 
@@ -455,45 +456,51 @@ describe("lifecycle hooks", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<div><span>0</span></div>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.increment();
     await nextTick();
     expect(fixture.innerHTML).toBe("<div><span>1</span></div>");
-    expect([
-      "Parent:willRender",
-      "Child:willUpdateProps",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Child:willPatch",
-      "Child:patched",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:willUpdateProps",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Child:willPatch",
+        "Child:patched",
+        "Parent:patched",
+      ]
+    `);
 
     parent.toggleSubWidget();
     await nextTick();
     expect(fixture.innerHTML).toBe("");
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("hooks are called in proper order in widget creation/destruction", async () => {
@@ -514,26 +521,30 @@ describe("lifecycle hooks", () => {
 
     const app = new App(Parent);
     await app.mount(fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     app.destroy();
-    expect([
-      "Parent:willUnmount",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:willDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willUnmount",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 
   test("willUpdateProps hook is called", async () => {
@@ -632,26 +643,30 @@ describe("lifecycle hooks", () => {
 
     const app = new App(Parent);
     await app.mount(fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     app.destroy();
-    expect([
-      "Parent:willUnmount",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:willDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willUnmount",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 
   test("lifecycle semantics, part 2", async () => {
@@ -680,42 +695,48 @@ describe("lifecycle hooks", () => {
 
     const app = new App(Parent);
     const parent = await app.mount(fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = true;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "GrandChild:setup",
-      "GrandChild:willStart",
-      "Child:rendered",
-      "GrandChild:willRender",
-      "GrandChild:rendered",
-      "Parent:willPatch",
-      "GrandChild:mounted",
-      "Child:mounted",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "GrandChild:setup",
+        "GrandChild:willStart",
+        "Child:rendered",
+        "GrandChild:willRender",
+        "GrandChild:rendered",
+        "Parent:willPatch",
+        "GrandChild:mounted",
+        "Child:mounted",
+        "Parent:patched",
+      ]
+    `);
 
     app.destroy();
-    expect([
-      "Parent:willUnmount",
-      "Child:willUnmount",
-      "GrandChild:willUnmount",
-      "GrandChild:willDestroy",
-      "Child:willDestroy",
-      "Parent:willDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willUnmount",
+        "Child:willUnmount",
+        "GrandChild:willUnmount",
+        "GrandChild:willDestroy",
+        "Child:willDestroy",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 
   test("lifecycle semantics, part 3", async () => {
@@ -744,19 +765,26 @@ describe("lifecycle hooks", () => {
 
     const app = new App(Parent);
     const parent = await app.mount(fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = true;
     // immediately destroy everything
     app.destroy();
     await nextTick();
-    expect(["Parent:willUnmount", "Parent:willDestroy"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willUnmount",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 
   test("lifecycle semantics, part 4", async () => {
@@ -789,34 +817,40 @@ describe("lifecycle hooks", () => {
     const app = new App(Parent);
     const parent = await app.mount(fixture);
 
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = true;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "GrandChild:setup",
-      "GrandChild:willStart",
-      "Child:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "GrandChild:setup",
+        "GrandChild:willStart",
+        "Child:rendered",
+      ]
+    `);
 
     app.destroy();
-    expect([
-      "Parent:willUnmount",
-      "GrandChild:willDestroy",
-      "Child:willDestroy",
-      "Parent:willDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willUnmount",
+        "GrandChild:willDestroy",
+        "Child:willDestroy",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 
   test("lifecycle semantics, part 5", async () => {
@@ -837,29 +871,33 @@ describe("lifecycle hooks", () => {
     }
 
     const parent = await mount(Parent, fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = false;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("lifecycle semantics, part 6", async () => {
@@ -880,32 +918,36 @@ describe("lifecycle hooks", () => {
     }
 
     const parent = await mount(Parent, fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.value = 2;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Child:willUpdateProps",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Child:willPatch",
-      "Child:patched",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:willUpdateProps",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Child:willPatch",
+        "Child:patched",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("onWillRender", async () => {
@@ -937,43 +979,53 @@ describe("lifecycle hooks", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<button>1</button>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.value++; // to block child render
     await nextTick();
-    expect(["Parent:willRender", "Child:willUpdateProps", "Parent:rendered"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:willUpdateProps",
+        "Parent:rendered",
+      ]
+    `);
 
     fixture.querySelector("button")!.click();
     await nextTick();
-    expect([]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`Array []`);
 
     fixture.querySelector("button")!.click();
     await nextTick();
-    expect([]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`Array []`);
     expect(fixture.innerHTML).toBe("<button>1</button>");
 
     def.resolve();
     await nextTick();
     expect(fixture.innerHTML).toBe("<button>3</button>");
-    expect([
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Child:willPatch",
-      "Child:patched",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Child:willPatch",
+        "Child:patched",
+        "Parent:patched",
+      ]
+    `);
   });
 
   // TODO: rename (remove? seems covered by lifecycle semantics)
@@ -1054,50 +1106,54 @@ describe("lifecycle hooks", () => {
 
     await mount(A, fixture);
     expect(fixture.innerHTML).toBe(`<div>A<div>B</div><div>C<div>D</div><div>E</div></div></div>`);
-    expect([
-      "A:setup",
-      "A:willStart",
-      "A:willRender",
-      "B:setup",
-      "B:willStart",
-      "C:setup",
-      "C:willStart",
-      "A:rendered",
-      "B:willRender",
-      "B:rendered",
-      "C:willRender",
-      "D:setup",
-      "D:willStart",
-      "E:setup",
-      "E:willStart",
-      "C:rendered",
-      "D:willRender",
-      "D:rendered",
-      "E:willRender",
-      "E:rendered",
-      "E:mounted",
-      "D:mounted",
-      "C:mounted",
-      "B:mounted",
-      "A:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:setup",
+        "A:willStart",
+        "A:willRender",
+        "B:setup",
+        "B:willStart",
+        "C:setup",
+        "C:willStart",
+        "A:rendered",
+        "B:willRender",
+        "B:rendered",
+        "C:willRender",
+        "D:setup",
+        "D:willStart",
+        "E:setup",
+        "E:willStart",
+        "C:rendered",
+        "D:willRender",
+        "D:rendered",
+        "E:willRender",
+        "E:rendered",
+        "E:mounted",
+        "D:mounted",
+        "C:mounted",
+        "B:mounted",
+        "A:mounted",
+      ]
+    `);
 
     // update
     c!.state.flag = false;
     await nextTick();
-    expect([
-      "C:willRender",
-      "F:setup",
-      "F:willStart",
-      "C:rendered",
-      "F:willRender",
-      "F:rendered",
-      "C:willPatch",
-      "E:willUnmount",
-      "E:willDestroy",
-      "F:mounted",
-      "C:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "C:willRender",
+        "F:setup",
+        "F:willStart",
+        "C:rendered",
+        "F:willRender",
+        "F:rendered",
+        "C:willPatch",
+        "E:willUnmount",
+        "E:willDestroy",
+        "F:mounted",
+        "C:patched",
+      ]
+    `);
   });
 
   test("mounted hook is called on every mount, not just the first one", async () => {
@@ -1118,43 +1174,49 @@ describe("lifecycle hooks", () => {
     }
 
     const parent = await mount(Parent, fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.hasChild = false;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+      ]
+    `);
 
     parent.state.hasChild = true;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Child:mounted",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Child:mounted",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("render in mounted", async () => {
@@ -1172,19 +1234,26 @@ describe("lifecycle hooks", () => {
 
     await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<span></span>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-      "Parent:willRender",
-      "Parent:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+        "Parent:willRender",
+        "Parent:rendered",
+      ]
+    `);
 
     await nextTick();
     expect(fixture.innerHTML).toBe("<span>Patched</span>");
-    expect(["Parent:willPatch", "Parent:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("render in patched", async () => {
@@ -1205,29 +1274,38 @@ describe("lifecycle hooks", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<span></span>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.render();
     await nextTick();
     expect(fixture.innerHTML).toBe("<span></span>");
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Parent:patched",
-      "Parent:willRender",
-      "Parent:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Parent:patched",
+        "Parent:willRender",
+        "Parent:rendered",
+      ]
+    `);
 
     await nextTick();
     expect(fixture.innerHTML).toBe("<span>Patched</span>");
-    expect(["Parent:willPatch", "Parent:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("render in willPatch", async () => {
@@ -1248,29 +1326,38 @@ describe("lifecycle hooks", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<span></span>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.render();
     await nextTick();
     expect(fixture.innerHTML).toBe("<span></span>");
 
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Parent:patched",
-      "Parent:willRender",
-      "Parent:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Parent:patched",
+        "Parent:willRender",
+        "Parent:rendered",
+      ]
+    `);
 
     await nextTick();
-    expect(["Parent:willPatch", "Parent:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("<span>Patched</span>");
   });
 
@@ -1313,19 +1400,21 @@ describe("lifecycle hooks", () => {
     await nextTick();
     app.destroy();
 
-    expect([
-      "onWillStart",
-      "onWillRender",
-      "onRendered",
-      "onMounted",
-      "onWillUpdateProps",
-      "onWillRender",
-      "onRendered",
-      "onWillPatch",
-      "onPatched",
-      "onWillUnmount",
-      "onWillDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "onWillStart",
+        "onWillRender",
+        "onRendered",
+        "onMounted",
+        "onWillUpdateProps",
+        "onWillRender",
+        "onRendered",
+        "onWillPatch",
+        "onPatched",
+        "onWillUnmount",
+        "onWillDestroy",
+      ]
+    `);
   });
 
   test("destroy new children before being mountged", async () => {
@@ -1357,26 +1446,30 @@ describe("lifecycle hooks", () => {
     const app = new App(Parent);
     const parent = await app.mount(fixture);
     expect(fixture.innerHTML).toBe("beforeafter");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.flag = true;
 
     await nextTick();
     expect(fixture.innerHTML).toBe("");
-    expect([
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Parent:willUnmount",
-      "Child:willDestroy",
-      "Parent:willDestroy",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Parent:willUnmount",
+        "Child:willDestroy",
+        "Parent:willDestroy",
+      ]
+    `);
   });
 });

--- a/tests/components/props.test.ts
+++ b/tests/components/props.test.ts
@@ -1,5 +1,5 @@
 import { Component, mount, onWillUpdateProps, useState, xml } from "../../src";
-import { makeTestFixture, nextTick, snapshotEverything, useLogLifecycle } from "../helpers";
+import { makeTestFixture, nextTick, snapshotEverything, steps, useLogLifecycle } from "../helpers";
 
 let fixture: HTMLElement;
 
@@ -272,26 +272,30 @@ test("bound functions are considered 'alike'", async () => {
 
   const parent = await mount(Parent, fixture);
   expect(fixture.innerHTML).toBe("1child");
-  expect([
-    "Parent:setup",
-    "Parent:willStart",
-    "Parent:willRender",
-    "Child:setup",
-    "Child:willStart",
-    "Parent:rendered",
-    "Child:willRender",
-    "Child:rendered",
-    "Child:mounted",
-    "Parent:mounted",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:setup",
+      "Parent:willStart",
+      "Parent:willRender",
+      "Child:setup",
+      "Child:willStart",
+      "Parent:rendered",
+      "Child:willRender",
+      "Child:rendered",
+      "Child:mounted",
+      "Parent:mounted",
+    ]
+  `);
   parent.state.val = 3;
   await nextTick();
-  expect([
-    "Parent:willRender",
-    "Parent:rendered",
-    "Parent:willPatch",
-    "Parent:patched",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:willRender",
+      "Parent:rendered",
+      "Parent:willPatch",
+      "Parent:patched",
+    ]
+  `);
   expect(fixture.innerHTML).toBe("3child");
 });
 
@@ -330,29 +334,33 @@ test(".alike suffix in a simple case", async () => {
   }
 
   const parent = await mount(Parent, fixture);
-  expect([
-    "Parent:setup",
-    "Parent:willStart",
-    "Parent:willRender",
-    "Child:setup",
-    "Child:willStart",
-    "Parent:rendered",
-    "Child:willRender",
-    "Child:rendered",
-    "Child:mounted",
-    "Parent:mounted",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:setup",
+      "Parent:willStart",
+      "Parent:willRender",
+      "Child:setup",
+      "Child:willStart",
+      "Parent:rendered",
+      "Child:willRender",
+      "Child:rendered",
+      "Child:mounted",
+      "Parent:mounted",
+    ]
+  `);
 
   expect(fixture.innerHTML).toBe("01");
   parent.state.counter++;
   await nextTick();
   expect(fixture.innerHTML).toBe("11");
-  expect([
-    "Parent:willRender",
-    "Parent:rendered",
-    "Parent:willPatch",
-    "Parent:patched",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:willRender",
+      "Parent:rendered",
+      "Parent:willPatch",
+      "Parent:patched",
+    ]
+  `);
 });
 
 test(".alike suffix in a list", async () => {
@@ -388,36 +396,40 @@ test(".alike suffix in a list", async () => {
   }
 
   await mount(Parent, fixture);
-  expect([
-    "Parent:setup",
-    "Parent:willStart",
-    "Parent:willRender",
-    "Todo:setup",
-    "Todo:willStart",
-    "Todo:setup",
-    "Todo:willStart",
-    "Parent:rendered",
-    "Todo:willRender",
-    "Todo:rendered",
-    "Todo:willRender",
-    "Todo:rendered",
-    "Todo:mounted",
-    "Todo:mounted",
-    "Parent:mounted",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:setup",
+      "Parent:willStart",
+      "Parent:willRender",
+      "Todo:setup",
+      "Todo:willStart",
+      "Todo:setup",
+      "Todo:willStart",
+      "Parent:rendered",
+      "Todo:willRender",
+      "Todo:rendered",
+      "Todo:willRender",
+      "Todo:rendered",
+      "Todo:mounted",
+      "Todo:mounted",
+      "Parent:mounted",
+    ]
+  `);
 
   expect(fixture.innerHTML).toBe("<button>1</button><button>2V</button>");
   fixture.querySelector("button")?.click();
   await nextTick();
   expect(fixture.innerHTML).toBe("<button>1V</button><button>2V</button>");
-  expect([
-    "Parent:willRender",
-    "Parent:rendered",
-    "Todo:willRender",
-    "Todo:rendered",
-    "Todo:willPatch",
-    "Todo:patched",
-    "Parent:willPatch",
-    "Parent:patched",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:willRender",
+      "Parent:rendered",
+      "Todo:willRender",
+      "Todo:rendered",
+      "Todo:willPatch",
+      "Todo:patched",
+      "Parent:willPatch",
+      "Parent:patched",
+    ]
+  `);
 });

--- a/tests/components/reactivity.test.ts
+++ b/tests/components/reactivity.test.ts
@@ -9,7 +9,7 @@ import {
   xml,
   toRaw,
 } from "../../src";
-import { makeTestFixture, nextTick, snapshotEverything, useLogLifecycle } from "../helpers";
+import { makeTestFixture, nextTick, snapshotEverything, steps, useLogLifecycle } from "../helpers";
 
 let fixture: HTMLElement;
 
@@ -175,30 +175,34 @@ describe("reactivity in lifecycle", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("2");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.content = null;
     parent.state.renderChild = false;
     await nextTick();
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("Component is automatically subscribed to reactive object received as prop", async () => {

--- a/tests/components/rendering.test.ts
+++ b/tests/components/rendering.test.ts
@@ -6,6 +6,7 @@ import {
   useLogLifecycle,
   makeDeferred,
   nextMicroTick,
+  steps,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -41,28 +42,32 @@ describe("rendering semantics", () => {
     const parent = await mount(Parent, fixture);
 
     expect(fixture.innerHTML).toBe("Achild");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.value = "B";
     await nextTick();
     expect(fixture.innerHTML).toBe("Bchild");
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("can force a render to update sub tree", async () => {
@@ -167,18 +172,20 @@ describe("rendering semantics", () => {
     const parent = await mount(Parent, fixture, { env });
 
     expect(fixture.innerHTML).toBe("parentAchild3");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     value = 4;
     parent.render(true);
@@ -187,30 +194,34 @@ describe("rendering semantics", () => {
     await nextMicroTick();
     await nextMicroTick();
     await nextMicroTick();
-    expect([
-      "Parent:willRender",
-      "Child:willUpdateProps",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:willUpdateProps",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+      ]
+    `);
 
     parent.state.value = "B";
 
     await nextTick();
 
     expect(fixture.innerHTML).toBe("parentBchild4");
-    expect([
-      "Parent:willRender",
-      "Child:willUpdateProps",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Child:willPatch",
-      "Child:patched",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Child:willUpdateProps",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Child:willPatch",
+        "Child:patched",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("props are reactive", async () => {
@@ -235,23 +246,32 @@ describe("rendering semantics", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("1");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.b = 3;
     await nextTick();
     expect(fixture.innerHTML).toBe("3");
-    expect(["Child:willRender", "Child:rendered", "Child:willPatch", "Child:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
   });
 
   test("props are reactive (nested prop)", async () => {
@@ -278,37 +298,48 @@ describe("rendering semantics", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("1");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.state.b.c = 3; // parent is now subscribed to 'b' key
     await nextTick();
     expect(fixture.innerHTML).toBe("3");
-    expect(["Child:willRender", "Child:rendered", "Child:willPatch", "Child:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
 
     parent.state.b = { c: 444 }; // triggers a parent and a child render
     await nextTick();
     expect(fixture.innerHTML).toBe("444");
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willPatch",
-      "Parent:patched",
-      "Child:willPatch",
-      "Child:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willPatch",
+        "Parent:patched",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
   });
 
   test("works as expected for dynamic number of props", async () => {
@@ -366,41 +397,45 @@ describe("rendering semantics", () => {
 
     const parent = await mount(A, fixture);
     expect(fixture.innerHTML).toBe("11");
-    expect([
-      "A:setup",
-      "A:willStart",
-      "A:willRender",
-      "B:setup",
-      "B:willStart",
-      "A:rendered",
-      "B:willRender",
-      "C:setup",
-      "C:willStart",
-      "B:rendered",
-      "C:willRender",
-      "C:rendered",
-      "C:mounted",
-      "B:mounted",
-      "A:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:setup",
+        "A:willStart",
+        "A:willRender",
+        "B:setup",
+        "B:willStart",
+        "A:rendered",
+        "B:willRender",
+        "C:setup",
+        "C:willStart",
+        "B:rendered",
+        "C:willRender",
+        "C:rendered",
+        "C:mounted",
+        "B:mounted",
+        "A:mounted",
+      ]
+    `);
 
     parent.state.obj.val = 3;
     await nextTick();
     expect(fixture.innerHTML).toBe("33");
-    expect([
-      "A:willRender",
-      "A:rendered",
-      "C:willRender",
-      "C:rendered",
-      "A:willPatch",
-      "A:patched",
-      "C:willPatch",
-      "C:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "A:willRender",
+        "A:rendered",
+        "C:willRender",
+        "C:rendered",
+        "A:willPatch",
+        "A:patched",
+        "C:willPatch",
+        "C:patched",
+      ]
+    `);
 
     def.resolve();
     await nextTick();
-    expect([]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`Array []`);
   });
 });
 
@@ -431,51 +466,67 @@ test("force render in case of existing render", async () => {
   }
   const parent = await mount(A, fixture);
   expect(fixture.innerHTML).toBe("C1");
-  expect([
-    "A:setup",
-    "A:willStart",
-    "A:willRender",
-    "B:setup",
-    "B:willStart",
-    "A:rendered",
-    "B:willRender",
-    "C:setup",
-    "C:willStart",
-    "B:rendered",
-    "C:willRender",
-    "C:rendered",
-    "C:mounted",
-    "B:mounted",
-    "A:mounted",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "A:setup",
+      "A:willStart",
+      "A:willRender",
+      "B:setup",
+      "B:willStart",
+      "A:rendered",
+      "B:willRender",
+      "C:setup",
+      "C:willStart",
+      "B:rendered",
+      "C:willRender",
+      "C:rendered",
+      "C:mounted",
+      "B:mounted",
+      "A:mounted",
+    ]
+  `);
 
   // trigger a new rendering, blocked in B
   parent.state.val = 2;
   await nextTick();
-  expect(["A:willRender", "B:willUpdateProps", "A:rendered"]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "A:willRender",
+      "B:willUpdateProps",
+      "A:rendered",
+    ]
+  `);
 
   // initiate a new render with deep=true. it should cancel the current render
   // and also be blocked in B
   parent.render(true);
   await nextTick();
-  expect(["A:willRender", "B:willUpdateProps", "A:rendered"]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "A:willRender",
+      "B:willUpdateProps",
+      "A:rendered",
+    ]
+  `);
 
   def.resolve();
   await nextTick();
   // we check here that the render reaches C (so, that it was properly forced)
-  expect([
-    "B:willRender",
-    "C:willUpdateProps",
-    "B:rendered",
-    "C:willRender",
-    "C:rendered",
-    "A:willPatch",
-    "B:willPatch",
-    "C:willPatch",
-    "C:patched",
-    "B:patched",
-    "A:patched",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "B:willRender",
+      "C:willUpdateProps",
+      "B:rendered",
+      "C:willRender",
+      "C:rendered",
+      "A:willPatch",
+      "B:willPatch",
+      "C:willPatch",
+      "C:patched",
+      "B:patched",
+      "A:patched",
+    ]
+  `);
 });
 
 test("children, default props and renderings", async () => {
@@ -503,26 +554,30 @@ test("children, default props and renderings", async () => {
   const parent = await mount(Parent, fixture);
 
   expect(fixture.innerHTML).toBe("Achild");
-  expect([
-    "Parent:setup",
-    "Parent:willStart",
-    "Parent:willRender",
-    "Child:setup",
-    "Child:willStart",
-    "Parent:rendered",
-    "Child:willRender",
-    "Child:rendered",
-    "Child:mounted",
-    "Parent:mounted",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:setup",
+      "Parent:willStart",
+      "Parent:willRender",
+      "Child:setup",
+      "Child:willStart",
+      "Parent:rendered",
+      "Child:willRender",
+      "Child:rendered",
+      "Child:mounted",
+      "Parent:mounted",
+    ]
+  `);
 
   parent.state.value = "B";
   await nextTick();
   expect(fixture.innerHTML).toBe("Bchild");
-  expect([
-    "Parent:willRender",
-    "Parent:rendered",
-    "Parent:willPatch",
-    "Parent:patched",
-  ]).toBeLogged();
+  expect(steps.splice(0)).toMatchInlineSnapshot(`
+    Array [
+      "Parent:willRender",
+      "Parent:rendered",
+      "Parent:willPatch",
+      "Parent:patched",
+    ]
+  `);
 });

--- a/tests/components/t_component.test.ts
+++ b/tests/components/t_component.test.ts
@@ -1,5 +1,5 @@
 import { Component, mount, useState, xml } from "../../src";
-import { makeTestFixture, nextTick, snapshotEverything, useLogLifecycle } from "../helpers";
+import { makeTestFixture, nextTick, snapshotEverything, steps, useLogLifecycle } from "../helpers";
 
 let fixture: HTMLElement;
 
@@ -29,18 +29,20 @@ describe("t-component", () => {
     await mount(Parent, fixture);
 
     expect(fixture.innerHTML).toBe("<div>child</div>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
   });
 
   test("switching dynamic component", async () => {
@@ -68,36 +70,40 @@ describe("t-component", () => {
 
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<div>child a</div>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "ChildA:setup",
-      "ChildA:willStart",
-      "Parent:rendered",
-      "ChildA:willRender",
-      "ChildA:rendered",
-      "ChildA:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "ChildA:setup",
+        "ChildA:willStart",
+        "Parent:rendered",
+        "ChildA:willRender",
+        "ChildA:rendered",
+        "ChildA:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     parent.Child = ChildB;
     parent.render();
     await nextTick();
     expect(fixture.innerHTML).toBe("child b");
-    expect([
-      "Parent:willRender",
-      "ChildB:setup",
-      "ChildB:willStart",
-      "Parent:rendered",
-      "ChildB:willRender",
-      "ChildB:rendered",
-      "Parent:willPatch",
-      "ChildA:willUnmount",
-      "ChildA:willDestroy",
-      "ChildB:mounted",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "ChildB:setup",
+        "ChildB:willStart",
+        "Parent:rendered",
+        "ChildB:willRender",
+        "ChildB:rendered",
+        "Parent:willPatch",
+        "ChildA:willUnmount",
+        "ChildA:willDestroy",
+        "ChildB:mounted",
+        "Parent:patched",
+      ]
+    `);
   });
 
   test("can switch between dynamic components without the need for a t-key", async () => {

--- a/tests/components/t_foreach.test.ts
+++ b/tests/components/t_foreach.test.ts
@@ -4,6 +4,7 @@ import {
   nextAppError,
   nextTick,
   snapshotEverything,
+  steps,
   useLogLifecycle,
 } from "../helpers";
 
@@ -91,23 +92,25 @@ describe("list of components", () => {
     expect(fixture.innerHTML).toBe(
       "<div><ul><li><div>1</div></li><li><div>2</div></li></ul></div>"
     );
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
   });
 
   test("reconciliation alg works for t-foreach in t-foreach", async () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -137,7 +137,7 @@ export function snapshotEverything() {
   };
 }
 
-const steps: string[] = [];
+export const steps: string[] = [];
 
 export function logStep(step: string) {
   steps.push(step);

--- a/tests/reactivity.test.ts
+++ b/tests/reactivity.test.ts
@@ -17,6 +17,7 @@ import {
   nextMicroTick,
   nextTick,
   snapshotEverything,
+  steps,
   useLogLifecycle,
 } from "./helpers";
 
@@ -1850,37 +1851,41 @@ describe("Reactivity: useState", () => {
       }
     }
     await mount(Parent, fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     expect(fixture.innerHTML).toBe("<div><span>123</span><span>123</span></div>");
     testContext.value = 321;
     await nextTick();
-    expect([
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willPatch",
-      "Child:patched",
-      "Child:willPatch",
-      "Child:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willPatch",
+        "Child:patched",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("<div><span>321</span><span>321</span></div>");
   });
 
@@ -1904,38 +1909,49 @@ describe("Reactivity: useState", () => {
     }
 
     await mount(Parent, fixture);
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     expect(fixture.innerHTML).toBe("<div><span>123</span><span>123</span></div>");
     testContext.value = 321;
     await nextMicroTick();
     await nextMicroTick();
-    expect([
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("<div><span>123</span><span>123</span></div>");
 
     await nextTick();
-    expect(["Child:willPatch", "Child:patched", "Child:willPatch", "Child:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willPatch",
+        "Child:patched",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
     expect(fixture.innerHTML).toBe("<div><span>321</span><span>321</span></div>");
   });
 
@@ -1969,43 +1985,54 @@ describe("Reactivity: useState", () => {
 
     await mount(GrandFather, fixture);
     expect(fixture.innerHTML).toBe("<div><span>123</span><div><span>123</span></div></div>");
-    expect([
-      "GrandFather:setup",
-      "GrandFather:willStart",
-      "GrandFather:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:setup",
-      "Parent:willStart",
-      "GrandFather:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-      "Child:mounted",
-      "GrandFather:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "GrandFather:setup",
+        "GrandFather:willStart",
+        "GrandFather:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:setup",
+        "Parent:willStart",
+        "GrandFather:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+        "Child:mounted",
+        "GrandFather:mounted",
+      ]
+    `);
 
     testContext.value = 321;
     await nextMicroTick();
     await nextMicroTick();
     expect(fixture.innerHTML).toBe("<div><span>123</span><div><span>123</span></div></div>");
-    expect([
-      "Child:willRender",
-      "Child:rendered",
-      "Child:willRender",
-      "Child:rendered",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willRender",
+        "Child:rendered",
+      ]
+    `);
 
     await nextTick();
     expect(fixture.innerHTML).toBe("<div><span>321</span><div><span>321</span></div></div>");
-    expect(["Child:willPatch", "Child:patched", "Child:willPatch", "Child:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willPatch",
+        "Child:patched",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
   });
 
   test("one components can subscribe twice to same context", async () => {
@@ -2181,38 +2208,49 @@ describe("Reactivity: useState", () => {
     }
     const parent = await mount(Parent, fixture);
     expect(fixture.innerHTML).toBe("<div><span>123</span></div>");
-    expect([
-      "Parent:setup",
-      "Parent:willStart",
-      "Parent:willRender",
-      "Child:setup",
-      "Child:willStart",
-      "Parent:rendered",
-      "Child:willRender",
-      "Child:rendered",
-      "Child:mounted",
-      "Parent:mounted",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:setup",
+        "Parent:willStart",
+        "Parent:willRender",
+        "Child:setup",
+        "Child:willStart",
+        "Parent:rendered",
+        "Child:willRender",
+        "Child:rendered",
+        "Child:mounted",
+        "Parent:mounted",
+      ]
+    `);
 
     testContext.a = 321;
     await nextTick();
-    expect(["Child:willRender", "Child:rendered", "Child:willPatch", "Child:patched"]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Child:willRender",
+        "Child:rendered",
+        "Child:willPatch",
+        "Child:patched",
+      ]
+    `);
 
     parent.state.flag = false;
     await nextTick();
     expect(fixture.innerHTML).toBe("<div></div>");
-    expect([
-      "Parent:willRender",
-      "Parent:rendered",
-      "Parent:willPatch",
-      "Child:willUnmount",
-      "Child:willDestroy",
-      "Parent:patched",
-    ]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`
+      Array [
+        "Parent:willRender",
+        "Parent:rendered",
+        "Parent:willPatch",
+        "Child:willUnmount",
+        "Child:willDestroy",
+        "Parent:patched",
+      ]
+    `);
 
     testContext.a = 456;
     await nextTick();
-    expect([]).toBeLogged();
+    expect(steps.splice(0)).toMatchInlineSnapshot(`Array []`);
   });
 
   test("destroyed component before being mounted is inactive", async () => {


### PR DESCRIPTION
This allows them to be updated automatically when needed instead of having to update them by hand.