### PR TITLE
[FIX] devtools: context menu should be above the border

### DIFF
--- a/tools/devtools/src/main.css
+++ b/tools/devtools/src/main.css
@@ -318,7 +318,7 @@
   color: var(--text-color);
   background-color: var(--background-color);
   border: 1px solid gray;
-  z-index: 1;
+  z-index: 2;
   box-shadow: 1px 2px 5px #888;
   font-family: var(--bs-font-sans-serif);
 }


### PR DESCRIPTION
This commit increases the z-index of the context menu so that the border won't be clickable anymore when behind the menu.