### PR TITLE
[FIX] parser: code_generator: wrapped children recognition

### DIFF
--- a/src/compiler/code_generator.ts
+++ b/src/compiler/code_generator.ts
@@ -995,7 +995,7 @@ export class CodeGenerator {
     const isNewBlock = !block || forceNewBlock;
     let codeIdx = this.target.code.length;
     if (isNewBlock) {
-      const n = ast.content.filter((c) => c.type !== ASTType.TSet).length;
+      const n = ast.content.filter((c) => !c.hasNoRepresentation).length;
       let result: string | null = null;
       if (n <= 1) {
         for (let child of ast.content) {
@@ -1009,15 +1009,15 @@ export class CodeGenerator {
     let index = 0;
     for (let i = 0, l = ast.content.length; i < l; i++) {
       const child = ast.content[i];
-      const isTSet = child.type === ASTType.TSet;
+      const forceNewBlock = !child.hasNoRepresentation;
       const subCtx = createContext(ctx, {
         block,
         index,
-        forceNewBlock: !isTSet,
+        forceNewBlock,
         isLast: ctx.isLast && i === l - 1,
       });
       this.compileAST(child, subCtx);
-      if (!isTSet) {
+      if (forceNewBlock) {
         index++;
       }
     }

--- a/tests/compiler/__snapshots__/t_debug_log.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_debug_log.test.ts.snap
@@ -49,6 +49,27 @@ exports[`debugging t-debug on sub template 2`] = `
 }"
 `;
 
+exports[`debugging t-debug: interaction with t-set 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  let block1 = createBlock(\`<span><block-text-0/></span>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    debugger;
+    setContextValue(ctx, \\"foo\\", 42);
+    debugger;
+    setContextValue(ctx, \\"bar\\", 49);
+    let txt1 = ctx['foo']+ctx['bar'];
+    return block1([txt1]);
+  }
+}"
+`;
+
 exports[`debugging t-log 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
@@ -63,6 +84,27 @@ exports[`debugging t-log 1`] = `
     setContextValue(ctx, \\"foo\\", 42);
     console.log(ctx['foo']+3);
     return block1();
+  }
+}"
+`;
+
+exports[`debugging t-log: interaction with t-set 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  let block1 = createBlock(\`<span><block-text-0/></span>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    console.log(ctx['foo']);
+    setContextValue(ctx, \\"foo\\", 42);
+    console.log(ctx['bar']);
+    setContextValue(ctx, \\"bar\\", 49);
+    let txt1 = ctx['foo']+ctx['bar'];
+    return block1([txt1]);
   }
 }"
 `;

--- a/tests/compiler/__snapshots__/t_key.test.ts.snap
+++ b/tests/compiler/__snapshots__/t_key.test.ts.snap
@@ -103,3 +103,18 @@ exports[`t-key t-key on sub dom node pushes a child block in its parent 2`] = `
   }
 }"
 `;
+
+exports[`t-key t-key: interaction with t-esc 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block1 = createBlock(\`<p><block-text-0/></p>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    const tKey_1 = ctx['key'];
+    let txt1 = ctx['text'];
+    return toggler(tKey_1, block1([txt1]));
+  }
+}"
+`;

--- a/tests/compiler/__snapshots__/translation.test.ts.snap
+++ b/tests/compiler/__snapshots__/translation.test.ts.snap
@@ -10,8 +10,7 @@ exports[`translation context body of t-sets are translated in context 1`] = `
     ctx = Object.create(ctx);
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"label\\", \`traduit\`);
-    const b2 = text(ctx['label']);
-    return multi([b2]);
+    return text(ctx['label']);
   }
 }"
 `;
@@ -94,6 +93,23 @@ exports[`translation context slot attrs and text contents are translated in cont
 }"
 `;
 
+exports[`translation context t-translation-context with several children 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block1 = createBlock(\`<div><div/><div/><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let b2;
+    if (true) {
+      b2 = text(\`\`);
+    }
+    return block1([], [b2]);
+  }
+}"
+`;
+
 exports[`translation context translation of attributes in context 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
@@ -139,6 +155,21 @@ exports[`translation support body of t-sets are translated 1`] = `
 `;
 
 exports[`translation support body of t-sets inside translation=off are not translated 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  let { isBoundary, withDefault, setContextValue } = helpers;
+  
+  return function template(ctx, node, key = \\"\\") {
+    ctx = Object.create(ctx);
+    ctx[isBoundary] = 1
+    setContextValue(ctx, \\"label\\", \`untranslated\`);
+    return text(ctx['label']);
+  }
+}"
+`;
+
+exports[`translation support body of t-sets inside translation=off are not translated 2 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler, comment } = bdom;
@@ -260,6 +291,23 @@ exports[`translation support t-set and falsy t-value: t-body are translated 1`] 
     ctx[isBoundary] = 1
     setContextValue(ctx, \\"label\\", withDefault(false, \`translated\`));
     return text(ctx['label']);
+  }
+}"
+`;
+
+exports[`translation support t-translation with several children 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block1 = createBlock(\`<div><div/><div/><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let b2;
+    if (true) {
+      b2 = text(\`\`);
+    }
+    return block1([], [b2]);
   }
 }"
 `;

--- a/tests/compiler/parser.test.ts
+++ b/tests/compiler/parser.test.ts
@@ -692,6 +692,7 @@ describe("qweb parser", () => {
       value: "value",
       defaultValue: null,
       body: null,
+      hasNoRepresentation: true,
     });
   });
 
@@ -702,6 +703,7 @@ describe("qweb parser", () => {
       defaultValue: "ok",
       value: null,
       body: null,
+      hasNoRepresentation: true,
     });
 
     expect(parse(`<t t-set="v"><div>ok</div></t>`)).toEqual({
@@ -723,6 +725,7 @@ describe("qweb parser", () => {
           content: [{ type: ASTType.Text, value: "ok" }],
         },
       ],
+      hasNoRepresentation: true,
     });
 
     expect(parse(`<t t-set="v"><div>ok</div>abc</t>`)).toEqual({
@@ -745,6 +748,7 @@ describe("qweb parser", () => {
         },
         { type: ASTType.Text, value: "abc" },
       ],
+      hasNoRepresentation: true,
     });
   });
 
@@ -758,6 +762,7 @@ describe("qweb parser", () => {
         defaultValue: "ok",
         value: null,
         body: null,
+        hasNoRepresentation: true,
       },
       tElif: null,
       tElse: null,
@@ -783,7 +788,14 @@ describe("qweb parser", () => {
           condition: "flag",
           content: { type: ASTType.Text, value: "1" },
           tElif: null,
-          tElse: { type: ASTType.TSet, name: "ourvar", value: "0", defaultValue: null, body: null },
+          tElse: {
+            type: ASTType.TSet,
+            name: "ourvar",
+            value: "0",
+            defaultValue: null,
+            body: null,
+            hasNoRepresentation: true,
+          },
         },
       ],
     });

--- a/tests/compiler/t_debug_log.test.ts
+++ b/tests/compiler/t_debug_log.test.ts
@@ -38,4 +38,34 @@ describe("debugging", () => {
     expect(console.log).toHaveBeenCalledWith(45);
     console.log = consoleLog;
   });
+
+  test("t-log: interaction with t-set", () => {
+    const consoleLog = console.log;
+    console.log = jest.fn();
+
+    const template = `
+      <t>
+        <t t-log="foo" t-set="foo" t-value="42"/>
+        <t t-log="bar" t-set="bar" t-value="49"/>
+        <span t-esc="foo + bar"/>
+      </t>
+    `;
+    snapshotTemplate(template);
+    renderToString(template);
+    expect(console.log).toHaveBeenCalledWith(undefined);
+    expect(console.log).toHaveBeenCalledWith(undefined);
+    console.log = consoleLog;
+  });
+
+  test("t-debug: interaction with t-set", () => {
+    const template = `
+      <t>
+        <t t-debug="" t-set="foo" t-value="42"/>
+        <t t-debug="" t-set="bar" t-value="49"/>
+        <span t-esc="foo + bar"/>
+      </t>
+    `;
+    snapshotTemplate(template);
+    renderToString(template);
+  });
 });

--- a/tests/compiler/t_key.test.ts
+++ b/tests/compiler/t_key.test.ts
@@ -63,4 +63,10 @@ describe("t-key", () => {
 
     expect(renderToString(template2, { key: "1" })).toBe("<div><h1></h1></div>");
   });
+
+  test("t-key: interaction with t-esc", async () => {
+    const template = `<p t-key="key" t-esc="text"/>`;
+
+    expect(renderToString(template, { key: "1", text: "abc" })).toBe("<p>abc</p>");
+  });
 });

--- a/tests/compiler/translation.test.ts
+++ b/tests/compiler/translation.test.ts
@@ -129,6 +129,21 @@ describe("translation support", () => {
     expect(fixture.innerHTML).toBe("untranslated");
   });
 
+  test("body of t-sets inside translation=off are not translated 2", async () => {
+    class SomeComponent extends Component {
+      static template = xml`
+        <t>
+          <t t-translation="off" t-set="label">untranslated</t>
+          <t t-esc="label"/>
+        </t>`;
+    }
+
+    const translateFn = () => "translated";
+
+    await mount(SomeComponent, fixture, { translateFn });
+    expect(fixture.innerHTML).toBe("untranslated");
+  });
+
   test("body of t-sets with html content are translated", async () => {
     class SomeComponent extends Component {
       static template = xml`
@@ -169,6 +184,22 @@ describe("translation support", () => {
 
     await mount(SomeComponent, fixture, { translateFn });
     expect(fixture.innerHTML).toBe("translated");
+  });
+
+  test("t-translation with several children", async () => {
+    class SomeComponent extends Component {
+      static template = xml`
+          <div>
+            <t t-translation="off">
+                <div/>
+                <div/>
+            </t>
+            <t t-if="true"/>
+        </div>
+      `;
+    }
+    await mount(SomeComponent, fixture);
+    expect(fixture.outerHTML).toBe("<div><div><div></div><div></div></div></div>");
   });
 });
 
@@ -292,5 +323,21 @@ describe("translation context", () => {
     expect(translateFn).toHaveBeenCalledWith("foo", "fr");
     expect(translateFn).toHaveBeenCalledWith("param", "fr");
     expect(translateFn).toHaveBeenCalledWith("title", "pt");
+  });
+
+  test("t-translation-context with several children", async () => {
+    class SomeComponent extends Component {
+      static template = xml`
+          <div>
+            <t t-translation-context="ctx">
+                <div/>
+                <div/>
+            </t>
+            <t t-if="true"/>
+        </div>
+      `;
+    }
+    await mount(SomeComponent, fixture);
+    expect(fixture.outerHTML).toBe("<div><div><div></div><div></div></div></div>");
   });
 });


### PR DESCRIPTION
Several directives (t-key, t-log, t-translation, …) are represented by wrapper ASTs that contain another AST or null.
Because these wrappers don't share the same type as their children, various AST type checks were broken.

This commit addresses those issues by:

- Commuting Translation / TranslationContext and Multi ASTs so that  Multi children are spread as expected (see parseChildren).

- Parsing the t-key directive before t-esc / t-out (in line with https://github.com/odoo/owl/pull/1685).

- Ensuring wrappers around TSet ASTs are recognized as having no representation, so compileMulti properly discards children equivalent to TSet.