### PR TITLE
[IMP] runtime: simplify info message when running in dev mode

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -29,15 +29,6 @@ export interface AppConfig<P, E> extends TemplateSetConfig, RootConfig<P, E> {
 
 let hasBeenLogged = false;
 
-export const DEV_MSG = () => {
-  const hash = (window as any).owl ? (window as any).owl.__info__.hash : "master";
-
-  return `Owl is running in 'dev' mode.
-
-This is not suitable for production use.
-See https://github.com/odoo/owl/blob/${hash}/doc/reference/app.md#configuration for more information.`;
-};
-
 const apps = new Set<App>();
 
 declare global {
@@ -88,7 +79,7 @@ export class App<
     }
     this.warnIfNoStaticProps = config.warnIfNoStaticProps || false;
     if (this.dev && !config.test && !hasBeenLogged) {
-      console.info(DEV_MSG());
+      console.info(`Owl is running in 'dev' mode.`);
       hasBeenLogged = true;
     }
     const env = config.env || {};

--- a/tests/components/props_validation.test.ts
+++ b/tests/components/props_validation.test.ts
@@ -1,6 +1,6 @@
 import { makeTestFixture, nextAppError, nextTick, snapshotEverything } from "../helpers";
 import { Component, onError, xml, mount, OwlError, useState } from "../../src";
-import { App, DEV_MSG } from "../../src/runtime/app";
+import { App } from "../../src/runtime/app";
 import { validateProps } from "../../src/runtime/template_helpers";
 import { Schema } from "../../src/runtime/validation";
 
@@ -13,7 +13,7 @@ let mockConsoleWarn: any;
 
 beforeAll(() => {
   console.info = (message: any) => {
-    if (message === DEV_MSG()) {
+    if (message === `Owl is running in 'dev' mode.`) {
       return;
     }
     info(message);

--- a/tests/misc/portal.test.ts
+++ b/tests/misc/portal.test.ts
@@ -11,7 +11,6 @@ import {
   useState,
 } from "../../src";
 import { xml } from "../../src/";
-import { DEV_MSG } from "../../src/runtime/app";
 import { elem, makeTestFixture, nextAppError, nextTick, snapshotEverything } from "../helpers";
 
 let fixture: HTMLElement;
@@ -30,7 +29,7 @@ snapshotEverything();
 
 beforeAll(() => {
   console.info = (message: any) => {
-    if (message === DEV_MSG()) {
+    if (message === `Owl is running in 'dev' mode.`) {
       return;
     }
     info(message);


### PR DESCRIPTION
The owl dev info message may be useful, but does not bring that much value. Also, this is even slightly annoying while debugging odoo, since it is common to have to go to dev mode, and the message takes some visual space, which is a distraction.  In this commit, we simplify it to just warn that owl is in dev mode.