### PR TITLE
[FIX] app: take into account `config.dev` if it is set

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -74,9 +74,7 @@ export class App<
     this.name = config.name || "";
     this.Root = Root;
     apps.add(this);
-    if (config.test) {
-      this.dev = true;
-    }
+    this.dev = config.dev ?? !!config.test;
     this.warnIfNoStaticProps = config.warnIfNoStaticProps || false;
     if (this.dev && !config.test && !hasBeenLogged) {
       console.info(`Owl is running in 'dev' mode.`);


### PR DESCRIPTION
__Behavior before commit:__
When [`mountWithCleanup`] is called, the config to create a new instance
of `App` contains `dev: false` and `test: true`.
In the constructor of [`TemplateSet`], `this.dev` is set to `config.dev`
but it's then it's overwritten in the constructor of `App` if
`config.test` is set.

This has the annoying side-effect of calling `wrapError` during Hoot
tests, which adds quite a big performance and memory overhead.

__Fix:__
Make sure that `this.dev` is set to `config.dev` even if `config.test`
is `true`.

[`mountWithCleanup`]: https://github.com/odoo/odoo/blob/7fd5f90fe8fce4de49ec10c683f92e7a3557981a/addons/web/static/tests/_framework/component_test_helpers.js#L138
[`TemplateSet`]: https://github.com/odoo/owl/blob/4e834369527f5d747de8f13236504dc20731c1c8/src/runtime/template_set.ts#L38

task-5269391