### PR TITLE
[IMP] types: correctly support Set type for props-validation

### DIFF
--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -9,6 +9,7 @@ type BaseType =
   | typeof Object
   | typeof Array
   | typeof Function
+  | typeof Set
   | true
   | "*";
 


### PR DESCRIPTION
Previously, having a Set as a type in the static props description of a component would would lead to a type error.

This commit adds Set to the list of supported types in the Schema