### PR TITLE
[FIX] devtools: don't unfold env base object prototype

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -748,7 +748,7 @@
           child.contentType = "object";
           child.content = this.serializer.serializeItem(Object.getPrototypeOf(parentObj), true);
           child.hasChildren = true;
-          if (!oldTree && type === "env") {
+          if (!oldTree && type === "env" && Object.getPrototypeOf(parentObj) !== Object.prototype) {
             child.toggled = true;
           }
           break;


### PR DESCRIPTION
This commit prevents the base object prototype from being unfolded when the env of a component gets unfolded since it does not contain useful information.