### PR TITLE
[FIX] parser: t-esc/t-out vs t-translation*

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -253,11 +253,11 @@ function parseNode(node: Node, ctx: ParsingContext): AST | null {
     parseTPortal(node, ctx) ||
     parseTCall(node, ctx) ||
     parseTCallBlock(node, ctx) ||
+    parseTTranslation(node, ctx) ||
+    parseTTranslationContext(node, ctx) ||
     parseTEscNode(node, ctx) ||
     parseTOutNode(node, ctx) ||
     parseTKey(node, ctx) ||
-    parseTTranslation(node, ctx) ||
-    parseTTranslationContext(node, ctx) ||
     parseTSlot(node, ctx) ||
     parseComponent(node, ctx) ||
     parseDOMNode(node, ctx) ||

--- a/tests/compiler/parser.test.ts
+++ b/tests/compiler/parser.test.ts
@@ -1971,6 +1971,54 @@ describe("qweb parser", () => {
     });
   });
 
+  test('t-translation="off": interaction with t-esc', async () => {
+    expect(parse(`<span t-esc="a" t-translation="off"/>`)).toEqual({
+      type: ASTType.TTranslation,
+      content: {
+        attrs: null,
+        attrsTranslationCtx: null,
+        content: [
+          {
+            defaultValue: "",
+            expr: "a",
+            type: ASTType.TEsc,
+          },
+        ],
+        dynamicTag: null,
+        model: null,
+        ns: null,
+        on: null,
+        ref: null,
+        tag: "span",
+        type: ASTType.DomNode,
+      },
+    });
+  });
+
+  test('t-translation="off": interaction with t-out', async () => {
+    expect(parse(`<span t-out="a" t-translation="off"/>`)).toEqual({
+      type: ASTType.TTranslation,
+      content: {
+        attrs: null,
+        attrsTranslationCtx: null,
+        content: [
+          {
+            body: null,
+            expr: "a",
+            type: ASTType.TOut,
+          },
+        ],
+        dynamicTag: null,
+        model: null,
+        ns: null,
+        on: null,
+        ref: null,
+        tag: "span",
+        type: ASTType.DomNode,
+      },
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // t-translation-context
   // ---------------------------------------------------------------------------
@@ -2005,6 +2053,56 @@ describe("qweb parser", () => {
       },
       translationCtx: "fr",
       type: ASTType.TTranslationContext,
+    });
+  });
+
+  test("t-translation-context: interaction with t-esc", async () => {
+    expect(parse(`<span t-esc="a" t-translation-context="fr"/>`)).toEqual({
+      type: ASTType.TTranslationContext,
+      content: {
+        attrs: null,
+        attrsTranslationCtx: null,
+        content: [
+          {
+            defaultValue: "",
+            expr: "a",
+            type: ASTType.TEsc,
+          },
+        ],
+        dynamicTag: null,
+        model: null,
+        ns: null,
+        on: null,
+        ref: null,
+        tag: "span",
+        type: ASTType.DomNode,
+      },
+      translationCtx: "fr",
+    });
+  });
+
+  test("t-translation-context: interaction with t-out", async () => {
+    expect(parse(`<span t-out="a" t-translation-context="fr"/>`)).toEqual({
+      type: ASTType.TTranslationContext,
+      content: {
+        attrs: null,
+        attrsTranslationCtx: null,
+        content: [
+          {
+            body: null,
+            expr: "a",
+            type: ASTType.TOut,
+          },
+        ],
+        dynamicTag: null,
+        model: null,
+        ns: null,
+        on: null,
+        ref: null,
+        tag: "span",
+        type: ASTType.DomNode,
+      },
+      translationCtx: "fr",
     });
   });
 


### PR DESCRIPTION
The directives t-esc/t-out both discard the ASTs that are not of DomNode type. Since the directives t-translation and t-translation-context both creates AST wrappers of type TTranslation and TTranslationContext respectively, mix t-esc/t-out and t-translation/t-translation-context does not work. For example parse

```xml
<span t-esc="'Hello'" t-translation="off"/>
```

gives the AST

```js
{
    type: ASTType.TEsc,
    expr: "'Hello'",
    defaultValue: "",
}
```

This makes the span not been rendered in the end.

We fix that problem.