### PR TITLE
[IMP] devtools: add support for file urls on chrome

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -14,7 +14,7 @@
     "default_popup": "popup_app/popup.html"
   },
   "permissions": ["scripting", "storage"],
-  "host_permissions": ["http://*/*", "https://*/*"],
+  "host_permissions": ["http://*/*", "https://*/*", "file://*"],
   "content_security_policy": {
     "script-src": "self",
     "object-src": "self"


### PR DESCRIPTION
This commit ensures that the hook will properly be loaded on file urls when using chrome (this was already working in firefox). It is still necessary to check the "Allow access to file URLs" option in the extensions manager for this to work properly.