### PR TITLE
[FIX] error_handling: onError works if handling happens between culpr…

### DIFF
--- a/src/runtime/error_handling.ts
+++ b/src/runtime/error_handling.ts
@@ -55,6 +55,7 @@ export function handleError(params: ErrorParams) {
     let current: Fiber | null = fiber;
     do {
       current.node.fiber = current;
+      fibersInError.set(current, error);
       current = current.parent;
     } while (current);
 

--- a/tests/components/__snapshots__/error_handling.test.ts.snap
+++ b/tests/components/__snapshots__/error_handling.test.ts.snap
@@ -94,6 +94,52 @@ exports[`basics no component catching error lead to full app destruction 2`] = `
 }"
 `;
 
+exports[`basics render from above on error -- handler is not a Root or MountFiber 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`Parent\`, true, false, false, []);
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comp1({}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`basics render from above on error -- handler is not a Root or MountFiber 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`Boom\`, true, false, false, []);
+  
+  let block1 = createBlock(\`<div><block-child-0/><block-child-1/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let b2, b3;
+    if (ctx['error']) {
+      b2 = text(\`Error\`);
+    } else {
+      b3 = comp1({onError: (ctx['handleError']).bind(this)}, key + \`__1\`, node, this, null);
+    }
+    return block1([], [b2, b3]);
+  }
+}"
+`;
+
+exports[`basics render from above on error -- handler is not a Root or MountFiber 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  let block1 = createBlock(\`<div><block-text-0/></div>\`);
+  
+  return function template(ctx, node, key = \\"\\") {
+    let txt1 = ctx['a'].b.c;
+    return block1([txt1]);
+  }
+}"
+`;
+
 exports[`basics simple catchError 1`] = `
 "function anonymous(app, bdom, helpers
 ) {


### PR DESCRIPTION
…it and root

Have a component implementing onError that calls a callback from one of its parent. That parent should not be the original source of the rendering (a parent above is).

Make the callback handle the error and trigger an render()

Before this commit, the parent did not see it was handling a subtree in error, and did not have a chance to revert that error state in its rendering stack.

After this commit, this flow works.