### PR TITLE
[FIX] code generator: prevent AST change

### DIFF
--- a/src/compiler/code_generator.ts
+++ b/src/compiler/code_generator.ts
@@ -1350,17 +1350,16 @@ export class CodeGenerator {
       isMultiple = isMultiple || this.slotNames.has(ast.name);
       this.slotNames.add(ast.name);
     }
-    const dynProps = ast.attrs ? ast.attrs["t-props"] : null;
-    if (ast.attrs) {
-      delete ast.attrs["t-props"];
-    }
+    const attrs = { ...ast.attrs };
+    const dynProps = attrs["t-props"];
+    delete attrs["t-props"];
     let key = this.target.loopLevel ? `key${this.target.loopLevel}` : "key";
     if (isMultiple) {
       key = this.generateComponentKey(key);
     }
 
     const props = ast.attrs
-      ? this.formatPropObject(ast.attrs, ast.attrsTranslationCtx, ctx.translationCtx)
+      ? this.formatPropObject(attrs, ast.attrsTranslationCtx, ctx.translationCtx)
       : [];
     const scope = this.getPropString(props, dynProps);
     if (ast.defaultContent) {

--- a/tests/compiler/__snapshots__/t_slot.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_slot.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`t-slot compile t-props correctly multiple time 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { callSlot } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    return callSlot(ctx, node, key, 'default', false, Object.assign({}, {a:1}));
+  }
+}"
+`;

--- a/tests/compiler/t_slot.test.ts
+++ b/tests/compiler/t_slot.test.ts
@@ -1,0 +1,15 @@
+import { parseXML } from "../../src/common/utils";
+import { compile } from "../../src/compiler";
+
+describe("t-slot", () => {
+  test("compile t-props correctly multiple time", () => {
+    const template = `<t t-slot="default" t-props="{ a: 1 }"/>`;
+    const parsedTemplate = parseXML(template).firstChild as Element;
+
+    const fn1 = compile(parsedTemplate);
+    expect(fn1.toString()).toMatchSnapshot();
+
+    const fn2 = compile(parsedTemplate);
+    expect(fn2.toString()).toBe(fn1.toString());
+  });
+});


### PR DESCRIPTION
This commit removes an AST change during the code generation of slots. Before, the `compileTSlot` function deleted the `t-props` attribute directly on `ast.attrs`. This creates wrong code when compiling a second time as the `t-props` attribute does not exist anymore.