### PR TITLE
[IMP] types: correctly support `Function` type for props-validation

### DIFF
--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -23,7 +23,7 @@ export type ComponentConstructor<P extends Props = any, E = any> = (new (
 
 export class Component<Props = any, Env = any> {
   static template: string = "";
-  static props?: any;
+  static props?: Schema;
   static defaultProps?: any;
 
   props: Props;

--- a/src/runtime/portal.ts
+++ b/src/runtime/portal.ts
@@ -65,7 +65,7 @@ export class Portal extends Component {
       type: String,
     },
     slots: true,
-  };
+  } as const;
 
   setup() {
     const node: any = this.__owl__;

--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -8,6 +8,7 @@ type BaseType =
   | typeof Date
   | typeof Object
   | typeof Array
+  | typeof Function
   | true
   | "*";
 

--- a/tests/components/props_validation.test.ts
+++ b/tests/components/props_validation.test.ts
@@ -594,7 +594,7 @@ describe("props validation", () => {
 
   test("props: can be defined with a boolean", async () => {
     class SubComp extends Component {
-      static props = { message: true };
+      static props = { message: true } as const;
     }
     expect(() => {
       validateProps(SubComp as any, {});
@@ -636,7 +636,7 @@ describe("props validation", () => {
 
   test("props: extra props cause an error, part 2", async () => {
     class SubComp extends Component {
-      static props = { message: true };
+      static props = { message: true } as const;
     }
     expect(() => {
       validateProps(SubComp as any, { message: 1, flag: true });


### PR DESCRIPTION
Previously, having a Function as a type in the static props description of a component would only work if the component was not the root component, as the static props description on Component was "any", whereas the static props description on ComponentConstructor was "Schema". This meant that static props description on non-root components was not type-checked, and on root components it was type-checked only on the mount call.

This commit makes it so that static type description is of type "Schema" on Component, now causing static props description to be type-checked, and adds `typeof Function` to the `BaseType` union, which allows declaring that a component expects a function as a prop.

Closes #1448