### PR TITLE
[FIX] validation: validate schema keys

### DIFF
--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -308,4 +308,13 @@ describe("validateSchema", () => {
     ]);
     expect(validateSchema({ a: "string" }, { a: [String, { value: false }] })).toEqual([]);
   });
+
+  test("validate schema's own keys", () => {
+    expect(validateSchema({ arr: [] }, { arr: { type: Array, elements: String } as any })).toEqual([
+      `invalid schema for 'arr': unknown keys "elements"`,
+    ]);
+    expect(validateSchema({ obj: {} }, { obj: { type: Object, shapes: String } as any })).toEqual([
+      `invalid schema for 'obj': unknown keys "shapes"`,
+    ]);
+  });
 });


### PR DESCRIPTION
This commit adds validation for the schema object itself, to ensure that only recognized keys are set on it.

This is done to avoid typos when writing validation schemas (e.g. `{ type: Array, element*S*: String  }`).