### PR TITLE
[IMP] runtime/utils: export htmlEscape and add tests

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -41,7 +41,7 @@ export { useComponent, useState } from "./component_node";
 export { status } from "./status";
 export { reactive, markRaw, toRaw } from "./reactivity";
 export { useEffect, useEnv, useExternalListener, useRef, useChildSubEnv, useSubEnv } from "./hooks";
-export { batched, EventBus, whenReady, loadFile, markup } from "./utils";
+export { batched, EventBus, htmlEscape, whenReady, loadFile, markup } from "./utils";
 export {
   onWillStart,
   onMounted,

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -81,15 +81,15 @@ export async function loadFile(url: string): Promise<string> {
  */
 export class Markup extends String {}
 
-function _escapeHtml(str: any): string | Markup {
+export function htmlEscape(str: any): Markup {
   if (str instanceof Markup) {
     return str;
   }
   if (str === undefined) {
-    return "";
+    return markup("");
   }
   if (typeof str === "number") {
-    return String(str);
+    return markup(String(str));
   }
   [
     ["&", "&amp;"],
@@ -101,7 +101,7 @@ function _escapeHtml(str: any): string | Markup {
   ].forEach((pairs) => {
     str = String(str).replace(new RegExp(pairs[0], "g"), pairs[1]);
   });
-  return str;
+  return markup(str);
 }
 
 /*
@@ -123,7 +123,7 @@ export function markup(
   let acc = "";
   let i = 0;
   for (; i < placeholders.length; ++i) {
-    acc += strings[i] + _escapeHtml(placeholders[i]);
+    acc += strings[i] + htmlEscape(placeholders[i]);
   }
   acc += strings[i];
   return new Markup(acc);


### PR DESCRIPTION
markup tag function requires markup awareness to determine whether a given parameter should be escaped or not.

This implies that pre-escaped content should be properly marked'ed up to avoid double escaping. Having to manually wrap all calls to escape with markup is cumbersome and prone to issues (on top of having to be validated by the security team for no reason).

This commit introduces a markup-aware escape function to resolve those issues.