### PR TITLE
[FIX] smarter synthetic events

### DIFF
--- a/tests/compiler/event_handling.test.ts
+++ b/tests/compiler/event_handling.test.ts
@@ -575,5 +575,16 @@ describe("t-on", () => {
       button.click();
       expect(steps).toEqual(["btnClicked", "divClicked"]);
     });
+
+    test("non-bubbling events cannot be synthesized", () => {
+      const template = `<div t-on-mouseenter.synthetic="onMouseEnter"></div>`;
+
+      const owner = {
+        onMouseEnter() {},
+      };
+      const node = mountToFixture(template, owner);
+      const div = <HTMLElement>node;
+      div.dispatchEvent(new MouseEvent("mouseenter"));
+    });
   });
 });


### PR DESCRIPTION
This commit fixes 2 behaviors regarding synthetic events:

- "non-bubbling" events (such as 'mouseenter', 'focus', etc.) are not allowed anymore as synthetic events, since this would not work either way;

- instead of an internal global variable to keep track of what events have already been registered with synthetic event handlers, special keys are now assigned on the document object. This has been done to avoid duplicate listeners when multiple instances of Owl are spawned.

Fixes https://github.com/odoo/owl/issues/1284