### PR TITLE
[FIX] devtools: sort object keys numerically as well

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -1931,7 +1931,7 @@
     } else if (!isSymbolA && isSymbolB) {
       return -1; // Place non-Symbols at the beginning
     } else {
-      return String(a).localeCompare(String(b)); // Sort other keys alphabetically
+      return String(a).localeCompare(String(b), undefined, { numeric: true }); // Sort other keys alphabetically
     }
   }
 


### PR DESCRIPTION
This commit makes the alphabetical sort of object keys account for numerical order as well so that it will feel right when handling objects with numerical keys.