### PR TITLE
[FIX] compiler: better support for arrow function and function call

### DIFF
--- a/src/compiler/inline_expressions.ts
+++ b/src/compiler/inline_expressions.ts
@@ -268,7 +268,7 @@ export function compileExprToArray(expr: string): Token[] {
   const localVars = new Set<string>();
   const tokens = tokenize(expr);
   let i = 0;
-  let stack = []; // to track last opening [ or {
+  let stack = []; // to track last opening (, [ or {
 
   while (i < tokens.length) {
     let token = tokens[i];
@@ -279,10 +279,12 @@ export function compileExprToArray(expr: string): Token[] {
     switch (token.type) {
       case "LEFT_BRACE":
       case "LEFT_BRACKET":
+      case "LEFT_PAREN":
         stack.push(token.type);
         break;
       case "RIGHT_BRACE":
       case "RIGHT_BRACKET":
+      case "RIGHT_PAREN":
         stack.pop();
     }
 

--- a/tests/compiler/inline_expressions.test.ts
+++ b/tests/compiler/inline_expressions.test.ts
@@ -174,6 +174,9 @@ describe("expression evaluation", () => {
     expect(compileExpr("list.data.map((data) => data)")).toBe(
       "ctx['list'].data.map((_data)=>_data)"
     );
+    expect(compileExpr("(ev) => { myFunc(v1, v2, ev.target.value); }")).toBe(
+      "(_ev)=>{ctx['myFunc'](ctx['v1'],ctx['v2'],_ev.target.value);}"
+    );
   });
   test.skip("arrow functions: not yet supported", () => {
     // e is added to localvars in inline_expression but not removed after the arrow func body


### PR DESCRIPTION
This commit fixes inline expressions when we have these conditions:
* inline expression that contains an arrow function
* inside the arrow function call a function with multiple arguments (3+)
* the second argument (not the first and not the last) must be a variable

In the `compileExprToArray` we have a code to handle missing tokens in an object
e.g.: {a} (equivalent to {a:a})

When OWL match all 3 conditions listed above we execute the code to handle the missing tokens and so it alter the tokens and adds a new token: `{ type: "COLON", value: ":" }`
This result in a Javascript compilation error:
OwlError: Failed to compile template "XXX": missing ) after argument list

To fix the error and avoid execute the code to handle the missing tokens, now, we track also the parentheses in our local stack.