### PR TITLE
[FIX] Typo docs

### DIFF
--- a/doc/reference/props.md
+++ b/doc/reference/props.md
@@ -238,7 +238,7 @@ class ComponentB extends owl.Component {
     count: {type: Number},
     messages: {
       type: Array,
-      element: {type: Object, shape: {id: Boolean, text: String }
+      element: {type: Object, shape: {id: Boolean, text: String }}
     },
    date: Date,
    combinedVal: [Number, Boolean],


### PR DESCRIPTION
Missing closing parenthesis in props validation code example