### PR TITLE
[IMP] devtools: allow expansion of empty class and better class display

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -834,7 +834,9 @@
             case obj instanceof Object:
               child.contentType = "object";
               child.hasChildren =
-                Object.keys(obj).length || Object.getOwnPropertySymbols(obj).length;
+                Object.keys(obj).length ||
+                Object.getOwnPropertySymbols(obj).length ||
+                obj.constructor.name !== "Object";
               break;
             default:
               child.contentType = typeof obj;

--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -109,23 +109,34 @@
         object(obj) {
           const result = [];
           let length = 0;
-          for (const [key, value] of Object.entries(obj)) {
-            if (length > 25) {
-              result.push("...");
-              break;
+          if (obj instanceof String) {
+            result[0] = `'${obj.toString()}'`;
+          } else if (obj instanceof Array) {
+            return `${obj.constructor.name} ${this.array([...obj])}`;
+          } else if (obj instanceof Number) {
+            result[0] = obj.toString();
+          } else {
+            for (const [key, value] of Object.entries(obj)) {
+              if (length > 25) {
+                result.push("...");
+                break;
+              }
+              const element = key + ": " + this.serializeItem(value);
+              length += element.length;
+              result.push(element);
             }
-            const element = key + ": " + this.serializeItem(value);
-            length += element.length;
-            result.push(element);
+            for (const key of Object.getOwnPropertySymbols(obj)) {
+              if (length > 25) {
+                result.push("...");
+                break;
+              }
+              const element = key.toString() + ": " + this.serializeItem(obj[key]);
+              length += element.length;
+              result.push(element);
+            }
           }
-          for (const key of Object.getOwnPropertySymbols(obj)) {
-            if (length > 25) {
-              result.push("...");
-              break;
-            }
-            const element = key.toString() + ": " + this.serializeItem(obj[key]);
-            length += element.length;
-            result.push(element);
+          if (obj.constructor.name !== "Object") {
+            return obj.constructor.name + " {" + result.join(", ") + "}";
           }
           return "{" + result.join(", ") + "}";
         },
@@ -823,7 +834,7 @@
               child.contentType = "set";
               child.hasChildren = true;
               break;
-            case obj instanceof Array:
+            case obj.constructor.name === "Array":
               child.contentType = "array";
               child.hasChildren = obj.length > 0;
               break;


### PR DESCRIPTION
First commit makes it possible to expand empty classes to see their prototype instead of displaying them as simple empty objects.

Second commit ensures that class names are displayed for non generic objects and extensions of generic classes will have custom display for their content.