### PR TITLE
[FIX] playground, compiler: correctly escape template literals

### DIFF
--- a/docs/playground/playground.js
+++ b/docs/playground/playground.js
@@ -41,9 +41,6 @@ const loadFile = (path) => {
  * Make an iframe, with all the js, css and xml properly injected.
  */
 function makeCodeIframe(js, css, xml) {
-  // escape backticks in the xml so they don't close the template string
-  const escapedXml = xml.replace(/`/g, '\\\`');
-
   const iframe = document.createElement("iframe");
   iframe.onload = () => {
     const doc = iframe.contentDocument;
@@ -55,6 +52,8 @@ function makeCodeIframe(js, css, xml) {
 
     const script = doc.createElement("script");
     script.type = "module";
+    // escape characters with special meaning in template literals
+    const escapedXml = xml.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/, "\\${");
     script.textContent = `const TEMPLATES = \`${escapedXml}\`\n${js}`;
     doc.body.appendChild(script);
 

--- a/tests/compiler/__snapshots__/comments.test.ts.snap
+++ b/tests/compiler/__snapshots__/comments.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments comment node with backslash at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comment(\` \\\\\\\\ \`);
+  }
+}"
+`;
+
+exports[`comments comment node with backtick at top-level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comment(\` \\\\\` \`);
+  }
+}"
+`;
+
+exports[`comments comment node with interpolation sigil at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comment(\` \\\\\${very cool} \`);
+  }
+}"
+`;
+
 exports[`comments only a comment 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/compiler/__snapshots__/simple_templates.test.ts.snap
+++ b/tests/compiler/__snapshots__/simple_templates.test.ts.snap
@@ -341,6 +341,39 @@ exports[`simple templates, mostly static template with t tag with multiple conte
 }"
 `;
 
+exports[`simple templates, mostly static text node with backslash at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(\`\\\\\\\\\`);
+  }
+}"
+`;
+
+exports[`simple templates, mostly static text node with backtick at top-level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(\`\\\\\`\`);
+  }
+}"
+`;
+
+exports[`simple templates, mostly static text node with interpolation sigil at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(\`\\\\\${very cool}\`);
+  }
+}"
+`;
+
 exports[`simple templates, mostly static two t-escs next to each other 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/compiler/__snapshots__/t_esc.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_esc.test.ts.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`t-esc default with backslash at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { withDefault } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(withDefault(undefined, \`\\\\\\\\\`));
+  }
+}"
+`;
+
+exports[`t-esc default with backtick at top-level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { withDefault } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(withDefault(undefined, \`\\\\\`\`));
+  }
+}"
+`;
+
+exports[`t-esc default with interpolation sigil at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { withDefault } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return text(withDefault(undefined, \`\\\\\${very cool}\`));
+  }
+}"
+`;
+
 exports[`t-esc div with falsy values 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/compiler/__snapshots__/t_set.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_set.test.ts.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`t-set body with backslash at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    setContextValue(ctx, \\"value\\", \`\\\\\\\\\`);
+    return text(ctx['value']);
+  }
+}"
+`;
+
+exports[`t-set body with backtick at top-level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    setContextValue(ctx, \\"value\\", \`\\\\\`\`);
+    return text(ctx['value']);
+  }
+}"
+`;
+
+exports[`t-set body with interpolation sigil at top level 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    setContextValue(ctx, \\"value\\", \`\\\\\${very cool}\`);
+    return text(ctx['value']);
+  }
+}"
+`;
+
 exports[`t-set evaluate value expression 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/compiler/comments.test.ts
+++ b/tests/compiler/comments.test.ts
@@ -26,4 +26,19 @@ describe("comments", () => {
         </div>`;
     expect(renderToString(template)).toBe("<div><span>true</span></div>");
   });
+
+  test("comment node with backslash at top level", () => {
+    const template = "<!-- \\ -->";
+    expect(renderToString(template)).toBe("<!-- \\ -->");
+  });
+
+  test("comment node with backtick at top-level", () => {
+    const template = "<!-- ` -->";
+    expect(renderToString(template)).toBe("<!-- ` -->");
+  });
+
+  test("comment node with interpolation sigil at top level", () => {
+    const template = "<!-- ${very cool} -->";
+    expect(renderToString(template)).toBe("<!-- ${very cool} -->");
+  });
 });

--- a/tests/compiler/simple_templates.test.ts
+++ b/tests/compiler/simple_templates.test.ts
@@ -154,4 +154,19 @@ describe("simple templates, mostly static", () => {
       </div>`;
     expect(renderToString(template, { a: "a", b: "b", c: "c" })).toBe("<div>abLoadingc</div>");
   });
+
+  test("text node with backslash at top level", () => {
+    const template = "\\";
+    expect(renderToString(template)).toBe("\\");
+  });
+
+  test("text node with backtick at top-level", () => {
+    const template = "`";
+    expect(renderToString(template)).toBe("`");
+  });
+
+  test("text node with interpolation sigil at top level", () => {
+    const template = "${very cool}";
+    expect(renderToString(template)).toBe("${very cool}");
+  });
 });

--- a/tests/compiler/t_esc.test.ts
+++ b/tests/compiler/t_esc.test.ts
@@ -121,4 +121,19 @@ describe("t-esc", () => {
     mount(bdom, fixture);
     expect(fixture.querySelector("span")!.textContent).toBe("<p>escaped</p>");
   });
+
+  test("default with backslash at top level", () => {
+    const template = '<t t-esc="undefined">\\</t>';
+    expect(renderToString(template)).toBe("\\");
+  });
+
+  test("default with backtick at top-level", () => {
+    const template = '<t t-esc="undefined">`</t>';
+    expect(renderToString(template)).toBe("`");
+  });
+
+  test("default with interpolation sigil at top level", () => {
+    const template = '<t t-esc="undefined">${very cool}</t>';
+    expect(renderToString(template)).toBe("${very cool}");
+  });
 });

--- a/tests/compiler/t_set.test.ts
+++ b/tests/compiler/t_set.test.ts
@@ -54,6 +54,21 @@ describe("t-set", () => {
     expect(renderToString(template)).toBe("ok");
   });
 
+  test("body with backslash at top level", () => {
+    const template = '<t t-set="value">\\</t><t t-esc="value"/>';
+    expect(renderToString(template)).toBe("\\");
+  });
+
+  test("body with backtick at top-level", () => {
+    const template = '<t t-set="value">`</t><t t-esc="value"/>';
+    expect(renderToString(template)).toBe("`");
+  });
+
+  test("body with interpolation sigil at top level", () => {
+    const template = '<t t-set="value">${very cool}</t><t t-esc="value"/>';
+    expect(renderToString(template)).toBe("${very cool}");
+  });
+
   test("set from body literal (with t-if/t-else", () => {
     const template = `
       <t>


### PR DESCRIPTION
This PR contains two commits that fix incomplete or inexistant escaping of strings that were injected into constructed template literals. See the individual commits for details.