### PR TITLE
[FIX] devtools: fix display and message passing for firefox

### DIFF
--- a/tools/devtools/manifest-firefox.json
+++ b/tools/devtools/manifest-firefox.json
@@ -29,7 +29,7 @@
     "scripts": ["background.js"]
   },
   "devtools_page": "devtools_app/devtools.html",
-  "content_security_policy": "script-src 'self' 'unsafe-eval' blob:; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/tools/devtools/src/content.js
+++ b/tools/devtools/src/content.js
@@ -1,5 +1,5 @@
 import globalHook from "./page_scripts/owl_devtools_global_hook";
-import { IS_FIREFOX } from "./utils";
+import { IS_FIREFOX, browserInstance } from "./utils";
 
 // Relays the owlDevtools__... type top window messages to the background script so that it can relay it to the devtools app
 window.addEventListener(
@@ -7,7 +7,7 @@ window.addEventListener(
   function (event) {
     if (event.data.type && event.data.source === "owl-devtools") {
       try {
-        chrome.runtime.sendMessage(
+        browserInstance.runtime.sendMessage(
           event.data.data
             ? { type: event.data.type, data: event.data.data, origin: event.data.origin }
             : { type: event.data.type, origin: event.data.origin }

--- a/tools/devtools/src/devtools_app/devtools.js
+++ b/tools/devtools/src/devtools_app/devtools.js
@@ -1,7 +1,6 @@
-import { IS_FIREFOX } from "../utils";
+import { IS_FIREFOX, browserInstance } from "../utils";
 
 let created = false;
-let browserInstance = IS_FIREFOX ? browser : chrome;
 
 // Try to load the owl panel each 1000 ms in case it (re)appears on the page later on
 const checkInterval = setInterval(createPanelsIfOwl, 1000);

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.js
@@ -70,6 +70,8 @@ export class ComponentsTab extends Component {
 
   onWindowResize = () => {
     const minWidth = (147 / window.innerWidth) * 100;
-    this.store.splitPosition = Math.max(this.store.splitPosition, minWidth);
+    if (minWidth <= 100) {
+      this.store.splitPosition = Math.max(this.store.splitPosition, minWidth);
+    }
   };
 }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
@@ -1,10 +1,8 @@
 /** @odoo-module **/
 
-import { isElementInCenterViewport, minimizeKey, IS_FIREFOX } from "../../../../utils";
+import { isElementInCenterViewport, minimizeKey, browserInstance } from "../../../../utils";
 import { useStore } from "../../../store/store";
 import { HighlightText } from "./highlight_text/highlight_text";
-
-const browserInstance = IS_FIREFOX ? browser : chrome;
 
 const { Component, useRef, useState, useEffect, onMounted } = owl;
 

--- a/tools/devtools/src/devtools_app/store/store.js
+++ b/tools/devtools/src/devtools_app/store/store.js
@@ -1,8 +1,6 @@
 const { reactive, useState, toRaw } = owl;
-import { fuzzySearch, IS_FIREFOX, getActiveTabURL } from "../../utils";
+import { fuzzySearch, IS_FIREFOX, getActiveTabURL, browserInstance } from "../../utils";
 import globalHook from "../../page_scripts/owl_devtools_global_hook";
-
-const browserInstance = IS_FIREFOX ? browser : chrome;
 
 // Main store which contains all states that needs to be maintained throughout all components in the devtools app
 export const store = reactive({
@@ -943,10 +941,9 @@ function arraysEqual(arr1, arr2) {
 
 async function getTabURL() {
   if (IS_FIREFOX) {
-    // This happens in firefox when the method is called inside devtools so we ask the background to execute it instead
-    browserInstance.runtime.sendMessage({ type: "getActiveTabURL" }).then((response) => {
-      return response.result;
-    });
+    // It is not possible to run getActiveTabURL inside the devtools when using firefox so we ask the background to execute it instead
+    const response = await browserInstance.runtime.sendMessage({ type: "getActiveTabURL" });
+    return response.result;
   } else {
     return await getActiveTabURL();
   }

--- a/tools/devtools/src/utils.js
+++ b/tools/devtools/src/utils.js
@@ -1,6 +1,6 @@
 export const IS_FIREFOX = navigator.userAgent.indexOf("Firefox") !== -1;
 
-const browserInstance = IS_FIREFOX ? browser : chrome;
+export const browserInstance = IS_FIREFOX ? browser : chrome;
 
 export async function getOwlStatus() {
   const response = await browserInstance.runtime.sendMessage({ type: "getOwlStatus" });


### PR DESCRIPTION
This commit fixes 2 issues specific to the firefox version of the extension:
First issue concerns the computation the position of the border between the subwindows of the components tab which could go terribly wrong due to the fact that the innerwidth of the window is implicitly set to 10 when the owl devtools window is hidden. Second issue comes from changes in the runtime.onMessage method of browser which now requires to directly return the response instead of using the sendResponse method.
Also perform a little cleanup on usage of browserInstance and in the manifest.