### PR TITLE
[IMP] devtools: migrate to Owl 3 with Owl 2 backward compatibility

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "manifest_version": 3,
   "description": "Chrome devtools extension for Odoo Owl framework",
   "icons": {

--- a/tools/devtools/manifest-firefox.json
+++ b/tools/devtools/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Firefox devtools extension for Odoo Owl framework",
   "manifest_version": 2,
   "browser_specific_settings": {

--- a/tools/devtools/src/devtools_app/context_menu/context_menu.js
+++ b/tools/devtools/src/devtools_app/context_menu/context_menu.js
@@ -1,36 +1,35 @@
-import { useStore } from "../store/store";
+import { StorePlugin } from "../store/store";
 
-const { Component, useEffect, useRef } = owl;
+const { Component, useEffect, signal, plugin, props, types: t } = owl;
 
 export class ContextMenu extends Component {
   static template = "devtools.ContextMenu";
-  static props = {
-    items: Array,
-  };
+
+  props = props({ items: t.array() });
+
   setup() {
-    this.store = useStore();
-    this.contextMenu = useRef("contextmenu");
-    useEffect(
-      (position) => {
-        const menu = this.contextMenu.el;
-        const menuWidth = menu.offsetWidth;
-        const menuHeight = menu.offsetHeight;
-        let { x, y } = position;
-        if (x + menuWidth > window.innerWidth) {
-          x = window.innerWidth - menuWidth;
-        }
-        if (y + menuHeight > window.innerHeight) {
-          y = window.innerHeight - menuHeight;
-        }
-        menu.style.left = x + "px";
-        // Need 25px offset because of the main navbar from the browser devtools
-        menu.style.top = y + "px";
-      },
-      () => [this.store.contextMenu?.position]
-    );
+    this.store = plugin(StorePlugin);
+    this.contextMenu = signal(null);
+    useEffect(() => {
+      const position = this.store.contextMenu()?.position;
+      const menu = this.contextMenu();
+      if (!menu || !position) return;
+      const menuWidth = menu.offsetWidth;
+      const menuHeight = menu.offsetHeight;
+      let { x, y } = position;
+      if (x + menuWidth > window.innerWidth) {
+        x = window.innerWidth - menuWidth;
+      }
+      if (y + menuHeight > window.innerHeight) {
+        y = window.innerHeight - menuHeight;
+      }
+      menu.style.left = x + "px";
+      // Need 25px offset because of the main navbar from the browser devtools
+      menu.style.top = y + "px";
+    });
   }
   onClickItem(action) {
     action();
-    this.store.contextMenu = null;
+    this.store.contextMenu.set(null);
   }
 }

--- a/tools/devtools/src/devtools_app/context_menu/context_menu.xml
+++ b/tools/devtools/src/devtools_app/context_menu/context_menu.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
   <t t-name="devtools.ContextMenu">
-    <div class="custom-menu" t-ref="contextmenu">
+    <div class="custom-menu" t-ref="this.contextMenu">
         <ul class="my-1">
-          <li t-foreach="props.items" t-as="item" t-key="item_index" t-if="item.show" t-esc="item.title" t-on-click.stop="() => this.onClickItem(item.action)" class="custom-menu-item py-1 px-4"/>
+          <li t-foreach="this.props.items" t-as="item" t-key="item_index" t-if="item.show" t-out="item.title" t-on-click.stop="() => this.onClickItem(item.action)" class="custom-menu-item py-1 px-4"/>
         </ul>
     </div>
   </t>

--- a/tools/devtools/src/devtools_app/devtools_panel.js
+++ b/tools/devtools/src/devtools_app/devtools_panel.js
@@ -1,10 +1,11 @@
-/** @odoo-module **/
-
 import { DevtoolsWindow } from "./devtools_window/devtools_window";
+import { StorePlugin } from "./store/store";
+import { ComponentsPlugin } from "./store/components_plugin";
+import { ProfilerPlugin } from "./store/profiler_plugin";
 const { mount } = owl;
 import { templates } from "../../assets/templates.js";
 
 for (const template in templates) {
   owl.App.registerTemplate(template, templates[template]);
 }
-mount(DevtoolsWindow, document.body, { dev: true });
+mount(DevtoolsWindow, document.body, { plugins: [StorePlugin, ComponentsPlugin, ProfilerPlugin] });

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/component_search_bar/component_search_bar.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/component_search_bar/component_search_bar.js
@@ -1,24 +1,22 @@
-import { useStore } from "../../../store/store";
+import { ComponentsPlugin } from "../../../store/components_plugin";
 
-const { Component } = owl;
+const { Component, plugin } = owl;
 
 export class ComponentSearchBar extends Component {
   static template = "devtools.ComponentSearchBar";
 
   setup() {
-    this.store = useStore();
+    this.components = plugin(ComponentsPlugin);
   }
 
   updateSearch(event) {
-    if (event.key !== "Enter") {
-      this.store.updateSearch(event.target.value);
-    }
+    this.components.updateSearch(event.target.value);
   }
 
   // Go to the next search result repeatedly while enter is pressed
   onSearchKeyDown(event) {
     if (event.key === "Enter") {
-      this.store.componentSearch.getNextSearch();
+      this.components.getNextSearch();
     }
   }
 }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/component_search_bar/component_search_bar.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/component_search_bar/component_search_bar.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.ComponentSearchBar" owl="1">
-    <div class="mouse-icon p-1" t-on-click.stop='() => this.store.toggleSelector()'>
-      <i title="Select an element in the page to inspect the corresponding component" class="fa fa-fw fa-mouse-pointer" t-attf-style="color: {{store.componentSearch.activeSelector ? 'var(--active-icon)' : 'var(--text-color)'}};"></i>
+  <t t-name="devtools.ComponentSearchBar">
+    <div class="mouse-icon p-1" t-on-click.stop='() => this.components.toggleSelector()'>
+      <i title="Select an element in the page to inspect the corresponding component" class="fa fa-fw fa-mouse-pointer" t-attf-style="color: {{this.components.activeSelector() ? 'var(--active-icon)' : 'var(--text-color)'}};"></i>
     </div>
     <div class="icons-separator"/>
     <div class="d-flex align-items-center ms-2 flex-grow-1">
       <i class="fa fa-search search-icon" aria-hidden="true"></i>
-      <input type="text" class="search-input ms-1 w-100 border-0 h-100" placeholder="Search" t-on-keyup.stop="updateSearch" t-on-keydown.stop="onSearchKeyDown" t-att-value="store.componentSearch.search"/>
-      <t t-if="store.componentSearch.search.length > 0">
-        <t t-esc="store.componentSearch.searchResults.length ? store.componentSearch.searchIndex + 1 : 0"/>|<t t-esc="store.componentSearch.searchResults.length"/>
-        <i class="fa fa-angle-up lg-icon utility-icon ms-1 p-1" t-on-click.stop="() => this.store.componentSearch.getPrevSearch()"></i>
-        <i class="fa fa-angle-down lg-icon utility-icon p-1" t-on-click.stop="() => this.store.componentSearch.getNextSearch()"></i>
-        <i class="fa fa-times lg-icon utility-icon p-1 me-2" t-on-click.stop='() => this.store.updateSearch("")'></i>
+      <input type="text" class="search-input ms-1 w-100 border-0 h-100" placeholder="Search" t-on-input.stop="this.updateSearch" t-on-keydown.stop="this.onSearchKeyDown" t-att-value="this.components.searchText()"/>
+      <t t-if="this.components.searchText().length > 0">
+        <t t-out="this.components.searchResults().length ? this.components.searchIndex() + 1 : 0"/>|<t t-out="this.components.searchResults().length"/>
+        <i class="fa fa-angle-up lg-icon utility-icon ms-1 p-1" t-on-click.stop="() => this.components.getPrevSearch()"></i>
+        <i class="fa fa-angle-down lg-icon utility-icon p-1" t-on-click.stop="() => this.components.getNextSearch()"></i>
+        <i class="fa fa-times lg-icon utility-icon p-1 me-2" t-on-click.stop='() => this.components.updateSearch("")'></i>
       </t>
     </div>
   </t>

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.js
@@ -1,10 +1,9 @@
-/** @odoo-module **/
-
-const { Component, onWillUnmount, useExternalListener } = owl;
+const { Component, onWillDestroy, useListener, plugin } = owl;
 import { TreeElement } from "./tree_element/tree_element";
 import { DetailsWindow } from "./details_window/details_window";
 import { ComponentSearchBar } from "./component_search_bar/component_search_bar";
-import { useStore } from "../../store/store";
+import { StorePlugin } from "../../store/store";
+import { ComponentsPlugin } from "../../store/components_plugin";
 
 export class ComponentsTab extends Component {
   static template = "devtools.ComponentsTab";
@@ -12,12 +11,13 @@ export class ComponentsTab extends Component {
   static components = { TreeElement, DetailsWindow, ComponentSearchBar };
 
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
     this.flushRendersTimeout = false;
-    useExternalListener(document, "keydown", this.onKeyboardEvent);
-    useExternalListener(window, "resize", this.onWindowResize);
+    useListener(document, "keydown", this.onKeyboardEvent.bind(this));
+    useListener(window, "resize", this.onWindowResize);
 
-    onWillUnmount(() => {
+    onWillDestroy(() => {
       window.removeEventListener("mousemove", this.onMouseMove);
       window.removeEventListener("mouseup", this.onMouseUp);
     });
@@ -27,19 +27,19 @@ export class ComponentsTab extends Component {
   onKeyboardEvent(event) {
     switch (event.key) {
       case "ArrowLeft":
-        this.store.toggleOrSelectPrevElement(true);
+        this.components.toggleOrSelectPrevElement(true);
         event.preventDefault();
         break;
       case "ArrowUp":
-        this.store.toggleOrSelectPrevElement(false);
+        this.components.toggleOrSelectPrevElement(false);
         event.preventDefault();
         break;
       case "ArrowRight":
-        this.store.toggleOrSelectNextElement(true);
+        this.components.toggleOrSelectNextElement(true);
         event.preventDefault();
         break;
       case "ArrowDown":
-        this.store.toggleOrSelectNextElement(false);
+        this.components.toggleOrSelectNextElement(false);
         event.preventDefault();
         break;
     }
@@ -56,9 +56,8 @@ export class ComponentsTab extends Component {
   onMouseMove = (event) => {
     const minWidth = (147 / window.innerWidth) * 100;
     const maxWidth = 100 - (100 / window.innerWidth) * 100;
-    this.store.splitPosition = Math.max(
-      Math.min((event.clientX / window.innerWidth) * 100, maxWidth),
-      minWidth
+    this.store.splitPosition.set(
+      Math.max(Math.min((event.clientX / window.innerWidth) * 100, maxWidth), minWidth)
     );
   };
 
@@ -71,7 +70,7 @@ export class ComponentsTab extends Component {
   onWindowResize = () => {
     const minWidth = (147 / window.innerWidth) * 100;
     if (minWidth <= 100) {
-      this.store.splitPosition = Math.max(this.store.splitPosition, minWidth);
+      this.store.splitPosition.set(Math.max(this.store.splitPosition(), minWidth));
     }
   };
 }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/components_tab.xml
@@ -1,37 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.ComponentsTab" owl="1">
-    <t t-if="store.apps.length === 0">
+  <t t-name="devtools.ComponentsTab">
+    <t t-if="this.components.apps().length === 0">
       <div class="status-message d-flex justify-content-center align-items-center">
         There are no apps currently running.
       </div>
     </t>
     <t t-else="">
       <div class="position-relative overflow-hidden d-flex flex-row h-100">
-        <div class="split-screen-left d-flex flex-column" t-attf-style="width:{{store.splitPosition}}%;">
+        <div class="split-screen-left d-flex flex-column" t-attf-style="width:{{this.components.activeSelector() ? 100 : this.store.splitPosition()}}%;">
           <div class="panel-top d-flex align-items-center">
             <ComponentSearchBar/>
           </div>
           <div class="overflow-auto h-100 font-monospace">
             <div id="tree-wrapper">
-              <t t-foreach="store.apps" t-as="app" t-key="app_index">
-                <TreeElement component="app"/> 
+              <t t-foreach="this.components.apps()" t-as="app" t-key="app_index">
+                <TreeElement component="app"/>
               </t>
             </div>
           </div>
         </div>
-        <div
-          class="split-screen-border user-select-none"
-          t-on-mousedown="onMouseDown"
-        />
-        <div class="split-screen-right d-flex flex-column font-monospace" t-attf-style="width:{{100 - store.splitPosition}}%;">
-          <DetailsWindow t-if="store.activeComponent"/>
-          <t t-else="">
-            <div class="status-message d-flex justify-content-center align-items-center">
-              There was an error while processing this component.
-            </div>
-          </t>
-        </div>
+        <t t-if="!this.components.activeSelector()">
+          <div
+            class="split-screen-border user-select-none"
+            t-on-mousedown="this.onMouseDown"
+          />
+          <div class="split-screen-right d-flex flex-column font-monospace" t-attf-style="width:{{100 - this.store.splitPosition()}}%;">
+            <DetailsWindow t-if="this.components.activeComponent()"/>
+            <t t-else="">
+              <div class="status-message d-flex justify-content-center align-items-center">
+                There was an error while processing this component.
+              </div>
+            </t>
+          </div>
+        </t>
       </div>
     </t>
   </t>

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/details_window.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/details_window.js
@@ -1,12 +1,14 @@
-const { Component } = owl;
-import { useStore } from "../../../store/store";
+const { Component, plugin } = owl;
+import { StorePlugin } from "../../../store/store";
+import { ComponentsPlugin } from "../../../store/components_plugin";
 import { ObjectTreeElement } from "./object_tree_element/object_tree_element";
 
 export class DetailsWindow extends Component {
   static template = "devtools.DetailsWindow";
   static components = { ObjectTreeElement };
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
   }
 
   get contextMenuItems() {
@@ -14,51 +16,58 @@ export class DetailsWindow extends Component {
       {
         title: "Inspect source code",
         show: true,
-        action: () => this.store.inspectComponent("source", this.store.activeComponent.path),
+        action: () =>
+          this.components.inspectComponent("source", this.components.activeComponent().path),
       },
       {
         title: "Store as global variable",
-        show: this.store.activeComponent.path.length !== 1,
+        show: this.components.activeComponent().path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
-            ...this.store.activeComponent.path,
+          this.components.logObjectInConsole([
+            ...this.components.activeComponent().path,
             { type: "item", value: "component" },
           ]),
       },
       {
         title: "Inspect in Elements tab",
-        show: this.store.activeComponent.path.length !== 1,
-        action: () => this.store.inspectComponent("DOM", this.store.activeComponent.path),
+        show: this.components.activeComponent().path.length !== 1,
+        action: () =>
+          this.components.inspectComponent("DOM", this.components.activeComponent().path),
       },
       {
         title: "Force rerender",
-        show: this.store.activeComponent.path.length !== 1,
-        action: () => this.store.refreshComponent(this.store.activeComponent.path),
+        show: this.components.activeComponent().path.length !== 1,
+        action: () => this.components.refreshComponent(this.components.activeComponent().path),
       },
       {
         title: "Store observed states as global variable",
-        show: this.store.activeComponent.path.length !== 1,
+        show: this.components.activeComponent().path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
-            ...this.store.activeComponent.path,
+          this.components.logObjectInConsole([
+            ...this.components.activeComponent().path,
             { type: "item", value: "subscriptions" },
           ]),
       },
       {
         title: "Inspect compiled template",
-        show: this.store.activeComponent.path.length !== 1,
+        show: this.components.activeComponent().path.length !== 1,
         action: () =>
-          this.store.inspectComponent("compiled template", this.store.activeComponent.path),
+          this.components.inspectComponent(
+            "compiled template",
+            this.components.activeComponent().path
+          ),
       },
       {
         title: "Log raw template",
-        show: this.store.activeComponent.path.length !== 1,
-        action: () => this.store.inspectComponent("raw template", this.store.activeComponent.path),
+        show: this.components.activeComponent().path.length !== 1,
+        action: () =>
+          this.components.inspectComponent("raw template", this.components.activeComponent().path),
       },
       {
         title: "Store as global variable",
-        show: this.store.activeComponent.path.length === 1,
-        action: () => this.store.logObjectInConsole([...this.store.activeComponent.path]),
+        show: this.components.activeComponent().path.length === 1,
+        action: () =>
+          this.components.logObjectInConsole([...this.components.activeComponent().path]),
       },
     ];
   }
@@ -68,6 +77,7 @@ export class DetailsWindow extends Component {
   }
 
   toggleCategory(ev, category) {
-    this.store.activeComponent[category].toggled = !this.store.activeComponent[category].toggled;
+    this.components.activeComponent()[category].toggled =
+      !this.components.activeComponent()[category].toggled;
   }
 }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/details_window.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/details_window.xml
@@ -1,107 +1,120 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.DetailsWindow" owl="1">
+  <t t-name="devtools.DetailsWindow">
     <div class="panel-top d-flex align-items-center">
       <div class="ms-1 p-1 text-truncate" style="width: 100%;">
-        <span t-if="store.activeComponent.path.length > 1">&lt;</span>
-        <b 
+        <span t-if="this.components.activeComponent().path.length > 1">&lt;</span>
+        <b
           style="color: var(--component-color); cursor: pointer;"
-          t-on-mouseover.stop="() => this.store.highlightComponent(this.store.activeComponent.path)"
-          t-on-click.stop="() => this.store.onActiveComponentClick()"
-          t-on-contextmenu.prevent="openMenu"
-          t-esc="store.activeComponent.name"
+          t-on-mouseover.stop="() => this.components.highlightComponent(this.components.activeComponent().path)"
+          t-on-click.stop="() => this.components.onActiveComponentClick()"
+          t-on-contextmenu.prevent="this.openMenu"
+          t-out="this.components.activeComponent().name"
         />
-        <span t-if="store.activeComponent.path.length > 1">&gt;</span>
-        <span class="version" t-else="">owl=<t t-esc="store.activeComponent.version"/></span>
+        <span t-if="this.components.activeComponent().path.length > 1">&gt;</span>
+        <span class="version" t-else="">owl=<t t-out="this.components.activeComponent().version"/></span>
       </div>
-      <t t-if="store.activeComponent.path.length > 1">
-        <i title="Inspect component in the Elements tab" class="fa fa-eye utility-icon p-1" t-on-click.stop="() => this.store.inspectComponent('DOM')"></i>
-        <i title="Store component as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.store.logObjectInConsole()"></i>
-        <i title="Inspect source code of component" class="fa fa-file-code-o utility-icon p-1" t-on-click.stop="() => this.store.inspectComponent('source')"></i>
-        <i title="Trigger rerender of the component" class="fa fa-refresh utility-icon p-1" t-on-click.stop="() => this.store.refreshComponent()"></i>
+      <t t-if="this.components.activeComponent().path.length > 1">
+        <i title="Inspect component in the Elements tab" class="fa fa-eye utility-icon p-1" t-on-click.stop="() => this.components.inspectComponent('DOM')"></i>
+        <i title="Store component as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.components.logObjectInConsole()"></i>
+        <i title="Inspect source code of component" class="fa fa-file-code-o utility-icon p-1" t-on-click.stop="() => this.components.inspectComponent('source')"></i>
+        <i title="Trigger rerender of the component" class="fa fa-refresh utility-icon p-1" t-on-click.stop="() => this.components.refreshComponent()"></i>
       </t>
       <t t-else="">
-        <i title="Store app as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.store.logObjectInConsole()"></i>
-        <i title="Inspect source code of the app" class="fa fa-file-code-o utility-icon p-1" t-on-click.stop="() => this.store.inspectComponent('source')"></i>
+        <i title="Store app as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.components.logObjectInConsole()"></i>
+        <i title="Inspect source code of the app" class="fa fa-file-code-o utility-icon p-1" t-on-click.stop="() => this.components.inspectComponent('source')"></i>
       </t>
     </div>
     <div class="details-container">
-      <div t-if="store.observedVariables.length and store.observedVariables.some((v) => v.visible)" id="observedVariables" class="details-panel ps-2 py-1">
+      <div t-if="this.components.observedVariables().length and this.components.observedVariables().some((v) => v.visible)" id="observedVariables" class="details-panel ps-2 py-1">
         <div class="d-flex mb-2">
           <div class="w-100">
             <b class="ps-2">observed variables</b>
           </div>
-          <i title="Remove observed variables" class="fa fa-times utility-icon p-1" t-on-click.stop="() => this.store.clearObservedVariable()"></i>
+          <i title="Remove observed variables" class="fa fa-times utility-icon p-1" t-on-click.stop="() => this.components.clearObservedVariable()"></i>
         </div>
-        <t t-foreach="store.observedVariables" t-as="observed" t-key="observed_index" t-if="observed.visible">
+        <t t-foreach="this.components.observedVariables()" t-as="observed" t-key="observed_index" t-if="observed.visible">
           <ObjectTreeElement object="observed" index="observed_index"/>
         </t>
       </div>
-      <div t-if="store.activeComponent.env.children.length > 0" id="env" class="details-panel ps-2 py-1">
+      <div t-if="this.components.activeComponent().env?.children.length > 0" id="env" class="details-panel ps-2 py-1">
         <div class="d-flex mb-2">
           <div class="w-100" t-on-click.stop="(ev) => this.toggleCategory(ev, 'env')">
             <i class="fa mx-1 pointer-icon"
-              t-att-class="{'fa-caret-right': !store.activeComponent.env.toggled, 'fa-caret-down': store.activeComponent.env.toggled}"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().env.toggled, 'fa-caret-down': this.components.activeComponent().env.toggled}"
             /><b>env</b>
           </div>
         </div>
-        <t t-if="store.activeComponent.env.toggled" t-foreach="store.activeComponent.env.children" t-as="env" t-key="env_index">
+        <t t-if="this.components.activeComponent().env.toggled" t-foreach="this.components.activeComponent().env.children" t-as="env" t-key="env_index">
           <ObjectTreeElement object="env"/>
         </t>
       </div>
-      <div t-if="store.activeComponent.props.children.length > 0" class="details-panel ps-2 py-1">
+      <div t-if="this.components.activeComponent().props.children.length > 0" class="details-panel ps-2 py-1">
         <div class="d-flex mb-2">
           <div class="w-100" t-on-click.stop="(ev) => this.toggleCategory(ev, 'props')">
             <i class="fa mx-1 pointer-icon"
-              t-att-class="{'fa-caret-right': !store.activeComponent.props.toggled, 'fa-caret-down': store.activeComponent.props.toggled}"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().props.toggled, 'fa-caret-down': this.components.activeComponent().props.toggled}"
             /><b>props</b>
           </div>
         </div>
-        <t t-if="store.activeComponent.props.toggled" t-foreach="store.activeComponent.props.children" t-as="prop" t-key="prop_index">
+        <t t-if="this.components.activeComponent().props.toggled" t-foreach="this.components.activeComponent().props.children" t-as="prop" t-key="prop_index">
           <ObjectTreeElement object="prop"/>
         </t>
       </div>
-      <div t-if="store.activeComponent.subscriptions.children.length > 0" id="subscriptions" class="details-panel ps-2 py-1">
+      <div t-if="this.components.activeComponent().reactiveValues?.children.length > 0" id="reactiveValues" class="details-panel ps-2 py-1">
+        <div class="d-flex mb-2">
+          <div class="w-100" t-on-click.stop="(ev) => this.toggleCategory(ev, 'reactiveValues')">
+            <i class="fa mx-1 pointer-icon"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().reactiveValues.toggled, 'fa-caret-down': this.components.activeComponent().reactiveValues.toggled}"
+            /><b>reactive values</b>
+          </div>
+        </div>
+        <t t-if="this.components.activeComponent().reactiveValues.toggled"
+           t-foreach="this.components.activeComponent().reactiveValues.children" t-as="rv" t-key="rv_index">
+          <ObjectTreeElement object="rv"/>
+        </t>
+      </div>
+      <div t-if="this.components.activeComponent().subscriptions.children.length > 0" id="subscriptions" class="details-panel ps-2 py-1">
         <div class="d-flex">
           <div title="Shows all the targets that will trigger a re-render of the component when one of its associated keys is modified" class="w-100 text-truncate" t-on-click.stop="(ev) => this.toggleCategory(ev, 'subscriptions')">
             <i class="fa mx-1 pointer-icon"
-              t-att-class="{'fa-caret-right': !store.activeComponent.subscriptions.toggled, 'fa-caret-down': store.activeComponent.subscriptions.toggled}"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().subscriptions.toggled, 'fa-caret-down': this.components.activeComponent().subscriptions.toggled}"
             /><b>observed state</b>
           </div>
-          <i title="Store observed states as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.store.logObjectInConsole([...this.store.activeComponent.path, {type: 'item', value: 'subscriptions'}])"></i>
+          <i title="Store observed states as global variable in the console" class="fa fa-bug utility-icon p-1" t-on-click.stop="() => this.components.logObjectInConsole([...this.components.activeComponent().path, {type: 'item', value: 'subscriptions'}])"></i>
         </div>
-        <div t-if="store.activeComponent.subscriptions.toggled" id="subscriptionsPanel">
-          <t t-foreach="store.activeComponent.subscriptions.children" t-as="subscription" t-key="subscription_index">
+        <div t-if="this.components.activeComponent().subscriptions.toggled" id="subscriptionsPanel">
+          <t t-foreach="this.components.activeComponent().subscriptions.children" t-as="subscription" t-key="subscription_index">
             <ObjectTreeElement object="subscription.target"/>
           </t>
         </div>
       </div>
-      <div t-if="store.activeComponent.instance.children.length > 0" id="instance" class="details-panel ps-2 py-1">
+      <div t-if="this.components.activeComponent().instance.children.length > 0" id="instance" class="details-panel ps-2 py-1">
         <div class="d-flex mb-2">
           <div class="w-100 text-truncate" t-on-click.stop="(ev) => this.toggleCategory(ev, 'instance')">
             <i class="fa mx-1 pointer-icon"
-              t-att-class="{'fa-caret-right': !store.activeComponent.instance.toggled, 'fa-caret-down': store.activeComponent.instance.toggled}"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().instance.toggled, 'fa-caret-down': this.components.activeComponent().instance.toggled}"
             /><b>instance</b>
           </div>
-          <t t-if="store.activeComponent.path.length > 1">
-            <i title="Inspect compiled template" class="fa fa-hashtag utility-icon p-1" t-on-click.stop="() => this.store.inspectComponent('compiled template')"></i>
-            <i title="Send raw template to console" class="fa fa-file-word-o utility-icon p-1" t-on-click.stop="() => this.store.inspectComponent('raw template')"></i>
+          <t t-if="this.components.activeComponent().path.length > 1">
+            <i title="Inspect compiled template" class="fa fa-hashtag utility-icon p-1" t-on-click.stop="() => this.components.inspectComponent('compiled template')"></i>
+            <i title="Send raw template to console" class="fa fa-file-word-o utility-icon p-1" t-on-click.stop="() => this.components.inspectComponent('raw template')"></i>
           </t>
         </div>
-        <t t-if="store.activeComponent.instance.toggled" t-foreach="store.activeComponent.instance.children" t-as="instance" t-key="instance_index">
+        <t t-if="this.components.activeComponent().instance.toggled" t-foreach="this.components.activeComponent().instance.children" t-as="instance" t-key="instance_index">
           <ObjectTreeElement object="instance"/>
         </t>
       </div>
-      <div t-if="store.activeComponent.hooks?.children.length > 0" id="hooks" class="details-panel ps-2 py-1">
+      <div t-if="this.components.activeComponent().hooks?.children.length > 0" id="hooks" class="details-panel ps-2 py-1">
         <div class="d-flex mb-2">
           <div class="w-100" t-on-click.stop="(ev) => this.toggleCategory(ev, 'hooks')">
             <i class="fa mx-1 pointer-icon"
-              t-att-class="{'fa-caret-right': !store.activeComponent.hooks.toggled, 'fa-caret-down': store.activeComponent.hooks.toggled}"
+              t-att-class="{'fa-caret-right': !this.components.activeComponent().hooks.toggled, 'fa-caret-down': this.components.activeComponent().hooks.toggled}"
             /><b>hooks</b>
           </div>
-          <i title="Remove breakpoints" class="fa fa-times utility-icon p-1" t-on-click.stop="() => this.store.removeBreakpoints()"></i>
+          <i title="Remove breakpoints" class="fa fa-times utility-icon p-1" t-on-click.stop="() => this.components.removeBreakpoints()"></i>
         </div>
-        <t t-if="store.activeComponent.hooks.toggled" t-foreach="store.activeComponent.hooks.children" t-as="hook" t-key="hook_index">
+        <t t-if="this.components.activeComponent().hooks.toggled" t-foreach="this.components.activeComponent().hooks.children" t-as="hook" t-key="hook_index">
           <ObjectTreeElement object="hook"/>
         </t>
       </div>

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/object_tree_element/object_tree_element.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/object_tree_element/object_tree_element.js
@@ -1,29 +1,29 @@
-import { useStore } from "../../../../store/store";
+import { StorePlugin } from "../../../../store/store";
+import { ComponentsPlugin } from "../../../../store/components_plugin";
 
-const { Component, useState, useEffect, useRef } = owl;
+const { Component, proxy, useEffect, signal, plugin, props, types: t } = owl;
 
 export class ObjectTreeElement extends Component {
   static template = "devtools.ObjectTreeElement";
-
   static components = { ObjectTreeElement };
 
+  props = props({ object: t.object(), "class?": t.string, "index?": t.number });
+
   setup() {
-    this.state = useState({
+    this.state = proxy({
       editMode: false,
       menuTop: 0,
       menuLeft: 0,
     });
-    const inputRef = useRef("input");
-    this.store = useStore();
-    useEffect(
-      (editMode) => {
-        // Focus on the input when it is created
-        if (editMode) {
-          inputRef.el.select();
-        }
-      },
-      () => [this.state.editMode]
-    );
+    this.inputRef = signal(null);
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
+    useEffect(() => {
+      // Focus on the input when it is created
+      if (this.state.editMode) {
+        this.inputRef()?.select();
+      }
+    });
   }
 
   get pathAsString() {
@@ -57,28 +57,31 @@ export class ObjectTreeElement extends Component {
       {
         title: "Store as global variable",
         show: true,
-        action: () => this.store.logObjectInConsole(this.props.object.path),
+        action: () => this.components.logObjectInConsole(this.props.object.path),
       },
       {
         title: "Inspect function source code",
         show: this.props.object.contentType === "function",
-        action: () => this.store.inspectFunctionSource(this.props.object.path),
+        action: () => this.components.inspectFunctionSource(this.props.object.path),
       },
       {
         title: "Observe variable",
         show: this.props.object.objectType !== "observed",
-        action: () => this.store.observeVariable(this.props.object.path),
+        action: () => this.components.observeVariable(this.props.object.path),
       },
       {
         title: "Unobserve variable",
         show: this.props.object.objectType === "observed",
-        action: () => this.store.clearObservedVariable(this.props.index),
+        action: () => this.components.clearObservedVariable(this.props.index),
       },
       {
         title: "Inject breakpoint on component",
         show: this.props.object.contentType === "array" && this.props.object.objectType === "hook",
         action: () =>
-          this.store.injectBreakpoint(this.props.object.name, this.store.activeComponent.path),
+          this.components.injectBreakpoint(
+            this.props.object.name,
+            this.components.activeComponent().path
+          ),
       },
       {
         title: "Inject conditional breakpoint on component",
@@ -86,9 +89,9 @@ export class ObjectTreeElement extends Component {
         action: () => {
           const condition = window.prompt("Enter the condition");
           if (condition) {
-            this.store.injectBreakpoint(
+            this.components.injectBreakpoint(
               this.props.object.name,
-              this.store.activeComponent.path,
+              this.components.activeComponent().path,
               false,
               condition
             );
@@ -102,9 +105,9 @@ export class ObjectTreeElement extends Component {
           this.props.object.objectType === "hook" &&
           !["mounted", "willStart"].includes(this.props.object.name),
         action: () =>
-          this.store.injectBreakpoint(
+          this.components.injectBreakpoint(
             this.props.object.name,
-            this.store.activeComponent.path,
+            this.components.activeComponent().path,
             true
           ),
       },
@@ -128,7 +131,11 @@ export class ObjectTreeElement extends Component {
   editObject(ev) {
     let value = ev.target.value;
     if (ev.keyCode === 13 && value !== "") {
-      this.store.editObjectTreeElement(this.props.object.path, value, this.props.object.objectType);
+      this.components.editObjectTreeElement(
+        this.props.object.path,
+        value,
+        this.props.object.objectType
+      );
       this.state.editMode = false;
     }
   }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/object_tree_element/object_tree_element.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/details_window/object_tree_element/object_tree_element.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.ObjectTreeElement" owl="1">
+  <t t-name="devtools.ObjectTreeElement">
     <div class="m-0 p-0 text-nowrap w-100 object-line"
-      t-att-class="props.class + (props.object.hasChildren ? ' bg-feedback' : '')"
-      t-on-click.stop="() => this.store.toggleObjectTreeElementsDisplay(this.props.object)"
-      t-on-contextmenu.prevent="openMenu"
+      t-att-class="this.props.class + (this.props.object.hasChildren ? ' bg-feedback' : '')"
+      t-on-click.stop="() => this.components.toggleObjectTreeElementsDisplay(this.props.object)"
+      t-on-contextmenu.prevent="this.openMenu"
     >
-      <div t-attf-style="padding-left: {{objectPadding}}rem">
+      <div t-attf-style="padding-left: {{this.objectPadding}}rem">
         <i class="fa px-1 pointer-icon caret"
-          t-att-class="{'fa-caret-right': !props.object.toggled, 'fa-caret-down': props.object.toggled}"
-          t-attf-style="visibility: {{props.object.hasChildren ? '' : 'hidden'}};"
+          t-att-class="{'fa-caret-right': !this.props.object.toggled, 'fa-caret-down': this.props.object.toggled}"
+          t-attf-style="visibility: {{this.props.object.hasChildren ? '' : 'hidden'}};"
         />
-        <t t-esc="props.object.name"/>
-        <t t-if="props.object.content.length > 0">: </t>
-        <t t-if="props.object.contentType == 'getter'">
-          <span class="getter-content object-content" t-att-class="objectLineClass" t-on-click.stop="() => this.store.loadGetterContent(this.props.object)">
-            <t t-esc="props.object.content"/>
+        <t t-out="this.props.object.name"/>
+        <t t-if="this.props.object.content.length > 0">: </t>
+        <t t-if="this.props.object.contentType == 'getter'">
+          <span class="getter-content object-content" t-att-class="this.objectLineClass" t-on-click.stop="() => this.components.loadGetterContent(this.props.object)">
+            <t t-out="this.props.object.content"/>
           </span>
         </t>
         <t t-else="">
-          <span class="object-content" t-att-class="objectLineClass" t-on-dblclick.stop="setupEditMode">
-            <t t-if="state.editMode">
-              <input t-attf-id="objectEditionInput/{{pathAsString}}" t-ref="input" type="text" placeholder="" t-att-value="props.object.content" t-on-keydown.stop="editObject"/>
+          <span class="object-content" t-att-class="this.objectLineClass" t-on-dblclick.stop="this.setupEditMode">
+            <t t-if="this.state.editMode">
+              <input t-attf-id="objectEditionInput/{{this.pathAsString}}" t-ref="this.inputRef" type="text" placeholder="" t-att-value="this.props.object.content" t-on-keydown.stop="this.editObject"/>
             </t>
             <t t-else="">
-              <t t-esc="props.object.content"/>
+              <t t-out="this.props.object.content"/>
             </t>
           </span>
         </t>
-        <span t-if="keyChanges" class="key-changes ms-1 badge p-1" title="Key additions/deletions are observed">+/-</span>
+        <span t-if="this.keyChanges" class="key-changes ms-1 badge p-1" title="Key additions/deletions are observed">+/-</span>
       </div>
     </div>
-    <t t-if="props.object.toggled" t-key="contextMenuId">
-      <t t-foreach="props.object.children" t-as="child" t-key="child_index">
+    <t t-if="this.props.object.toggled" t-key="this.contextMenuId">
+      <t t-foreach="this.props.object.children" t-as="child" t-key="child_index">
         <ObjectTreeElement object="child" class="this.classFor(child)"/>
       </t>
     </t>

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/highlight_text/highlight_text.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/highlight_text/highlight_text.js
@@ -1,16 +1,16 @@
-/** @odoo-module **/
-
-const { Component, onWillRender } = owl;
+const { Component, props, types: t } = owl;
 
 export class HighlightText extends Component {
-  setup() {
-    onWillRender(() => {
-      const splitText = this.splitFuzzySearch(this.props.originalText, this.props.searchValue);
-      this.splitText =
-        this.props.searchValue.length && splitText.length > 1
-          ? splitText
-          : [this.props.originalText];
-    });
+  static template = "utils.HighlightText";
+  static highlightClass = "highlight-search";
+
+  props = props({ originalText: t.string, searchValue: t.string });
+
+  splitText() {
+    const splitText = this.splitFuzzySearch(this.props.originalText, this.props.searchValue);
+    return this.props.searchValue.length && splitText.length > 1
+      ? splitText
+      : [this.props.originalText];
   }
 
   // Logic to split the text to highlight it according to a fuzzy search pattern
@@ -42,9 +42,3 @@ export class HighlightText extends Component {
     return splits;
   }
 }
-HighlightText.template = "utils.HighlightText";
-HighlightText.props = {
-  originalText: String,
-  searchValue: String,
-};
-HighlightText.highlightClass = "highlight-search";

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/highlight_text/highlight_text.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/highlight_text/highlight_text.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="utils.HighlightText" owl="1">
-        <t t-foreach="splitText" t-as="name" t-key="name_index">
-            <b t-if="name_index % 2" t-esc="name" t-att-class="constructor.highlightClass"/>
-            <t t-else="" t-esc="name"/>
+    <t t-name="utils.HighlightText">
+        <t t-foreach="this.splitText()" t-as="name" t-key="name_index">
+            <b t-if="name_index % 2" t-out="name" t-att-class="this.constructor.highlightClass"/>
+            <t t-else="" t-out="name"/>
         </t>
     </t>
 </templates>

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
@@ -1,45 +1,51 @@
-/** @odoo-module **/
-
 import { isElementInCenterViewport, minimizeKey, browserInstance } from "../../../../utils";
-import { useStore } from "../../../store/store";
+import { StorePlugin } from "../../../store/store";
+import { ComponentsPlugin } from "../../../store/components_plugin";
 import { HighlightText } from "./highlight_text/highlight_text";
 
-const { Component, useRef, useState, useEffect, onMounted } = owl;
+const { Component, signal, proxy, useEffect, onMounted, plugin, props, types: t } = owl;
 
 export class TreeElement extends Component {
   static template = "devtools.TreeElement";
-
   static components = { TreeElement, HighlightText };
 
+  props = props({ component: t.object() });
+
   setup() {
-    this.state = useState({
+    this.state = proxy({
       searched: false,
     });
-    this.store = useStore();
-    this.element = useRef("element");
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
+    this.element = signal(null);
     this.stringifiedPath = JSON.stringify(this.props.component.path);
     // Scroll to the selected element when it changes
     onMounted(() => {
       if (this.props.component.selected) {
-        this.element.el.scrollIntoView({ block: "center", behavior: "auto" });
+        this.element()?.scrollIntoView({ block: "center", behavior: "auto" });
       }
     });
-    useEffect(
-      (selected) => {
-        if (selected) {
-          if (!isElementInCenterViewport(this.element.el)) {
-            this.element.el.scrollIntoView({ block: "center", behavior: "smooth" });
-          }
+    useEffect(() => {
+      const selected = this.props.component.selected;
+      const el = this.element();
+      if (selected && el) {
+        if (this.components.activeSelector() || !isElementInCenterViewport(el)) {
+          el.scrollIntoView({ block: "center", behavior: "smooth" });
         }
-        this.store.selectedElement = this.element.el;
-      },
-      () => [this.props.component.selected]
-    );
+      }
+      if (el) {
+        this.components.selectedElement.set(el);
+      }
+    });
     // Effect to apply a short highlight effect to the component when it is rendered
-    useEffect(
-      () => {
-        if (this.store.renderPaths.has(this.stringifiedPath)) {
-          const treeElement = this.element.el;
+    useEffect(() => {
+      if (this.components.renderPaths.has(this.stringifiedPath)) {
+        if (this.blockHighlight) {
+          return;
+        }
+        const treeElement = this.element();
+        if (treeElement) {
+          this.blockHighlight = true;
           treeElement.classList.add("render-highlight");
           setTimeout(() => {
             treeElement.classList.add("highlight-fade");
@@ -50,20 +56,17 @@ export class TreeElement extends Component {
             }, 500);
           }, 50);
         }
-      },
-      () => [this.store.renderPaths.size]
-    );
+      }
+    });
     // Used to know when the component is in the search bar results
-    useEffect(
-      (searchResults) => {
-        if (searchResults.includes(this.props.component.path)) {
-          this.state.searched = true;
-        } else {
-          this.state.searched = false;
-        }
-      },
-      () => [this.store.componentSearch.searchResults]
-    );
+    useEffect(() => {
+      const searchResults = this.components.searchResults();
+      if (searchResults.includes(this.props.component.path)) {
+        this.state.searched = true;
+      } else {
+        this.state.searched = false;
+      }
+    });
   }
 
   get componentPadding() {
@@ -79,12 +82,12 @@ export class TreeElement extends Component {
       {
         title: "Expand children",
         show: true,
-        action: () => this.store.toggleComponentAndChildren(this.props.component, true),
+        action: () => this.components.toggleComponentAndChildren(this.props.component, true),
       },
       {
         title: "Fold all children",
         show: true,
-        action: () => this.store.toggleComponentAndChildren(this.props.component, false),
+        action: () => this.components.toggleComponentAndChildren(this.props.component, false),
       },
       {
         title: "Fold direct children",
@@ -94,13 +97,13 @@ export class TreeElement extends Component {
       {
         title: "Inspect source code",
         show: true,
-        action: () => this.store.inspectComponent("source", this.props.component.path),
+        action: () => this.components.inspectComponent("source", this.props.component.path),
       },
       {
         title: "Store as global variable",
         show: this.props.component.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.component.path,
             { type: "item", value: "component" },
           ]),
@@ -108,18 +111,18 @@ export class TreeElement extends Component {
       {
         title: "Inspect in Elements tab",
         show: this.props.component.path.length !== 1,
-        action: () => this.store.inspectComponent("DOM", this.props.component.path),
+        action: () => this.components.inspectComponent("DOM", this.props.component.path),
       },
       {
         title: "Force rerender",
         show: this.props.component.path.length !== 1,
-        action: () => this.store.refreshComponent(this.props.component.path),
+        action: () => this.components.refreshComponent(this.props.component.path),
       },
       {
         title: "Store observed states as global variable",
         show: this.props.component.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.component.path,
             { type: "item", value: "subscriptions" },
           ]),
@@ -127,26 +130,27 @@ export class TreeElement extends Component {
       {
         title: "Inspect compiled template",
         show: this.props.component.path.length !== 1,
-        action: () => this.store.inspectComponent("compiled template", this.props.component.path),
+        action: () =>
+          this.components.inspectComponent("compiled template", this.props.component.path),
       },
       {
         title: "Log raw template",
         show: this.props.component.path.length !== 1,
-        action: () => this.store.inspectComponent("raw template", this.props.component.path),
+        action: () => this.components.inspectComponent("raw template", this.props.component.path),
       },
       {
         title: "Store as global variable",
         show: this.props.component.path.length === 1,
-        action: () => this.store.logObjectInConsole([...this.props.component.path]),
+        action: () => this.components.logObjectInConsole([...this.props.component.path]),
       },
       {
         title: "Don't fold component by default",
-        show: this.store.settings.componentsToggleBlacklist.has(this.props.component.name),
+        show: this.store.componentsToggleBlacklist().has(this.props.component.name),
         action: () => this.toggleComponentToBlacklist(),
       },
       {
         title: "Fold component by default",
-        show: !this.store.settings.componentsToggleBlacklist.has(this.props.component.name),
+        show: !this.store.componentsToggleBlacklist().has(this.props.component.name),
         action: () => this.toggleComponentToBlacklist(),
       },
     ];
@@ -163,36 +167,32 @@ export class TreeElement extends Component {
 
   // Used to select the component node
   toggleComponent() {
-    if (this.store.settings.toggleOnSelected) {
+    if (this.store.toggleOnSelected()) {
       this.toggleDisplay();
     }
     if (!this.props.component.selected) {
-      this.store.selectComponent(this.props.component.path);
+      this.components.selectComponent(this.props.component.path);
     }
   }
 
   // Adds the component name to the components toggle blacklist if not already present
   // Else, remove it from the blacklist
   toggleComponentToBlacklist() {
-    if (this.store.settings.componentsToggleBlacklist.has(this.props.component.name)) {
+    if (this.store.componentsToggleBlacklist().has(this.props.component.name)) {
       if (!this.props.component.toggled) {
         this.props.component.toggled = !this.props.component.toggled;
       }
-      this.store.settings.componentsToggleBlacklist.delete(this.props.component.name);
+      this.store.componentsToggleBlacklist().delete(this.props.component.name);
       browserInstance.storage.local.set({
-        owlDevtoolsComponentsToggleBlacklist: Array.from(
-          this.store.settings.componentsToggleBlacklist
-        ),
+        owlDevtoolsComponentsToggleBlacklist: Array.from(this.store.componentsToggleBlacklist()),
       });
     } else {
       if (this.props.component.toggled) {
         this.props.component.toggled = !this.props.component.toggled;
       }
-      this.store.settings.componentsToggleBlacklist.add(this.props.component.name);
+      this.store.componentsToggleBlacklist().add(this.props.component.name);
       browserInstance.storage.local.set({
-        owlDevtoolsComponentsToggleBlacklist: Array.from(
-          this.store.settings.componentsToggleBlacklist
-        ),
+        owlDevtoolsComponentsToggleBlacklist: Array.from(this.store.componentsToggleBlacklist()),
       });
     }
   }

--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.TreeElement" owl="1">
-    <div t-ref="element"
-      t-att-class="{'component-selected': props.component.selected,'component-highlighted': props.component.highlighted}"
+  <t t-name="devtools.TreeElement">
+    <div t-ref="this.element"
+      t-att-class="{'component-selected': this.props.component.selected,'component-highlighted': this.props.component.highlighted}"
       class="tree-component m-0 p-0 w-100 text-nowrap user-select-none"
-      t-on-contextmenu.prevent="openMenu"
-      t-on-mouseover.stop="() => this.store.highlightComponent(props.component.path)"
-      t-on-click.stop="toggleComponent"
+      t-on-contextmenu.prevent="this.openMenu"
+      t-on-mouseover.stop="() => this.components.highlightComponent(this.props.component.path)"
+      t-on-click.stop="this.toggleComponent"
     >
-      <div class="component-wrapper" t-attf-style="padding-left: {{componentPadding}}rem">
+      <div class="component-wrapper" t-attf-style="padding-left: {{this.componentPadding}}rem">
         <i class="fa px-1 pointer-icon caret"
-          t-att-class="{'fa-caret-right': !props.component.toggled, 'fa-caret-down': props.component.toggled}"
-          t-on-click.stop="toggleDisplay"
-          t-attf-style="{{props.component.children.length > 0 ? '' : 'visibility: hidden;'}}"
+          t-att-class="{'fa-caret-right': !this.props.component.toggled, 'fa-caret-down': this.props.component.toggled}"
+          t-on-click.stop="this.toggleDisplay"
+          t-attf-style="{{this.props.component.children.length > 0 ? '' : 'visibility: hidden;'}}"
         />
-        <span t-if="props.component.depth">&lt;</span>
+        <span t-if="this.props.component.depth">&lt;</span>
         <span style="color: var(--component-color);">
-          <HighlightText originalText="props.component.name" searchValue="state.searched ? store.componentSearch.search : ''"/>
-          <t t-if="minimizedKey.length > 0">
-            <span t-if="minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
-              <t t-esc="minimizedKey"/>
+          <HighlightText originalText="this.props.component.name" searchValue="this.state.searched ? this.components.searchText() : ''"/>
+          <t t-if="this.minimizedKey.length > 0">
+            <span t-if="this.minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
+              <t t-out="this.minimizedKey"/>
             </span>
           </t>
         </span>
-        <span t-if="props.component.depth">&gt;</span>
-        <span class="version" t-else="">owl=<t t-esc="props.component.version"/></span>
+        <span t-if="this.props.component.depth">&gt;</span>
+        <span class="version" t-else="">owl=<t t-out="this.props.component.version"/></span>
       </div>
     </div>
-    <t t-if="props.component.toggled">
-      <t t-foreach="props.component.children" t-as="child" t-key="child.key">
-        <TreeElement component="child_value"/>
+    <t t-if="this.props.component.toggled">
+      <t t-foreach="this.props.component.children" t-as="child" t-key="child.key">
+        <TreeElement component="child"/>
       </t>
     </t>
   </t>

--- a/tools/devtools/src/devtools_app/devtools_window/devtools_window.js
+++ b/tools/devtools/src/devtools_app/devtools_window/devtools_window.js
@@ -1,16 +1,17 @@
-const { Component } = owl;
+const { Component, plugin } = owl;
 import { ContextMenu } from "../context_menu/context_menu";
-import { useStore } from "../store/store";
+import { StorePlugin } from "../store/store";
+import { ComponentsPlugin } from "../store/components_plugin";
 import { ComponentsTab } from "./components_tab/components_tab";
 import { ProfilerTab } from "./profiler_tab/profiler_tab";
 import { Tab } from "./tab/tab";
 
 export class DevtoolsWindow extends Component {
-  static props = [];
   static template = "devtools.DevtoolsWindow";
   static components = { ComponentsTab, Tab, ProfilerTab, ContextMenu };
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
   }
 
   selectFrame(ev) {

--- a/tools/devtools/src/devtools_app/devtools_window/devtools_window.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/devtools_window.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.DevtoolsWindow" owl="1">
-    <div id="container" class="d-flex w-100 h-100 flex-column position-absolute overflow-hidden" t-on-mouseover.stop="() => this.store.removeHighlights()" t-on-mouseout.stop="() => this.store.removeHighlights()">
-      <t t-if="!store.extensionContextStatus">
+  <t t-name="devtools.DevtoolsWindow">
+    <div id="container" class="d-flex w-100 h-100 flex-column position-absolute overflow-hidden" t-on-mouseover.stop="() => this.components.removeHighlights()" t-on-mouseout.stop="() => this.components.removeHighlights()">
+      <t t-if="!this.store.extensionContextStatus()">
         <div class="status-message d-flex justify-content-center align-items-center">
           Extension context is invalid. Please close the devtools and reload the page.
         </div>
       </t>
-      <t t-elif="store.owlStatus">
+      <t t-elif="this.store.owlStatus()">
         <div class="panel-top d-flex align-items-center custom-navbar">
           <Tab tabName="'ComponentsTab'"/>
           <Tab tabName="'ProfilerTab'"/>
-          <select t-if="store.frameUrls.length > 1" class="form-select form-select-sm custom-select navbar-select border-0" t-on-change="selectFrame">
-            <t t-foreach="store.frameUrls" t-as="frame" t-key="frame_index">
-              <option t-att-value="frame"><t t-esc="frame"/></option>
+          <select t-if="this.store.frameUrls().length > 1" class="form-select form-select-sm custom-select navbar-select border-0" t-on-change="this.selectFrame">
+            <t t-foreach="this.store.frameUrls()" t-as="frame" t-key="frame_index">
+              <option t-att-value="frame"><t t-out="frame"/></option>
             </t>
           </select>
           <i class="ms-auto p-1 me-1 lg-icon fa fa-question-circle navbar-icon" title="Open devtools doc" t-on-click.stop="() => this.store.openDocumentation()"></i>
-          <i class="p-1 me-1 lg-icon fa navbar-icon" title="Toggle dark mode" t-att-class="{ 'fa-sun-o': store.settings.darkMode, 'fa-moon-o' : !store.settings.darkMode}" t-on-click.stop="() => this.store.toggleDarkMode()"></i>
+          <i class="p-1 me-1 lg-icon fa navbar-icon" title="Toggle dark mode" t-att-class="{ 'fa-sun-o': this.store.darkMode(), 'fa-moon-o' : !this.store.darkMode()}" t-on-click.stop="() => this.store.toggleDarkMode()"></i>
           <i class="p-1 me-1 lg-icon fa fa-repeat navbar-icon" title="Refresh extension" t-on-click.stop="() => this.store.refreshExtension()"></i>
         </div>
-        <ComponentsTab t-if="store.page === 'ComponentsTab'"/>
-        <ProfilerTab t-if="store.page === 'ProfilerTab'"/>
+        <ComponentsTab t-if="this.store.page() === 'ComponentsTab'"/>
+        <ProfilerTab t-if="this.store.page() === 'ProfilerTab'"/>
       </t>
       <t t-else="">
         <div class="status-message d-flex justify-content-center align-items-center">
           Owl is not loaded on this page.
         </div>
       </t>
-      <ContextMenu t-if="store.contextMenu" items="store.contextMenu.items"/>
+      <ContextMenu t-if="this.store.contextMenu()" items="this.store.contextMenu().items"/>
     </div>
   </t>
 </templates>

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event/event.js
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event/event.js
@@ -1,13 +1,17 @@
 import { minimizeKey } from "../../../../utils";
-import { useStore } from "../../../store/store";
+import { StorePlugin } from "../../../store/store";
+import { ComponentsPlugin } from "../../../store/components_plugin";
 
-const { Component } = owl;
+const { Component, plugin, props, types: t } = owl;
 
 export class Event extends Component {
   static template = "devtools.Event";
 
+  props = props({ event: t.object() });
+
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
   }
 
   // Formatting for displaying the key of the component
@@ -48,13 +52,13 @@ export class Event extends Component {
       {
         title: "Inspect source code",
         show: true,
-        action: () => this.store.inspectComponent("source", this.props.event.path),
+        action: () => this.components.inspectComponent("source", this.props.event.path),
       },
       {
         title: "Store as global variable",
         show: this.props.event.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.event.path,
             { type: "item", value: "component" },
           ]),
@@ -62,18 +66,18 @@ export class Event extends Component {
       {
         title: "Inspect in Elements tab",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("DOM", this.props.event.path),
+        action: () => this.components.inspectComponent("DOM", this.props.event.path),
       },
       {
         title: "Force rerender",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.refreshComponent(this.props.event.path),
+        action: () => this.components.refreshComponent(this.props.event.path),
       },
       {
         title: "Store observed states as global variable",
         show: this.props.event.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.event.path,
             { type: "item", value: "subscriptions" },
           ]),
@@ -81,17 +85,17 @@ export class Event extends Component {
       {
         title: "Inspect compiled template",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("compiled template", this.props.event.path),
+        action: () => this.components.inspectComponent("compiled template", this.props.event.path),
       },
       {
         title: "Log raw template",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("raw template", this.props.event.path),
+        action: () => this.components.inspectComponent("raw template", this.props.event.path),
       },
       {
         title: "Store as global variable",
         show: this.props.event.path.length === 1,
-        action: () => this.store.logObjectInConsole([...this.props.event.path]),
+        action: () => this.components.logObjectInConsole([...this.props.event.path]),
       },
     ];
   }

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event/event.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event/event.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.Event" owl="1">
-    <div class="event-container" t-att-class="{ 'event-last': props.event.isLast }">
-      <div class="my-0 p-0 object-line" t-on-click.stop="toggleDisplay">
+  <t t-name="devtools.Event">
+    <div class="event-container" t-att-class="{ 'event-last': this.props.event.isLast }">
+      <div class="my-0 p-0 object-line" t-on-click.stop="this.toggleDisplay">
         <div class="ps-2 text-nowrap">
           <i class="fa px-1 pointer-icon caret"
-            t-att-class="{'fa-caret-right': !props.event.toggled, 'fa-caret-down': props.event.toggled}"
-            t-attf-style="visibility: {{props.event.origin ? '' : 'hidden'}};"
+            t-att-class="{'fa-caret-right': !this.props.event.toggled, 'fa-caret-down': this.props.event.toggled}"
+            t-attf-style="visibility: {{this.props.event.origin ? '' : 'hidden'}};"
           />
-          <t t-esc="props.event.type"/>:
+          <t t-out="this.props.event.type"/>:
           &lt;<span style="cursor:pointer; color: var(--component-color);"
-                t-on-click.stop="() => this.store.selectComponent(props.event.path)"
-                t-on-mouseover.stop="() => this.store.highlightComponent(props.event.path)"
-                t-on-contextmenu="openMenu"
-                t-esc="props.event.component"
+                t-on-click.stop="() => this.components.selectComponent(this.props.event.path)"
+                t-on-mouseover.stop="() => this.components.highlightComponent(this.props.event.path)"
+                t-on-contextmenu="this.openMenu"
+                t-out="this.props.event.component"
               />
-          <t t-if="minimizedKey.length > 0">
-            <span t-if="minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
-              <t t-esc="minimizedKey"/>
+          <t t-if="this.minimizedKey.length > 0">
+            <span t-if="this.minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
+              <t t-out="this.minimizedKey"/>
             </span>
           </t>&gt;
           <span>
-            (<t t-esc="renderTime"/>ms)
+            (<t t-out="this.renderTime"/>ms)
           </span>
         </div>
       </div>
-      <t t-if="props.event.toggled">
+      <t t-if="this.props.event.toggled">
         <div class="my-0 pt-1 object-line">
           <i class="fa fa-caret-right mx-1 pe-2" style="visibility: hidden;"></i>
           <span>
             origin:
             &lt;<span style="cursor:pointer; color: var(--component-color);"
-                  t-on-click.stop="() => this.store.selectComponent(props.event.origin.path)"
-                  t-on-mouseover.stop="() => this.store.highlightComponent(props.event.origin.path)"
-                  t-esc="props.event.origin.component"
+                  t-on-click.stop="() => this.components.selectComponent(this.props.event.origin.path)"
+                  t-on-mouseover.stop="() => this.components.highlightComponent(this.props.event.origin.path)"
+                  t-out="this.props.event.origin.component"
                 />
-            <t t-if="originMinimizedKey.length > 0">
+            <t t-if="this.originMinimizedKey.length > 0">
               <span style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
-                <t t-esc="originMinimizedKey"/>
+                <t t-out="this.originMinimizedKey"/>
               </span>
             </t>&gt;
           </span>

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_node/event_node.js
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_node/event_node.js
@@ -1,15 +1,20 @@
 import { minimizeKey } from "../../../../utils";
-import { useStore } from "../../../store/store";
+import { StorePlugin } from "../../../store/store";
+import { ComponentsPlugin } from "../../../store/components_plugin";
+import { ProfilerPlugin } from "../../../store/profiler_plugin";
 
-const { Component } = owl;
+const { Component, plugin, props, types: t } = owl;
 
 export class EventNode extends Component {
   static template = "devtools.EventNode";
-
   static components = { EventNode };
 
+  props = props({ event: t.object() });
+
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
+    this.components = plugin(ComponentsPlugin);
+    this.profiler = plugin(ProfilerPlugin);
   }
 
   get eventPadding() {
@@ -21,12 +26,12 @@ export class EventNode extends Component {
       {
         title: "Expand children",
         show: true,
-        action: () => this.store.toggleEventAndChildren(this.props.event, true),
+        action: () => this.profiler.toggleEventAndChildren(this.props.event, true),
       },
       {
         title: "Fold all children",
         show: true,
-        action: () => this.store.toggleEventAndChildren(this.props.event, false),
+        action: () => this.profiler.toggleEventAndChildren(this.props.event, false),
       },
       {
         title: "Fold direct children",
@@ -41,13 +46,13 @@ export class EventNode extends Component {
       {
         title: "Inspect source code",
         show: true,
-        action: () => this.store.inspectComponent("source", this.props.event.path),
+        action: () => this.components.inspectComponent("source", this.props.event.path),
       },
       {
         title: "Store as global variable",
         show: this.props.event.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.event.path,
             { type: "item", value: "component" },
           ]),
@@ -55,18 +60,18 @@ export class EventNode extends Component {
       {
         title: "Inspect in Elements tab",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("DOM", this.props.event.path),
+        action: () => this.components.inspectComponent("DOM", this.props.event.path),
       },
       {
         title: "Force rerender",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.refreshComponent(this.props.event.path),
+        action: () => this.components.refreshComponent(this.props.event.path),
       },
       {
         title: "Store observed states as global variable",
         show: this.props.event.path.length !== 1,
         action: () =>
-          this.store.logObjectInConsole([
+          this.components.logObjectInConsole([
             ...this.props.event.path,
             { type: "item", value: "subscriptions" },
           ]),
@@ -74,17 +79,17 @@ export class EventNode extends Component {
       {
         title: "Inspect compiled template",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("compiled template", this.props.event.path),
+        action: () => this.components.inspectComponent("compiled template", this.props.event.path),
       },
       {
         title: "Log raw template",
         show: this.props.event.path.length !== 1,
-        action: () => this.store.inspectComponent("raw template", this.props.event.path),
+        action: () => this.components.inspectComponent("raw template", this.props.event.path),
       },
       {
         title: "Store as global variable",
         show: this.props.event.path.length === 1,
-        action: () => this.store.logObjectInConsole([...this.props.event.path]),
+        action: () => this.components.logObjectInConsole([...this.props.event.path]),
       },
     ];
   }

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_node/event_node.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_node/event_node.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.EventNode" owl="1">
+  <t t-name="devtools.EventNode">
     <div class="my-0 p-0 object-line"
-      t-on-click.stop="toggleDisplay"
-      t-on-contextmenu="openNodeMenu"
+      t-on-click.stop="this.toggleDisplay"
+      t-on-contextmenu="this.openNodeMenu"
     >
-      <div class="text-nowrap" t-attf-style="padding-left: {{eventPadding}}rem">
+      <div class="text-nowrap" t-attf-style="padding-left: {{this.eventPadding}}rem">
         <i class="fa px-1 pointer-icon caret"
-          t-att-class="{'fa-caret-right': !props.event.toggled, 'fa-caret-down': props.event.toggled}"
-          t-attf-style="visibility: {{props.event.children.length > 0 ? '' : 'hidden'}};"
+          t-att-class="{'fa-caret-right': !this.props.event.toggled, 'fa-caret-down': this.props.event.toggled}"
+          t-attf-style="visibility: {{this.props.event.children.length > 0 ? '' : 'hidden'}};"
         />
         <span>
-          <t t-esc="props.event.type"/>:
+          <t t-out="this.props.event.type"/>:
           &lt;<span style="cursor:pointer; color: var(--component-color);"
-                t-on-click.stop="() => this.store.selectComponent(props.event.path)"
-                t-on-mouseover.stop="() => this.store.highlightComponent(props.event.path)"
-                t-on-contextmenu.stop="openComponentMenu"
-                t-esc="props.event.component"/>
-          <t t-if="minimizedKey.length > 0">
-            <span t-if="minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
-              <t t-esc="minimizedKey"/>
+                t-on-click.stop="() => this.components.selectComponent(this.props.event.path)"
+                t-on-mouseover.stop="() => this.components.highlightComponent(this.props.event.path)"
+                t-on-contextmenu.stop="this.openComponentMenu"
+                t-out="this.props.event.component"/>
+          <t t-if="this.minimizedKey.length > 0">
+            <span t-if="this.minimizedKey.length > 0" style="color: var(--key-name);"> key</span>=<span style="color: var(--key-content);">
+              <t t-out="this.minimizedKey"/>
             </span>
           </t>&gt;
           <span>
-            (<t t-esc="renderTime"/>ms)
+            (<t t-out="this.renderTime"/>ms)
           </span>
         </span>
       </div>
     </div>
-    <t t-if="props.event.toggled">
-      <t t-foreach="props.event.children" t-as="child" t-key="child.id">
+    <t t-if="this.props.event.toggled">
+      <t t-foreach="this.props.event.children" t-as="child" t-key="child.id">
         <EventNode event="child"/>
       </t>
     </t>

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_search_bar/event_search_bar.js
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_search_bar/event_search_bar.js
@@ -1,12 +1,12 @@
-import { useStore } from "../../../store/store";
+import { StorePlugin } from "../../../store/store";
 
-const { Component } = owl;
+const { Component, plugin } = owl;
 
 export class EventSearchBar extends Component {
   static template = "devtools.EventSearchBar";
 
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
   }
 
   // On keyup

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_search_bar/event_search_bar.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/event_search_bar/event_search_bar.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.EventSearchBar" owl="1">
+  <t t-name="devtools.EventSearchBar">
     <div class="search-bar-wrapper">
       <i class="fa fa-search search-icon" aria-hidden="true"></i>
-      <input type="text" class="search-input" placeholder="Search" t-on-keyup.stop="updateSearch" t-att-value="store.eventSearch.search"/>
-      <t t-if="store.eventSearch.search.length > 0">
-        <i class="fa fa-times lg-icon utility-icon pe-2" t-on-click.stop="clearSearch"></i>
+      <input type="text" class="search-input" placeholder="Search" t-on-keyup.stop="this.updateSearch" t-att-value="this.store.eventSearch.search"/>
+      <t t-if="this.store.eventSearch.search.length > 0">
+        <i class="fa fa-times lg-icon utility-icon pe-2" t-on-click.stop="this.clearSearch"></i>
       </t>
     </div>
   </t>

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.js
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.js
@@ -1,5 +1,5 @@
-const { Component } = owl;
-import { useStore } from "../../store/store";
+const { Component, plugin } = owl;
+import { ProfilerPlugin } from "../../store/profiler_plugin";
 import { Event } from "./event/event";
 import { EventNode } from "./event_node/event_node";
 import { EventSearchBar } from "./event_search_bar/event_search_bar";
@@ -10,20 +10,20 @@ export class ProfilerTab extends Component {
   static components = { Event, EventNode, EventSearchBar };
 
   setup() {
-    this.store = useStore();
+    this.profiler = plugin(ProfilerPlugin);
   }
 
   showHelp() {
-    return this.store.events.length < 1 && !this.store.activeRecorder;
+    return this.profiler.events().length < 1 && !this.profiler.activeRecorder();
   }
 
   selectDisplayMode(ev) {
     const val = ev.target.value;
     if (val === "Tree") {
-      this.store.buildEventsTree();
-      this.store.eventsTreeView = true;
+      this.profiler.buildEventsTree();
+      this.profiler.eventsTreeView.set(true);
     } else {
-      this.store.eventsTreeView = false;
+      this.profiler.eventsTreeView.set(false);
     }
   }
 }

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.ProfilerTab" owl="1">
+  <t t-name="devtools.ProfilerTab">
     <div class="position-relative overflow-hidden d-flex flex-column h-100">
       <div class="panel-top d-flex align-items-center">
-        <i title="Start/Stop Recording" class="fa fa-circle profiler-icon p-2" t-attf-style="color: {{store.activeRecorder ? 'var(--active-recorder)' : 'var(--text-color)'}};" t-on-click.stop="() => this.store.toggleRecording()" aria-hidden="true"></i>
-        <i title="Clear events" class="fa fa-ban profiler-icon p-2" t-on-click.stop="() => this.store.clearEventsConsole()" aria-hidden="true"></i>
+        <i title="Start/Stop Recording" class="fa fa-circle profiler-icon p-2" t-attf-style="color: {{this.profiler.activeRecorder() ? 'var(--active-recorder)' : 'var(--text-color)'}};" t-on-click.stop="() => this.profiler.toggleRecording()" aria-hidden="true"></i>
+        <i title="Clear events" class="fa fa-ban profiler-icon p-2" t-on-click.stop="() => this.profiler.clearEventsConsole()" aria-hidden="true"></i>
         <div class="icons-separator"/>
-        <select class="form-select form-select-sm custom-select pointer-icon border-0" t-on-change="selectDisplayMode">
-          <option t-att-selected="store.eventsTreeView" value="Tree">Tree view</option>
-          <option t-att-selected="!store.eventsTreeView" value="List">Events log</option>
+        <select class="form-select form-select-sm custom-select pointer-icon border-0" t-on-change="this.selectDisplayMode">
+          <option t-att-selected="this.profiler.eventsTreeView()" value="Tree">Tree view</option>
+          <option t-att-selected="!this.profiler.eventsTreeView()" value="List">Events log</option>
         </select>
-        <i title="Collapse All" class="fa fa-list p-2 profiler-icon" t-on-click="() => this.store.collapseAll()" t-attf-style="{{store.eventsTreeView ? '' : 'display: none;'}}"></i>
+        <i title="Collapse All" class="fa fa-list p-2 profiler-icon" t-on-click="() => this.profiler.collapseAll()" t-attf-style="{{this.profiler.eventsTreeView() ? '' : 'display: none;'}}"></i>
         <div class="icons-separator"/>
         <label class="p-1 mx-1 form-check-label pointer-icon" title="Trace renderings in console">
-          <input type="checkbox" class="form-check-input me-1 pointer-icon" t-att-checked="store.traceRenderings" t-on-input="() => this.store.toggleTracing()"/> Trace Renderings
+          <input type="checkbox" class="form-check-input me-1 pointer-icon" t-att-checked="this.profiler.traceRenderings()" t-on-input="() => this.profiler.toggleTracing()"/> Trace Renderings
         </label>
-        <label class="p-1 mx-1 form-check-label pointer-icon" title="Trace subscriptions in console (warning: it is VERY verbose)">
-          <input type="checkbox" class="form-check-input me-1 pointer-icon" t-att-checked="store.traceSubscriptions" t-on-input="() => this.store.toggleSubscriptionTracing()"/> Trace Subscriptions
-        </label>
+        <t t-if="this.profiler.subscriptionTracingSupported()">
+          <label class="p-1 mx-1 form-check-label pointer-icon" title="Trace subscriptions in console (warning: it is VERY verbose)">
+            <input type="checkbox" class="form-check-input me-1 pointer-icon" t-att-checked="this.profiler.traceSubscriptions()" t-on-input="() => this.profiler.toggleSubscriptionTracing()"/> Trace Subscriptions
+          </label>
+        </t>
         <!-- <EventSearchBar/> -->
       </div>
       <div class="events-container h-100 font-monospace">
-        <t t-if="showHelp()">
+        <t t-if="this.showHelp()">
           <div class="status-message d-flex justify-content-center align-items-center">
             <div>
               Click on the <i class="fa fa-circle" style="font-size: 0.8em;"></i> button to start recording events.
@@ -29,13 +31,13 @@
           </div>
         </t>
         <t t-else="">
-          <t t-if="store.eventsTreeView">
-            <t t-foreach="store.eventsTree" t-as="event" t-key="event.id">
+          <t t-if="this.profiler.eventsTreeView()">
+            <t t-foreach="this.profiler.eventsTree()" t-as="event" t-key="event.id">
               <EventNode event="event"/>
             </t>
           </t>
           <t t-else="">
-            <t t-foreach="store.events" t-as="event" t-key="event_index">
+            <t t-foreach="this.profiler.events()" t-as="event" t-key="event_index">
               <Event event="event"/>
             </t>
           </t>

--- a/tools/devtools/src/devtools_app/devtools_window/tab/tab.js
+++ b/tools/devtools/src/devtools_app/devtools_window/tab/tab.js
@@ -1,20 +1,18 @@
-/** @odoo-module **/
+import { StorePlugin } from "../../store/store";
 
-import { useStore } from "../../store/store";
-
-const { Component } = owl;
+const { Component, plugin, props, types: t } = owl;
 
 export class Tab extends Component {
-  static props = ["tabName"];
-
   static template = "devtools.Tab";
 
+  props = props({ tabName: t.string });
+
   setup() {
-    this.store = useStore();
+    this.store = plugin(StorePlugin);
   }
 
   get active() {
-    return this.props.tabName === this.store.page;
+    return this.props.tabName === this.store.page();
   }
 
   get name() {

--- a/tools/devtools/src/devtools_app/devtools_window/tab/tab.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/tab/tab.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-  <t t-name="devtools.Tab" owl="1">
-    <div t-on-click="selectTab" class="navbar-btn d-block" t-att-class="active
+  <t t-name="devtools.Tab">
+    <div t-on-click="this.selectTab" class="navbar-btn d-block" t-att-class="this.active
                 ? 'btn-selected'
                 : ''">
-      <t t-esc="name" />
+      <t t-out="this.name" />
     </div>
   </t>
 </templates>

--- a/tools/devtools/src/devtools_app/store/components_plugin.js
+++ b/tools/devtools/src/devtools_app/store/components_plugin.js
@@ -1,0 +1,542 @@
+const { Plugin, signal, proxy, toRaw, plugin } = owl;
+import { fuzzySearch, IS_FIREFOX, browserInstance } from "../../utils";
+import { StorePlugin, evalFunctionInWindow, evalInWindow } from "./store";
+
+// Plugin handling all components-tab state and logic: tree, search, navigation,
+// selector/highlight, details panel, inspect/debug, and observed variables.
+export class ComponentsPlugin extends Plugin {
+  // --- Component tree state ---
+  apps = signal(proxy([]));
+  activeComponent = signal(
+    proxy({
+      path: ["0"],
+      name: "App",
+      subscriptions: { toggled: true, children: [] },
+      props: { toggled: true, children: [] },
+      env: { toggled: false, children: [] },
+      instance: { toggled: true, children: [] },
+      hooks: { toggled: true, children: [] },
+      version: "1.0",
+    })
+  );
+
+  // --- Search state ---
+  searchText = signal("");
+  searchResults = signal([]);
+  searchIndex = signal(0);
+
+  // --- Selector / highlight state ---
+  activeSelector = signal(false);
+  selectedElement = signal(null);
+  renderPaths = proxy(new Set());
+
+  // --- Inspect state ---
+  observedVariables = signal(proxy([]));
+
+  setup() {
+    this._store = plugin(StorePlugin);
+  }
+
+  // -------------------------------------------------------------------------
+  // Components tree
+  // -------------------------------------------------------------------------
+
+  async loadComponentsTree(fromOld) {
+    if (IS_FIREFOX) {
+      await evalInWindow("window.$0 = $0;", this._store.activeFrame());
+    }
+    const [apps, details] = await evalFunctionInWindow(
+      "getComponentsTree",
+      fromOld && this.activeComponent()
+        ? [this.activeComponent().path, this.apps(), this.activeComponent()]
+        : [],
+      this._store.activeFrame()
+    );
+    this.apps.set(proxy(apps || []));
+    if (!fromOld && this._store.expandByDefault()) {
+      this.apps().forEach((tree) => expandNodes(tree, this._store.componentsToggleBlacklist()));
+    }
+    if (details.env) {
+      keepEnvLit(details);
+    }
+    this.activeComponent.set(proxy(details));
+    if (this.searchText().length) {
+      this.updateSearch(this.searchText());
+    }
+  }
+
+  // Deselects all components, walks the tree to the given path, marks it selected,
+  // and returns the resolved component node.
+  _applyTreeSelection(path) {
+    this.apps().forEach((app) => {
+      app.selected = false;
+      app.highlighted = false;
+      app.children.forEach((child) => deselectComponent(child));
+    });
+    // path[0] = app index, path[1] = root index, path[2..] = child keys
+    let component =
+      path.length === 1
+        ? this.apps()[path[0]]
+        : this.apps()[path[0]].children[parseInt(path[1], 10)];
+    for (let i = 2; i < path.length; i++) {
+      component.toggled = true;
+      const result = component.children.find((child) => child.key === path[i]);
+      if (result) {
+        component = result;
+      } else {
+        break;
+      }
+    }
+    component.selected = true;
+    highlightChildren(component);
+    return component;
+  }
+
+  async selectComponent(path, highlight = true) {
+    const component = this._applyTreeSelection(path);
+    if (highlight) {
+      this.highlightComponent(path);
+    }
+    const details = await evalFunctionInWindow(
+      "getComponentDetails",
+      [component.path],
+      this._store.activeFrame()
+    );
+    if (!details) {
+      await this.loadComponentsTree(false);
+    } else {
+      if (details.env) {
+        keepEnvLit(details);
+      }
+      this.activeComponent.set(proxy(details));
+    }
+    if (this._store.page() !== "ComponentsTab") {
+      this._store.switchTab("ComponentsTab");
+    }
+  }
+
+  // Used during HTML selector hover: updates tree selection without loading component
+  // details, avoiding expensive async evals on every mouseover event.
+  hoverSelectComponent(path) {
+    this.lastHoveredPath = path;
+    this._applyTreeSelection(path);
+    if (this._store.page() !== "ComponentsTab") {
+      this._store.switchTab("ComponentsTab");
+    }
+  }
+
+  // Toggle all parent components of the specified one to make sure it is visible in the tree
+  toggleComponentParents(path) {
+    let cp = path.slice(2);
+    this.apps()[path[0]].toggled = true;
+    let component = this.apps()[path[0]].children[parseInt(path[1], 10)];
+    for (const key of cp) {
+      component.toggled = true;
+      component = component.children.find((child) => child.key === key);
+    }
+  }
+
+  // Returns access to the specified component in the tree
+  getComponentByPath(path) {
+    let component;
+    if (path.length < 2) {
+      component = this.apps()[path[0]];
+    } else {
+      component = this.apps()[path[0]].children[parseInt(path[1], 10)];
+    }
+    let cp = path.slice(2);
+    for (const key of cp) {
+      component = component.children.find((child) => child.key === key);
+    }
+    return component;
+  }
+
+  // Expand/fold the component and its children based on toggle
+  toggleComponentAndChildren(component, toggle) {
+    if (toggle) {
+      expandNodes(component);
+    } else {
+      foldNodes(component);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Component search
+  // -------------------------------------------------------------------------
+
+  updateSearch(search) {
+    this.searchText.set(search);
+    this.searchResults.set([]);
+    const results = [];
+    this.apps().forEach((app) => this._getComponentSearchResults(search, app, results));
+    this.searchResults.set(results);
+    if (results.length > 0) {
+      this.searchIndex.set(0);
+      this.selectComponent(results[0]);
+      this.apps().forEach((app) => foldNodes(app));
+      for (const result of results) {
+        this.toggleComponentParents(result);
+      }
+    } else {
+      this.searchIndex.set(-1);
+    }
+  }
+
+  _getComponentSearchResults(search, node, results) {
+    if (search.length < 1) {
+      return;
+    }
+    if (fuzzySearch(node.name, search)) {
+      results.push(node.path);
+    }
+    if (node.children) {
+      node.children.forEach((child) => this._getComponentSearchResults(search, child, results));
+    }
+  }
+
+  getNextSearch() {
+    const index = this.searchIndex();
+    const results = this.searchResults();
+    if (index > -1 && index < results.length - 1) {
+      this.setSearchIndex(index + 1);
+    } else if (index === results.length - 1) {
+      this.setSearchIndex(0);
+    }
+  }
+
+  getPrevSearch() {
+    const index = this.searchIndex();
+    const results = this.searchResults();
+    if (index > 0) {
+      this.setSearchIndex(index - 1);
+    } else if (index === 0) {
+      this.setSearchIndex(results.length - 1);
+    }
+  }
+
+  setSearchIndex(index) {
+    this.searchIndex.set(index);
+    this.selectComponent(this.searchResults()[index]);
+  }
+
+  // -------------------------------------------------------------------------
+  // Tree navigation (keyboard)
+  // -------------------------------------------------------------------------
+
+  toggleOrSelectPrevElement(toggle) {
+    if (toggle) {
+      const component = this.getComponentByPath(this.activeComponent().path);
+      if (component.children.length > 0 && component.toggled) {
+        component.toggled = false;
+      } else if (this.activeComponent().path.length > 1) {
+        this.selectComponent(this.activeComponent().path.slice(0, -1));
+      }
+      return;
+    }
+    const parentPath = [...this.activeComponent().path];
+    const key = parentPath.pop();
+    if (parentPath.length === 0) {
+      const parent = this.apps();
+      const index = Number(key);
+      if (index > 0) {
+        let sibling = parent[index - 1];
+        while (sibling.toggled && sibling.children.length) {
+          sibling = sibling.children[sibling.children.length - 1];
+        }
+        this.selectComponent(sibling.path);
+      }
+    } else {
+      const parent = this.getComponentByPath(parentPath);
+      const index = parent.children.findIndex((child) => child.key === key);
+      if (index > 0) {
+        let sibling = parent.children[index - 1];
+        while (sibling.toggled && sibling.children.length) {
+          sibling = sibling.children[sibling.children.length - 1];
+        }
+        this.selectComponent(sibling.path);
+      } else {
+        this.selectComponent(parent.path);
+      }
+    }
+  }
+
+  toggleOrSelectNextElement(toggle) {
+    let component = this.getComponentByPath(this.activeComponent().path);
+    if (toggle) {
+      if (!component.children.length) {
+        return;
+      } else if (!component.toggled) {
+        component.toggled = true;
+        return;
+      }
+    }
+    if (component.toggled && component.children.length) {
+      this.selectComponent(component.children[0].path);
+    } else {
+      const parentPath = [...this.activeComponent().path];
+      while (true) {
+        const key = parentPath.pop();
+        if (parentPath.length === 0) {
+          const index = Number(key);
+          if (index < this.apps().length - 1) {
+            this.selectComponent(this.apps()[index + 1].path);
+          }
+          return;
+        }
+        const parent = this.getComponentByPath(parentPath);
+        const index = parent.children.findIndex((child) => child.key === key);
+        if (index < parent.children.length - 1 && index > -1) {
+          this.selectComponent(parent.children[index + 1].path);
+          return;
+        }
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Object tree / details
+  // -------------------------------------------------------------------------
+
+  async loadGetterContent(obj) {
+    const result = await evalFunctionInWindow(
+      "loadGetterContent",
+      [obj],
+      this._store.activeFrame()
+    );
+    Object.keys(obj).forEach((key) => {
+      obj[key] = result[key];
+    });
+    obj.children = [];
+  }
+
+  async toggleObjectTreeElementsDisplay(obj) {
+    if (!obj.hasChildren || window.getSelection().toString().length) {
+      return;
+    }
+    if (obj.hasChildren && obj.children.length === 0) {
+      const children = await evalFunctionInWindow(
+        "loadObjectChildren",
+        [obj.path, obj.depth, obj.contentType, obj.objectType, this.activeComponent()],
+        this._store.activeFrame()
+      );
+      obj.children = children;
+    }
+    obj.toggled = !obj.toggled;
+  }
+
+  editObjectTreeElement(path, value, objectType) {
+    evalFunctionInWindow("editObject", [path, value, objectType], this._store.activeFrame());
+  }
+
+  // -------------------------------------------------------------------------
+  // Selector / highlight
+  // -------------------------------------------------------------------------
+
+  toggleSelector() {
+    this.activeSelector.set(!this.activeSelector());
+    evalFunctionInWindow(
+      this.activeSelector() ? "enableHTMLSelector" : "disableHTMLSelector",
+      [],
+      this._store.activeFrame()
+    );
+  }
+
+  highlightComponent(path) {
+    evalFunctionInWindow("highlightComponent", [path], this._store.activeFrame());
+  }
+
+  removeHighlights() {
+    if (this._store.owlStatus() && !this.invalidContext) {
+      evalFunctionInWindow("removeHighlights", [], this._store.activeFrame());
+    }
+  }
+
+  onActiveComponentClick() {
+    this.selectedElement()?.scrollIntoView({ block: "center", behavior: "smooth" });
+    copyToClipboard(this.activeComponent().name);
+  }
+
+  // -------------------------------------------------------------------------
+  // Inspect / debug
+  // -------------------------------------------------------------------------
+
+  refreshComponent(path = this.activeComponent().path) {
+    evalFunctionInWindow("refreshComponent", [path], this._store.activeFrame());
+  }
+
+  logObjectInConsole(path) {
+    if (!path) {
+      if (this.activeComponent().path.length > 1) {
+        path = [...this.activeComponent().path, { type: "item", value: "component" }];
+      } else {
+        path = this.activeComponent().path;
+      }
+    }
+    evalFunctionInWindow("sendObjectToConsole", [path], this._store.activeFrame());
+  }
+
+  async inspectFunctionSource(path) {
+    await evalFunctionInWindow("inspectFunctionSource", [path], this._store.activeFrame());
+    if (IS_FIREFOX) {
+      await evalInWindow("inspect(window.$temp);", this._store.activeFrame());
+    }
+  }
+
+  async inspectComponent(type, path = this.activeComponent().path) {
+    switch (type) {
+      case "DOM":
+        await evalFunctionInWindow("inspectComponentDOM", [path], this._store.activeFrame());
+        break;
+      case "source":
+        if (path.length > 1) {
+          await evalFunctionInWindow(
+            "inspectFunctionSource",
+            [
+              [
+                ...path,
+                { type: "item", value: "component" },
+                { type: "item", value: "constructor" },
+              ],
+            ],
+            this._store.activeFrame()
+          );
+        } else {
+          await evalFunctionInWindow(
+            "inspectFunctionSource",
+            [[...path, { type: "item", value: "constructor" }]],
+            this._store.activeFrame()
+          );
+        }
+        break;
+      case "compiled template":
+        await evalFunctionInWindow(
+          "inspectComponentCompiledTemplate",
+          [path],
+          this._store.activeFrame()
+        );
+        break;
+      case "raw template":
+        await evalFunctionInWindow(
+          "inspectComponentRawTemplate",
+          [path],
+          this._store.activeFrame()
+        );
+        break;
+    }
+    if (IS_FIREFOX && type !== "raw template") {
+      await evalInWindow("inspect(window.$temp);", this._store.activeFrame());
+    }
+  }
+
+  async injectBreakpoint(hook, path, instanceOnly = false, condition = "1") {
+    path = [...path];
+    await evalFunctionInWindow(
+      "injectBreakpoint",
+      [hook, path, instanceOnly, condition],
+      this._store.activeFrame()
+    );
+    await this.loadComponentsTree(true);
+  }
+
+  async removeBreakpoints() {
+    await evalFunctionInWindow("removeBreakpoints", [], this._store.activeFrame());
+    await this.loadComponentsTree(true);
+  }
+
+  async observeVariable(path) {
+    this.observedVariables().push({ path: [...path], visible: false });
+    const result = await evalFunctionInWindow(
+      "getObservedVariables",
+      [[...this.observedVariables()]],
+      this._store.activeFrame()
+    );
+    this.observedVariables.set(proxy(result));
+    await browserInstance.storage.local.set({
+      observedVariables: toRaw(this.observedVariables()).map((o) => o.path),
+    });
+  }
+
+  clearObservedVariable(index) {
+    if (index !== undefined) {
+      this.observedVariables().splice(index, 1);
+    } else {
+      this.observedVariables.set(proxy([]));
+    }
+    browserInstance.storage.local.set({ observedVariables: toRaw(this.observedVariables()) });
+  }
+}
+
+// -------------------------------------------------------------------------
+// Standalone helper functions
+// -------------------------------------------------------------------------
+
+function deselectComponent(component) {
+  component.selected = false;
+  component.highlighted = false;
+  for (const child of component.children) {
+    deselectComponent(child);
+  }
+}
+
+function highlightChildren(component) {
+  component.children.forEach((child) => {
+    child.highlighted = true;
+    highlightChildren(child);
+  });
+}
+
+function expandNodes(node, blacklistSet = null) {
+  if (blacklistSet && blacklistSet.has(node.name)) {
+    node.toggled = false;
+  } else {
+    node.toggled = true;
+  }
+  for (const child of node.children) {
+    expandNodes(child, blacklistSet);
+  }
+}
+
+function foldNodes(node) {
+  node.toggled = false;
+  for (const child of node.children) {
+    foldNodes(child);
+  }
+}
+
+function keepEnvLit(details) {
+  if (!details) return;
+  let alreadyMet = new Set();
+  for (let i = 0; i < details.env.children.length; i++) {
+    if (i < details.env.children.length - 1) {
+      alreadyMet.add(details.env.children[i].name);
+    } else {
+      let lastElement = details.env.children[i];
+      while (lastElement.children.at(-1)?.name === "[[Prototype]]") {
+        for (const [index, child] of lastElement.children.entries()) {
+          if (index < lastElement.children.length - 1) {
+            if (!alreadyMet.has(child.name)) {
+              child.keepLit = true;
+              alreadyMet.add(child.name);
+            }
+          } else {
+            lastElement = child;
+          }
+        }
+      }
+    }
+  }
+}
+
+function copyToClipboard(text) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand("copy");
+  } catch (err) {
+    console.error("Copy failed", err);
+  }
+  document.body.removeChild(textarea);
+}

--- a/tools/devtools/src/devtools_app/store/profiler_plugin.js
+++ b/tools/devtools/src/devtools_app/store/profiler_plugin.js
@@ -1,0 +1,237 @@
+const { Plugin, signal, proxy, toRaw, plugin } = owl;
+import { browserInstance } from "../../utils";
+import { StorePlugin, evalFunctionInWindow } from "./store";
+
+// Plugin handling all profiler-tab state and logic: event recording, event tree,
+// tracing, and subscription tracing.
+export class ProfilerPlugin extends Plugin {
+  // --- Profiler state ---
+  events = signal(proxy([]));
+  eventsTree = signal(proxy([]));
+  eventsTreeView = signal(true);
+  activeRecorder = signal(false);
+  traceRenderings = signal(false);
+  traceSubscriptions = signal(false);
+  // false when inspecting an OWL 3 page (reactive not exposed → patchReactivity() cannot work)
+  subscriptionTracingSupported = signal(true);
+
+  setup() {
+    this._store = plugin(StorePlugin);
+  }
+
+  // -------------------------------------------------------------------------
+  // Events / profiler
+  // -------------------------------------------------------------------------
+
+  buildEventsTree() {
+    let tree = [];
+    for (const event of this.events()) {
+      let eventNode = Object.assign({}, event);
+      eventNode.children = [];
+      eventNode.toggled = true;
+      if (!eventNode.origin) {
+        eventNode.depth = 0;
+        tree.push(eventNode);
+      } else {
+        for (let i = tree.length - 1; i >= 0; i--) {
+          if (arraysEqual(eventNode.origin.path, tree[i].path)) {
+            const relativePath = eventNode.path.slice(
+              tree[i].path.length,
+              eventNode.path.length - 1
+            );
+            let parent = tree[i];
+            for (const key of relativePath) {
+              parent = parent.children.find((child) => child.key === key);
+            }
+            eventNode.depth = parent.depth + 1;
+            parent.children.push(eventNode);
+            break;
+          }
+        }
+      }
+    }
+    this.eventsTree.set(proxy(tree));
+  }
+
+  toggleEventAndChildren(event, toggle) {
+    if (toggle) {
+      expandNodes(event);
+    } else {
+      foldNodes(event);
+    }
+  }
+
+  collapseAll() {
+    for (let event of this.eventsTree()) {
+      event.toggled = false;
+    }
+  }
+
+  async toggleRecording() {
+    this.activeRecorder.set(
+      await evalFunctionInWindow(
+        "toggleEventsRecording",
+        [!this.activeRecorder(), this.events().length],
+        this._store.activeFrame()
+      )
+    );
+  }
+
+  clearEventsConsole() {
+    this.events.set(proxy([]));
+    this.eventsTree.set(proxy([]));
+    evalFunctionInWindow("resetEvents", [], this._store.activeFrame());
+  }
+
+  _loadEvents(events) {
+    if (!Array.isArray(events)) {
+      return;
+    }
+    for (const event of events) {
+      if (
+        !isObjectWithShape(event, {
+          type: "string",
+          component: "string",
+          key: "string",
+          path: "object",
+          time: "number",
+          id: "number",
+        }) ||
+        !(Array.isArray(event.path) && event.path.every((val) => typeof val === "string"))
+      ) {
+        return;
+      }
+      event.origin = null;
+      event.toggled = false;
+      event.isLast = false;
+      if (!event.type.includes("render")) {
+        const evts = this.events();
+        for (let i = evts.length - 1; i >= 0; i--) {
+          if (!evts[i].origin && event.path.join("/").includes(evts[i].path.join("/"))) {
+            event.origin = toRaw(evts[i]);
+            break;
+          }
+          if (evts[i].origin && event.path.join("/").includes(evts[i].origin.path.join("/"))) {
+            event.origin = toRaw(evts[i].origin);
+            break;
+          }
+        }
+      }
+      if (this.eventsTreeView()) {
+        let eventNode = Object.assign({}, event);
+        eventNode.children = [];
+        eventNode.toggled = true;
+        if (!eventNode.origin) {
+          eventNode.depth = 0;
+          this.eventsTree().push(eventNode);
+        } else {
+          const tree = this.eventsTree();
+          for (let i = tree.length - 1; i >= 0; i--) {
+            if (eventNode.origin.path.join("/") === tree[i].path.join("/")) {
+              const relativePath = eventNode.path.slice(
+                tree[i].path.length,
+                eventNode.path.length - 1
+              );
+              let parent = tree[i];
+              for (const key of relativePath) {
+                parent = parent.children.find((child) => child.key === key);
+              }
+              eventNode.depth = parent.depth + 1;
+              parent.children.push(eventNode);
+              break;
+            }
+          }
+        }
+      }
+      this._addEventSorted(event);
+    }
+    const evts = this.events();
+    evts[evts.length - 1].isLast = true;
+  }
+
+  _addEventSorted(item) {
+    const evts = this.events();
+    let low = 0;
+    let high = evts.length;
+    while (low < high) {
+      let mid = Math.floor((low + high) / 2);
+      if (evts[mid].id < item.id) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    evts.splice(low, 0, item);
+  }
+
+  // -------------------------------------------------------------------------
+  // Tracing
+  // -------------------------------------------------------------------------
+
+  async toggleTracing() {
+    this.traceRenderings.set(
+      await evalFunctionInWindow(
+        "toggleTracing",
+        [!this.traceRenderings()],
+        this._store.activeFrame()
+      )
+    );
+  }
+
+  async refreshSubscriptionTracingSupport(frame) {
+    const supported = await evalFunctionInWindow(
+      "supportsSubscriptionTracing",
+      [],
+      frame ?? this._store.activeFrame()
+    );
+    this.subscriptionTracingSupported.set(supported);
+    // If the active frame no longer supports subscription tracing, turn it off.
+    if (!supported && this.traceSubscriptions()) {
+      this.traceSubscriptions.set(false);
+    }
+  }
+
+  async toggleSubscriptionTracing() {
+    this.traceSubscriptions.set(
+      await evalFunctionInWindow(
+        "toggleSubscriptionTracing",
+        [!this.traceSubscriptions()],
+        this._store.activeFrame()
+      )
+    );
+  }
+}
+
+// -------------------------------------------------------------------------
+// Standalone helper functions
+// -------------------------------------------------------------------------
+
+function isObjectWithShape(obj, shape) {
+  if (typeof obj !== "object" || Array.isArray(obj)) {
+    return false;
+  }
+  return Object.keys(shape).every(
+    (key) => obj.hasOwnProperty(key) && typeof obj[key] === shape[key]
+  );
+}
+
+function arraysEqual(arr1, arr2) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  return arr1.every((val, i) => val === arr2[i]);
+}
+
+function expandNodes(node) {
+  node.toggled = true;
+  for (const child of node.children) {
+    expandNodes(child);
+  }
+}
+
+function foldNodes(node) {
+  node.toggled = false;
+  for (const child of node.children) {
+    foldNodes(child);
+  }
+}

--- a/tools/devtools/src/devtools_app/store/store.js
+++ b/tools/devtools/src/devtools_app/store/store.js
@@ -1,397 +1,74 @@
-const { reactive, useState, toRaw } = owl;
-import { fuzzySearch, IS_FIREFOX, getActiveTabURL, browserInstance } from "../../utils";
+const { Plugin, signal, proxy, plugin } = owl;
+import { IS_FIREFOX, getActiveTabURL, browserInstance } from "../../utils";
 import globalHook from "../../page_scripts/owl_devtools_global_hook";
+import { ComponentsPlugin } from "./components_plugin";
+import { ProfilerPlugin } from "./profiler_plugin";
 
-// Main store which contains all states that needs to be maintained throughout all components in the devtools app
-export const store = reactive({
-  devtoolsId: 0,
-  settings: {
-    expandByDefault: true,
-    toggleOnSelected: false,
-    darkmode: false,
-    componentsToggleBlacklist: new Set(),
-  },
-  contextMenu: null,
-  isFirefox: IS_FIREFOX,
-  frameUrls: ["top"],
-  activeFrame: "top",
-  page: "ComponentsTab",
-  events: [],
-  eventsTreeView: true,
-  eventsTree: [],
-  activeRecorder: false,
-  owlStatus: true,
-  extensionContextStatus: true,
-  splitPosition: window.innerWidth > window.innerHeight ? 45 : 60,
-  apps: [],
-  traceRenderings: false,
-  traceSubscriptions: false,
-  activeComponent: {
-    path: ["0"],
-    name: "App",
-    subscriptions: { toggled: true, children: [] },
-    props: { toggled: true, children: [] },
-    env: { toggled: false, children: [] },
-    instance: { toggled: true, children: [] },
-    hooks: { toggled: true, children: [] },
-    version: "1.0",
-  },
-  selectedElement: null,
-  observedVariables: [],
-  componentSearch: {
-    search: "",
-    searchResults: [],
-    searchIndex: 0,
-    activeSelector: false,
-    getNextSearch() {
-      if (this.searchIndex > -1 && this.searchIndex < this.searchResults.length - 1) {
-        store.setSearchIndex(this.searchIndex + 1);
-      } else if (this.searchIndex === this.searchResults.length - 1) {
-        store.setSearchIndex(0);
-      }
-    },
-    getPrevSearch() {
-      if (this.searchIndex > 0) {
-        store.setSearchIndex(this.searchIndex - 1);
-      } else if (this.searchIndex === 0) {
-        store.setSearchIndex(this.searchResults.length - 1);
-      }
-    },
-  },
-  // eventSearch: {
-  //   search: "",
-  //   searchResults: [],
-  //   filters: [],
-  // },
-  renderPaths: new Set(),
+// Core plugin: initialization, port listener, settings, frame management,
+// context menu, tab navigation, and shared UI state.
+export class StorePlugin extends Plugin {
+  // --- Primitive state ---
+  devtoolsId = signal(0);
+  contextMenu = signal(null);
+  page = signal("ComponentsTab");
+  activeFrame = signal("top");
+  frameUrls = signal(["top"]);
+  owlStatus = signal(true);
+  extensionContextStatus = signal(true);
+  splitPosition = signal(window.innerWidth > window.innerHeight ? 45 : 60);
 
-  // Used to navigate between the Components tab and the Events tab
+  // --- Settings ---
+  expandByDefault = signal(true);
+  toggleOnSelected = signal(false);
+  darkMode = signal(false);
+  componentsToggleBlacklist = signal.Set(new Set());
+
+  // --- Non-reactive ---
+  isFirefox = IS_FIREFOX;
+
+  setup() {
+    this._components = plugin(ComponentsPlugin);
+    this._profiler = plugin(ProfilerPlugin);
+    this._init();
+    this._setupPortListener();
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab / context menu
+  // -------------------------------------------------------------------------
+
   switchTab(componentName) {
-    this.page = componentName;
-    this.componentSearch.activeSelector = false;
-    evalFunctionInWindow("disableHTMLSelector", [], this.activeFrame);
-  },
+    this.page.set(componentName);
+    this._components.activeSelector.set(false);
+    evalFunctionInWindow("disableHTMLSelector", [], this.activeFrame());
+  }
 
   openContextMenu(event, items) {
-    this.contextMenu = {
-      position: {
-        x: event.clientX,
-        y: event.clientY,
-      },
+    this.contextMenu.set({
+      position: { x: event.clientX, y: event.clientY },
       items,
-    };
-  },
-
-  // Load all data related to the components tree using the global hook loaded on the page
-  // Use fromOld to specify if we want to keep most of the toggled/selected data of the old tree
-  // when generating the new one
-  async loadComponentsTree(fromOld) {
-    if (IS_FIREFOX) {
-      await evalInWindow("window.$0 = $0;", this.activeFrame);
-    }
-    const [apps, details] = await evalFunctionInWindow(
-      "getComponentsTree",
-      fromOld && this.activeComponent
-        ? [this.activeComponent.path, this.apps, this.activeComponent]
-        : [],
-      this.activeFrame
-    );
-    this.apps = apps ? apps : [];
-    if (!fromOld && this.settings.expandByDefault) {
-      this.apps.forEach((tree) => expandNodes(tree, true));
-    }
-    keepEnvLit(details);
-    this.activeComponent = details;
-    if (this.componentSearch.search.length) {
-      this.updateSearch(this.componentSearch.search);
-    }
-  },
-
-  // Select a component by retrieving its details from the page based on its path
-  async selectComponent(path) {
-    // Deselect all components
-    this.apps.forEach((app) => {
-      app.selected = false;
-      app.highlighted = false;
-      app.children.forEach((child) => {
-        deselectComponent(child);
-      });
     });
-    let component;
-    // element is the app here
-    if (path.length === 1) {
-      component = this.apps[path[0]];
-      // the second element in the path is always the root of the app so no need to check
-    } else {
-      component = this.apps[path[0]].children[0];
-    }
-    for (let i = 2; i < path.length; i++) {
-      component.toggled = true;
-      const result = component.children.find((child) => child.key === path[i]);
-      if (result) {
-        component = result;
-      } else {
-        break;
-      }
-    }
-    component.selected = true;
-    highlightChildren(component);
-    this.highlightComponent(path);
-    const details = await evalFunctionInWindow(
-      "getComponentDetails",
-      [component.path],
-      this.activeFrame
-    );
-    if (!details) {
-      await this.loadComponentsTree(false);
-    } else {
-      keepEnvLit(details);
-      this.activeComponent = details;
-    }
-    if (this.page !== "ComponentsTab") {
-      this.switchTab("ComponentsTab");
-    }
-  },
+  }
 
-  // Update the search state value with the current search string and trigger the search
-  updateSearch(search) {
-    this.componentSearch.search = search;
-    this.componentSearch.searchResults = [];
-    this.apps.forEach((app) => this.getComponentSearchResults(search, app));
-    if (this.componentSearch.searchResults.length > 0) {
-      this.componentSearch.searchIndex = 0;
-      this.selectComponent(this.componentSearch.searchResults[0]);
-      this.apps.forEach((app) => foldNodes(app));
-      for (const result of this.componentSearch.searchResults) {
-        this.toggleComponentParents(result);
-      }
-    } else {
-      this.componentSearch.searchIndex = -1;
-    }
-  },
+  // -------------------------------------------------------------------------
+  // Shared tree utility
+  // -------------------------------------------------------------------------
 
-  // Search for results in the components tree given the current search string (in a fuzzy way)
-  getComponentSearchResults(search, node) {
-    if (search.length < 1) {
-      return;
-    }
-    if (fuzzySearch(node.name, search)) {
-      this.componentSearch.searchResults.push(node.path);
-    }
-    if (node.children) {
-      node.children.forEach((child) => this.getComponentSearchResults(search, child));
-    }
-  },
-
-  // Same but only record the component names for events
-  // getComponentNameSearchResults(search, node) {
-  //   if (search.length < 1) return;
-  //   if (fuzzySearch(node.name, search)) {
-  //     if(!this.eventSearch.searchResults.includes(node.name))
-  //       this.eventSearch.searchResults.push(node.name);
-  //   }
-  //   if (node.children) {
-  //     node.children.forEach((child) => this.getComponentNameSearchResults(search, child));
-  //   }
-  // },
-
-  // updateEventSearch(search){
-  //   this.eventSearch.search = search;
-  //   this.eventSearch.searchResults = [];
-  //   this.apps.forEach((app) => this.getComponentNameSearchResults(search, app));
-  //   [""]
-  // },
-
-  // Toggle all parent components of the specified one to make sure it is visible in the tree
-  toggleComponentParents(path) {
-    let cp = path.slice(2);
-    this.apps[path[0]].toggled = true;
-    let component = this.apps[path[0]].children[0];
-    for (const key of cp) {
-      component.toggled = true;
-      component = component.children.find((child) => child.key === key);
-    }
-  },
-
-  // Returns access to the specified component in the tree
-  getComponentByPath(path) {
-    let component;
-    if (path.length < 2) {
-      component = this.apps[path[0]];
-    } else {
-      component = this.apps[path[0]].children[0];
-    }
-    let cp = path.slice(2);
-    for (const key of cp) {
-      component = component.children.find((child) => child.key === key);
-    }
-    return component;
-  },
-
-  // expand/fold the component and its children based on toggle
-  toggleComponentAndChildren(component, toggle) {
-    if (toggle) {
-      expandNodes(component);
-    } else {
-      foldNodes(component);
-    }
-  },
-
+  // Fold the immediate children of a tree element (works for both component and event trees)
   foldDirectChildren(element) {
     for (const child of element.children) {
       child.toggled = false;
     }
-  },
+  }
 
-  // Action related to the left(toggle)/up(not toggle) arrow keys for navigation purpose
-  // The resulting behaviour is the same as in the Elements tab of the chrome devtools
-  toggleOrSelectPrevElement(toggle) {
-    if (toggle) {
-      const component = this.getComponentByPath(this.activeComponent.path);
-      if (component.children.length > 0 && component.toggled) {
-        component.toggled = false;
-      } else if (this.activeComponent.path.length > 1) {
-        this.selectComponent(this.activeComponent.path.slice(0, -1));
-      }
-      return;
-    }
-    const parentPath = [...this.activeComponent.path];
-    const key = parentPath.pop();
-    // If component is an app, find descendant with the highest successive children indexes of the app above
-    // or do nothing if there is no app above
-    if (parentPath.length === 0) {
-      const parent = this.apps;
-      const index = Number(key);
-      if (index > 0) {
-        let sibling = parent[index - 1];
-        while (sibling.toggled && sibling.children.length) {
-          sibling = sibling.children[sibling.children.length - 1];
-        }
-        this.selectComponent(sibling.path);
-      }
-    } else {
-      const parent = this.getComponentByPath(parentPath);
-      const index = parent.children.findIndex((child) => child.key === key);
-      if (index > 0) {
-        let sibling = parent.children[index - 1];
-        while (sibling.toggled && sibling.children.length) {
-          sibling = sibling.children[sibling.children.length - 1];
-        }
-        this.selectComponent(sibling.path);
-      } else {
-        this.selectComponent(parent.path);
-      }
-    }
-  },
+  // -------------------------------------------------------------------------
+  // Frames
+  // -------------------------------------------------------------------------
 
-  // Action related to the right(toggle)/down(not toggle) arrow keys for navigation purpose
-  // The resulting behaviour is the same as in the Elements tab of the chrome devtools
-  toggleOrSelectNextElement(toggle) {
-    let component = this.getComponentByPath(this.activeComponent.path);
-    if (toggle) {
-      if (!component.children.length) {
-        return;
-      } else if (!component.toggled) {
-        component.toggled = true;
-        return;
-      }
-    }
-    // If component has children and is toggled, select its first child
-    if (component.toggled && component.children.length) {
-      this.selectComponent(component.children[0].path);
-    } else {
-      const parentPath = [...this.activeComponent.path];
-      while (true) {
-        const key = parentPath.pop();
-        if (parentPath.length === 0) {
-          const index = Number(key);
-          if (index < this.apps.length - 1) {
-            this.selectComponent(this.apps[index + 1].path);
-          }
-          return;
-        }
-        const parent = this.getComponentByPath(parentPath);
-        const index = parent.children.findIndex((child) => child.key === key);
-        if (index < parent.children.length - 1 && index > -1) {
-          this.selectComponent(parent.children[index + 1].path);
-          return;
-        }
-      }
-    }
-  },
-
-  // Set the search index to the provided one in order to select the current searched component
-  setSearchIndex(index) {
-    this.componentSearch.searchIndex = index;
-    this.selectComponent(this.componentSearch.searchResults[index]);
-  },
-
-  // Replace the (...) content of a getter with the value returned by the corresponding get method
-  async loadGetterContent(obj) {
-    const result = await evalFunctionInWindow("loadGetterContent", [obj], this.activeFrame);
-    Object.keys(obj).forEach((key) => {
-      obj[key] = result[key];
-    });
-    obj.children = [];
-  },
-
-  // Expand the children of the input object property and load it from page if necessary
-  async toggleObjectTreeElementsDisplay(obj) {
-    if (!obj.hasChildren || window.getSelection().toString().length) {
-      return;
-    }
-    // Since it is sometimes impossible (and always ineffective) to load all descendants of a property
-    // when the component details are loaded, we need to populate the children of a property only when
-    // it is first expanded. Do note that it has a limit to how deep we can expand (when reaching a circular dependancy)
-    if (obj.hasChildren && obj.children.length === 0) {
-      const children = await evalFunctionInWindow(
-        "loadObjectChildren",
-        [obj.path, obj.depth, obj.contentType, obj.objectType, this.activeComponent],
-        this.activeFrame
-      );
-      obj.children = children;
-    }
-    obj.toggled = !obj.toggled;
-  },
-
-  // Toggle the selector tool which is used to select a component based on the hovered Dom element
-  toggleSelector() {
-    this.componentSearch.activeSelector = !this.componentSearch.activeSelector;
-    evalFunctionInWindow(
-      this.componentSearch.activeSelector ? "enableHTMLSelector" : "disableHTMLSelector",
-      [],
-      this.activeFrame
-    );
-  },
-
-  // Update the value of the given object with the new provided one
-  editObjectTreeElement(path, value, objectType) {
-    evalFunctionInWindow("editObject", [path, value, objectType], this.activeFrame);
-  },
-
-  // toggle the tracing mode which will record all root render events and send their trace in the console
-  async toggleTracing() {
-    this.traceRenderings = await evalFunctionInWindow(
-      "toggleTracing",
-      [!this.traceRenderings],
-      this.activeFrame
-    );
-  },
-
-  // toggle subscriptions tracing mode which will record all new subscriptions
-  async toggleSubscriptionTracing() {
-    this.traceSubscriptions = await evalFunctionInWindow(
-      "toggleSubscriptionTracing",
-      [!this.traceSubscriptions],
-      this.activeFrame
-    );
-  },
-
-  // Checks for all iframes in the page, register it and load the scripts inside if not already done
   async updateIFrameList() {
     const frames = await evalFunctionInWindow("getIFrameUrls");
-    this.frameUrls = ["top"];
-    if (this.activeFrame !== "top") {
+    this.frameUrls.set(["top"]);
+    if (this.activeFrame() !== "top") {
       this.selectFrame("top");
     }
     for (const frame of frames) {
@@ -405,600 +82,241 @@ export const store = reactive({
           await loadScripts(frame);
         }
         evalFunctionInWindow("initDevtools", [frame], frame);
-        if (!this.frameUrls.includes(frame)) {
-          this.frameUrls = [...this.frameUrls, frame];
+        if (!this.frameUrls().includes(frame)) {
+          this.frameUrls.set([...this.frameUrls(), frame]);
         }
       }
     }
-  },
+  }
 
-  // Remove all the highlight boxes created above the html elements in the page to show components
-  removeHighlights() {
-    if (this.owlStatus && !this.invalidContext) {
-      evalFunctionInWindow("removeHighlights", [], this.activeFrame);
-    }
-  },
-
-  // Reset the context of all values in the devtools tab and load the one from the given frame
   selectFrame(frame) {
-    this.removeHighlights();
-    evalFunctionInWindow("toggleEventsRecording", [false, 0], this.activeFrame);
-    evalFunctionInWindow("toggleTracing", [false], this.activeFrame);
-    evalFunctionInWindow("toggleSubscriptionTracing", [false], this.activeFrame);
-    this.events = [];
-    this.eventsTree = [];
-    this.activeFrame = frame;
-    store.loadComponentsTree(false);
+    this._components.removeHighlights();
+    evalFunctionInWindow("toggleEventsRecording", [false, 0], this.activeFrame());
+    evalFunctionInWindow("toggleTracing", [false], this.activeFrame());
+    evalFunctionInWindow("toggleSubscriptionTracing", [false], this.activeFrame());
+    this._profiler.events.set(proxy([]));
+    this._profiler.eventsTree.set(proxy([]));
+    this.activeFrame.set(frame);
+    this._components.loadComponentsTree(false);
+    this._profiler.refreshSubscriptionTracingSupport(frame);
     evalFunctionInWindow(
       "toggleEventsRecording",
-      [this.activeRecorder, this.events.length],
-      this.activeFrame
+      [this._profiler.activeRecorder(), this._profiler.events().length],
+      this.activeFrame()
     );
-    evalFunctionInWindow("toggleTracing", [this.traceRenderings], this.activeFrame);
-    evalFunctionInWindow("toggleSubscriptionTracing", [this.traceSubscriptions], this.activeFrame);
-  },
-
-  // Constructs the tree that represents the currently recorded events to see them as a tree instead of a temporally accurate list
-  buildEventsTree() {
-    let tree = [];
-    for (const event of this.events) {
-      let eventNode = Object.assign({}, event);
-      eventNode.children = [];
-      eventNode.toggled = true;
-      if (!eventNode.origin) {
-        eventNode.depth = 0;
-        tree.push(eventNode);
-      } else {
-        // This is litteraly an array.find but which starts searching from the end of the array
-        for (let i = tree.length - 1; i >= 0; i--) {
-          if (arraysEqual(eventNode.origin.path, tree[i].path)) {
-            // path from the origin event (root render) to the direct parent of the current event
-            const relativePath = eventNode.path.slice(
-              tree[i].path.length,
-              eventNode.path.length - 1
-            );
-            let parent = tree[i];
-            // find the direct parent in the tree
-            for (const key of relativePath) {
-              parent = parent.children.find((child) => child.key === key);
-            }
-            eventNode.depth = parent.depth + 1;
-            parent.children.push(eventNode);
-            break;
-          }
-        }
-      }
-    }
-    this.eventsTree = tree;
-  },
-
-  // expand/fold the event tree node based on toggle
-  toggleEventAndChildren(event, toggle) {
-    if (toggle) {
-      expandNodes(event);
-    } else {
-      foldNodes(event);
-    }
-  },
-
-  collapseAll() {
-    for (let event of this.eventsTree) {
-      event.toggled = false;
-    }
-  },
-
-  // Reset all the relevant data about the page currently stored
-  async resetData() {
-    await loadSettings();
-    this.loadComponentsTree(false);
-    this.events = [];
-    this.eventsTree = [];
-    this.activeRecorder = false;
-    evalFunctionInWindow("toggleEventsRecording", [false, 0]);
-    this.traceRenderings = false;
-    evalFunctionInWindow("toggleTracing", [false]);
-    this.traceSubscriptions = false;
-    evalFunctionInWindow("toggleSubscriptionTracing", [false]);
-    this.updateIFrameList();
-  },
-
-  // Triggers manually the rendering of the selected component
-  refreshComponent(path = this.activeComponent.path) {
-    evalFunctionInWindow("refreshComponent", [path], this.activeFrame);
-  },
-
-  // Allows to log any object in the console, defaults to the active component (or app)
-  logObjectInConsole(path) {
-    if (!path) {
-      if (this.activeComponent.path.length > 1) {
-        path = [...this.activeComponent.path, { type: "item", value: "component" }];
-      } else {
-        path = this.activeComponent.path;
-      }
-    }
-    evalFunctionInWindow("sendObjectToConsole", [path], this.activeFrame);
-  },
-
-  // inspect the source code of the object given by its path
-  async inspectFunctionSource(path) {
-    await evalFunctionInWindow("inspectFunctionSource", [path], this.activeFrame);
-    if (IS_FIREFOX) {
-      await evalInWindow("inspect(window.$temp);", this.activeFrame);
-    }
-  },
-
-  // Inspect the given component's data based on the given type
-  async inspectComponent(type, path = this.activeComponent.path) {
-    switch (type) {
-      case "DOM":
-        await evalFunctionInWindow("inspectComponentDOM", [path], this.activeFrame);
-        break;
-      case "source":
-        if (path.length > 1) {
-          await evalFunctionInWindow(
-            "inspectFunctionSource",
-            [
-              [
-                ...path,
-                { type: "item", value: "component" },
-                { type: "item", value: "constructor" },
-              ],
-            ],
-            this.activeFrame
-          );
-        } else {
-          await evalFunctionInWindow(
-            "inspectFunctionSource",
-            [[...path, { type: "item", value: "constructor" }]],
-            this.activeFrame
-          );
-        }
-        break;
-      case "compiled template":
-        await evalFunctionInWindow("inspectComponentCompiledTemplate", [path], this.activeFrame);
-        break;
-      case "raw template":
-        await evalFunctionInWindow("inspectComponentRawTemplate", [path], this.activeFrame);
-        break;
-    }
-    if (IS_FIREFOX && type !== "raw template") {
-      await evalInWindow("inspect(window.$temp);", this.activeFrame);
-    }
-  },
-
-  async injectBreakpoint(hook, path, instanceOnly = false, condition = "1") {
-    path = [...path];
-    await evalFunctionInWindow(
-      "injectBreakpoint",
-      [hook, path, instanceOnly, condition],
-      this.activeFrame
+    evalFunctionInWindow("toggleTracing", [this._profiler.traceRenderings()], this.activeFrame());
+    evalFunctionInWindow(
+      "toggleSubscriptionTracing",
+      [this._profiler.traceSubscriptions()],
+      this.activeFrame()
     );
-    await this.loadComponentsTree(true);
-  },
+  }
 
-  async removeBreakpoints() {
-    await evalFunctionInWindow("removeBreakpoints", [], this.activeFrame);
-    await this.loadComponentsTree(true);
-  },
+  // -------------------------------------------------------------------------
+  // Settings / UI
+  // -------------------------------------------------------------------------
 
-  async observeVariable(path) {
-    this.observedVariables.push({ path: [...path], visible: false });
-    this.observedVariables = await evalFunctionInWindow(
-      "getObservedVariables",
-      [store.observedVariables],
-      store.activeFrame
-    );
-    await browserInstance.storage.local.set({
-      observedVariables: toRaw(this.observedVariables).map((o) => o.path),
-    });
-  },
-
-  clearObservedVariable(index) {
-    if (index !== undefined) {
-      this.observedVariables.splice(index, 1);
-    } else {
-      this.observedVariables = [];
-    }
-    browserInstance.storage.local.set({ observedVariables: toRaw(this.observedVariables) });
-  },
-
-  // Trigger the highlight on the component in the page
-  highlightComponent(path) {
-    evalFunctionInWindow("highlightComponent", [path], this.activeFrame);
-  },
-
-  // Center the view around the currently selected component
-  onActiveComponentClick() {
-    this.selectedElement.scrollIntoView({ block: "center", behavior: "smooth" });
-    copyToClipboard(this.activeComponent.name);
-  },
-
-  // Toggle the recording of events in the page
-  async toggleRecording() {
-    this.activeRecorder = await evalFunctionInWindow(
-      "toggleEventsRecording",
-      [!this.activeRecorder, this.events.length],
-      this.activeFrame
-    );
-  },
-
-  // Reset all events data
-  clearEventsConsole() {
-    this.events = [];
-    this.eventsTree = [];
-    evalFunctionInWindow("resetEvents", [], this.activeFrame);
-  },
-
-  // Refresh the whole extension
-  async refreshExtension() {
-    await loadScripts();
-    await this.resetData();
-  },
-
-  // Toggle dark mode in the extension and store result in the storage
   toggleDarkMode() {
-    this.settings.darkMode = !this.settings.darkMode;
-    if (this.settings.darkMode) {
+    this.darkMode.set(!this.darkMode());
+    if (this.darkMode()) {
       document.querySelector("html").classList.add("dark-mode");
     } else {
       document.querySelector("html").classList.remove("dark-mode");
     }
-    browserInstance.storage.local.set({ owlDevtoolsDarkMode: this.settings.darkMode });
-  },
+    browserInstance.storage.local.set({ owlDevtoolsDarkMode: this.darkMode() });
+  }
 
   openDocumentation() {
     browserInstance.runtime.sendMessage({ type: "openDoc" });
-  },
-});
-
-// Instantiate the store
-export function useStore() {
-  return useState(store);
-}
-
-init();
-
-async function init() {
-  store.devtoolsId = await getTabURL();
-
-  evalFunctionInWindow("initDevtools", []);
-
-  await loadSettings();
-
-  // We want to load the base components tree when the devtools tab is first opened
-  store.loadComponentsTree(false);
-
-  // We also want to detect the different iframes at first loading of the devtools tab
-  store.updateIFrameList();
-
-  // Global listeners to close the currently shown context menu when the user clicks or opens another
-  document.addEventListener("click", () => (store.contextMenu = null), { capture: true });
-  document.addEventListener("contextmenu", () => (store.contextMenu = null), { capture: true });
-  window.addEventListener("blur", () => (store.contextMenu = null), { capture: true });
-
-  // Make sure the events recorder is at its initial state in every frame
-  for (const frame of store.frameUrls) {
-    evalFunctionInWindow("toggleEventsRecording", [false, 0], frame);
   }
 
-  browserInstance.runtime.sendMessage({ type: "newDevtoolsPanel", id: store.devtoolsId });
+  async refreshExtension() {
+    await loadScripts();
+    await this._resetData();
+  }
 
-  // Heartbeat message to test whether the extension context is still valid or not
-  setInterval(() => {
-    if (store.extensionContextStatus) {
-      try {
-        browserInstance.runtime.sendMessage({ type: "keepAlive", id: store.devtoolsId });
-      } catch (e) {
-        store.extensionContextStatus = false;
-      }
+  // -------------------------------------------------------------------------
+  // Initialization (private)
+  // -------------------------------------------------------------------------
+
+  async _resetData() {
+    await this._loadSettings();
+    this._components.loadComponentsTree(false);
+    this._profiler.events.set(proxy([]));
+    this._profiler.eventsTree.set(proxy([]));
+    this._profiler.activeRecorder.set(false);
+    evalFunctionInWindow("toggleEventsRecording", [false, 0]);
+    this._profiler.traceRenderings.set(false);
+    evalFunctionInWindow("toggleTracing", [false]);
+    this._profiler.traceSubscriptions.set(false);
+    evalFunctionInWindow("toggleSubscriptionTracing", [false]);
+    this._profiler.refreshSubscriptionTracingSupport();
+    this.updateIFrameList();
+  }
+
+  async _init() {
+    this.devtoolsId.set(await getTabURL());
+
+    evalFunctionInWindow("initDevtools", []);
+
+    await this._loadSettings();
+
+    this._components.loadComponentsTree(false);
+    this.updateIFrameList();
+    this._profiler.refreshSubscriptionTracingSupport();
+
+    document.addEventListener("click", () => this.contextMenu.set(null), { capture: true });
+    document.addEventListener("contextmenu", () => this.contextMenu.set(null), { capture: true });
+    window.addEventListener("blur", () => this.contextMenu.set(null), { capture: true });
+
+    for (const frame of this.frameUrls()) {
+      evalFunctionInWindow("toggleEventsRecording", [false, 0], frame);
     }
-  }, 500);
-  // Refresh observed variables values every 200 ms
-  setInterval(async () => {
-    if (store.owlStatus) {
-      store.observedVariables = await evalFunctionInWindow(
-        "getObservedVariables",
-        [[...store.observedVariables]],
-        store.activeFrame
-      );
-    }
-  }, 200);
-}
 
-let rootRendersTimeout = false;
-// Connect to the port to communicate to the background script
-browserInstance.runtime.onConnect.addListener((port) => {
-  if (port.name === "OwlDevtoolsPort_" + store.devtoolsId) {
-    port.onMessage.addListener(async (msg) => {
-      // Reload the tree after checking if the scripts are loaded when this message is received
-      if (msg.type === "Reload") {
-        store.owlStatus = await evalInWindow("window.__OWL__DEVTOOLS_GLOBAL_HOOK__ !== undefined;");
-        if (store.owlStatus) {
-          evalFunctionInWindow("initDevtools", []);
-          await store.resetData();
-        }
-      }
-      // Received when a frame has been delayed when loading the scripts due to owl being lazy loaded
-      if (msg.type === "FrameReady") {
-        store.updateIFrameList();
-        store.owlStatus = true;
-        await store.resetData();
-      }
-      // We need to reload the components tree when the set of apps in the page is modified
-      if (msg.type === "RefreshApps") {
-        store.loadComponentsTree(true);
-      }
-      // When message of type Complete is received, overwrite the component tree with the new one from page
-      // A Complete message is sent everytime a root render is triggered on the page
-      if (msg.type === "Complete") {
-        if (msg.origin.frame !== store.activeFrame) {
-          return;
-        }
-        if (!(Array.isArray(msg.data) && msg.data.every((val) => typeof val === "string"))) {
-          return;
-        }
-        // This determines which components will have a short highlight effect in the tree to indicate they have been rendered
-        store.renderPaths.add(JSON.stringify(msg.data));
-        clearTimeout(rootRendersTimeout);
-        rootRendersTimeout = setTimeout(() => {
-          store.renderPaths.clear();
-        }, 100);
-        store.loadComponentsTree(true);
-      }
-      // Select the component based on the path received with the SelectElement message
-      if (msg.type === "SelectElement") {
-        if (!(Array.isArray(msg.data) && msg.data.every((val) => typeof val === "string"))) {
-          return;
-        }
-        store.selectComponent(msg.data);
-      }
-      // Stop the DOM element selector tool upon receiving the StopSelector message
-      if (msg.type === "StopSelector") {
-        store.componentSearch.activeSelector = false;
-      }
+    browserInstance.runtime.sendMessage({ type: "newDevtoolsPanel", id: this.devtoolsId() });
 
-      // Logic for recording an event when the event message is received
-      if (msg.type === "Event") {
-        let events = msg.data;
-        loadEvents(events);
-      }
-
-      // If we know a new iframe has been added to the page, load scripts into it and update the
-      // frames list if it has been directly loaded.
-      if (msg.type === "NewIFrame") {
-        const isLoaded = await loadScripts(msg.data);
-        if (isLoaded) {
-          store.updateIFrameList();
+    setInterval(() => {
+      if (this.extensionContextStatus()) {
+        try {
+          browserInstance.runtime.sendMessage({ type: "keepAlive", id: this.devtoolsId() });
+        } catch (e) {
+          this.extensionContextStatus.set(false);
         }
+      }
+    }, 500);
+
+    // Refresh observed variables values every 200 ms
+    setInterval(async () => {
+      if (this.owlStatus()) {
+        const result = await evalFunctionInWindow(
+          "getObservedVariables",
+          [[...this._components.observedVariables()]],
+          this.activeFrame()
+        );
+        this._components.observedVariables.set(proxy(result));
+      }
+    }, 200);
+  }
+
+  _setupPortListener() {
+    let rootRendersTimeout = null;
+    browserInstance.runtime.onConnect.addListener((port) => {
+      if (port.name === "OwlDevtoolsPort_" + this.devtoolsId()) {
+        port.onMessage.addListener(async (msg) => {
+          // Reload the tree after checking if the scripts are loaded when this message is received
+          if (msg.type === "Reload") {
+            this.owlStatus.set(
+              await evalInWindow("window.__OWL__DEVTOOLS_GLOBAL_HOOK__ !== undefined;")
+            );
+            if (this.owlStatus()) {
+              evalFunctionInWindow("initDevtools", []);
+              await this._resetData();
+            }
+          }
+          // Received when a frame has been delayed when loading the scripts due to owl being lazy loaded
+          if (msg.type === "FrameReady") {
+            this.updateIFrameList();
+            this.owlStatus.set(true);
+            // Only reset data when inspecting an iframe: when on the top frame,
+            // a new iframe becoming ready is a background event and should not
+            // discard the profiler data the user has already recorded.
+            if (this.activeFrame() !== "top") {
+              await this._resetData();
+            }
+          }
+          // We need to reload the components tree when the set of apps in the page is modified
+          if (msg.type === "RefreshApps") {
+            this._components.loadComponentsTree(true);
+          }
+          // When message of type Complete is received, overwrite the component tree with the new one from page.
+          // A Complete message is sent everytime a root render is triggered on the page.
+          if (msg.type === "Complete") {
+            if (msg.origin.frame !== this.activeFrame()) {
+              return;
+            }
+            if (!(Array.isArray(msg.data) && msg.data.every((val) => typeof val === "string"))) {
+              return;
+            }
+            // This determines which components will have a short highlight effect in the tree
+            // to indicate they have been rendered
+            this._components.renderPaths.add(JSON.stringify(msg.data));
+            if (!rootRendersTimeout) {
+              this._components.loadComponentsTree(true);
+            }
+            clearTimeout(rootRendersTimeout);
+            rootRendersTimeout = setTimeout(() => {
+              rootRendersTimeout = null;
+              this._components.renderPaths.clear();
+              this._components.loadComponentsTree(true);
+            }, 100);
+          }
+          // Highlight the hovered component in the tree without loading its details,
+          // keeping the SelectElement handler fast during rapid mouseover events.
+          if (msg.type === "SelectElement") {
+            if (!(Array.isArray(msg.data) && msg.data.every((val) => typeof val === "string"))) {
+              return;
+            }
+            this._components.hoverSelectComponent(msg.data);
+          }
+          // Stop the DOM element selector tool upon receiving the StopSelector message.
+          // Now that the user has clicked, load full details for the last hovered component.
+          if (msg.type === "StopSelector") {
+            this._components.activeSelector.set(false);
+            const lastPath = this._components.lastHoveredPath;
+            if (lastPath) {
+              this._components.lastHoveredPath = null;
+              this._components.selectComponent(lastPath, false);
+            }
+          }
+          // Logic for recording an event when the event message is received
+          if (msg.type === "Event") {
+            this._profiler._loadEvents(msg.data);
+          }
+          // If we know a new iframe has been added to the page, load scripts into it and update the
+          // frames list if it has been directly loaded.
+          if (msg.type === "NewIFrame") {
+            const isLoaded = await loadScripts(msg.data);
+            if (isLoaded) {
+              this.updateIFrameList();
+            }
+          }
+        });
       }
     });
   }
-});
 
-// Load all settings from the chrome sync storage
-async function loadSettings() {
-  let storage = await browserInstance.storage.local.get();
-  // Darkmode
-  if (storage.owlDevtoolsDarkMode === undefined) {
-    // Load dark mode based on the global settings of the chrome devtools
-    darkMode = browserInstance.devtools.panels.themeName === "dark";
-  } else {
-    darkMode = storage.owlDevtoolsDarkMode;
-  }
-  store.settings.darkMode = darkMode;
-  if (darkMode) {
-    document.querySelector("html").classList.add("dark-mode");
-  } else {
-    document.querySelector("html").classList.remove("dark-mode");
-  }
-  // Components toggle blacklist
-  if (storage.owlDevtoolsComponentsToggleBlacklist !== undefined) {
-    store.settings.componentsToggleBlacklist = new Set(
-      storage.owlDevtoolsComponentsToggleBlacklist
-    );
-  }
-  // Observed variables
-  if (storage.observedVariables) {
-    store.observedVariables = [];
-    for (const path of storage.observedVariables) {
-      store.observedVariables.push({
-        path: [...path],
-        visible: false,
-      });
-    }
-  }
-}
-
-// Function to handle and store a batch of events coming from the page
-function loadEvents(events) {
-  if (!Array.isArray(events)) {
-    return;
-  }
-  for (const event of events) {
-    // Check if the event data has the right shape for security purpose
-    if (
-      !isObjectWithShape(event, {
-        type: "string",
-        component: "string",
-        key: "string",
-        path: "object",
-        time: "number",
-        id: "number",
-      }) ||
-      !(Array.isArray(event.path) && event.path.every((val) => typeof val === "string"))
-    ) {
-      return;
-    }
-    event.origin = null;
-    event.toggled = false;
-    event.isLast = false;
-    // Logic to retrace the origin of the event if it is not a root render event
-    if (!event.type.includes("render")) {
-      for (let i = store.events.length - 1; i >= 0; i--) {
-        if (
-          !store.events[i].origin &&
-          event.path.join("/").includes(store.events[i].path.join("/"))
-        ) {
-          event.origin = toRaw(store.events[i]);
-          break;
-        }
-        if (
-          store.events[i].origin &&
-          event.path.join("/").includes(store.events[i].origin.path.join("/"))
-        ) {
-          event.origin = toRaw(store.events[i].origin);
-          break;
-        }
-      }
-    }
-    // Add the event to the events tree immediatly when the events view is in tree mode
-    if (store.eventsTreeView) {
-      let eventNode = Object.assign({}, event);
-      eventNode.children = [];
-      eventNode.toggled = true;
-      if (!eventNode.origin) {
-        eventNode.depth = 0;
-        store.eventsTree.push(eventNode);
-      } else {
-        // Similar to when we're constructing the whole tree
-        for (let i = store.eventsTree.length - 1; i >= 0; i--) {
-          if (eventNode.origin.path.join("/") === store.eventsTree[i].path.join("/")) {
-            const relativePath = eventNode.path.slice(
-              store.eventsTree[i].path.length,
-              eventNode.path.length - 1
-            );
-            let parent = store.eventsTree[i];
-            for (const key of relativePath) {
-              parent = parent.children.find((child) => child.key === key);
-            }
-            eventNode.depth = parent.depth + 1;
-            parent.children.push(eventNode);
-            break;
-          }
-        }
-      }
-    }
-    // Make sure we add the event while keeping the whole list ordered by id
-    addEventSorted(event);
-  }
-  store.events[store.events.length - 1].isLast = true;
-}
-
-// Deselect component and remove highlight on all children
-function deselectComponent(component) {
-  component.selected = false;
-  component.highlighted = false;
-  for (const child of component.children) {
-    deselectComponent(child);
-  }
-}
-
-// Used to check if the given object has the right shape
-function isObjectWithShape(obj, shape) {
-  if (typeof obj !== "object" || Array.isArray(obj)) {
-    return false;
-  }
-
-  return Object.keys(shape).every(
-    (key) => obj.hasOwnProperty(key) && typeof obj[key] === shape[key]
-  );
-}
-
-// A binary search algorith to efficiently add an event in the events array while keeping it sorted
-function addEventSorted(item) {
-  let low = 0;
-  let high = store.events.length;
-  while (low < high) {
-    let mid = Math.floor((low + high) / 2);
-    if (store.events[mid].id < item.id) {
-      low = mid + 1;
+  async _loadSettings() {
+    let storage = await browserInstance.storage.local.get();
+    let dm;
+    if (storage.owlDevtoolsDarkMode === undefined) {
+      dm = browserInstance.devtools.panels.themeName === "dark";
     } else {
-      high = mid;
+      dm = storage.owlDevtoolsDarkMode;
     }
-  }
-  store.events.splice(low, 0, item);
-}
-
-// Apply highlight recursively to all children of a selected component
-function highlightChildren(component) {
-  component.children.forEach((child) => {
-    child.highlighted = true;
-    highlightChildren(child);
-  });
-}
-
-// Expand the node given in entry and all of its children
-function expandNodes(node, blacklist = false) {
-  if (blacklist && store.settings.componentsToggleBlacklist.has(node.name)) {
-    node.toggled = false;
-  } else {
-    node.toggled = true;
-  }
-  for (const child of node.children) {
-    expandNodes(child, blacklist);
-  }
-}
-
-// This function transforms the env part of the details such that all env keys are not
-// greyed out in the UI at their first occurence
-function keepEnvLit(details) {
-  let alreadyMet = new Set();
-  for (let i = 0; i < details.env.children.length; i++) {
-    if (i < details.env.children.length - 1) {
-      alreadyMet.add(details.env.children[i].name);
+    this.darkMode.set(dm);
+    if (dm) {
+      document.querySelector("html").classList.add("dark-mode");
     } else {
-      let lastElement = details.env.children[i];
-      while (lastElement.children.at(-1)?.name === "[[Prototype]]") {
-        for (const [index, child] of lastElement.children.entries()) {
-          if (index < lastElement.children.length - 1) {
-            if (!alreadyMet.has(child.name)) {
-              child.keepLit = true;
-              alreadyMet.add(child.name);
-            }
-          } else {
-            lastElement = child;
-          }
-        }
+      document.querySelector("html").classList.remove("dark-mode");
+    }
+    if (storage.owlDevtoolsComponentsToggleBlacklist !== undefined) {
+      this.componentsToggleBlacklist.set(new Set(storage.owlDevtoolsComponentsToggleBlacklist));
+    }
+    if (storage.observedVariables) {
+      const vars = [];
+      for (const path of storage.observedVariables) {
+        vars.push({ path: [...path], visible: false });
       }
+      this._components.observedVariables.set(proxy(vars));
     }
   }
 }
 
-// Fold the node given in entry and all of its children
-function foldNodes(node) {
-  node.toggled = false;
-  for (const child of node.children) {
-    foldNodes(child);
-  }
-}
+// -------------------------------------------------------------------------
+// Standalone helper functions (exported for use by sub-plugins)
+// -------------------------------------------------------------------------
 
-// Load the scripts in the specified frame
-async function loadScripts(frameUrl) {
-  return await evalInWindow(globalHook, frameUrl);
-}
-
-// Shallow array equality
-function arraysEqual(arr1, arr2) {
-  if (arr1.length !== arr2.length) {
-    // Check if the arrays are of the same length
-    return false;
-  }
-  return arr1.every((val, i) => val === arr2[i]); // Compare each element of the arrays
-}
-
-async function getTabURL() {
-  if (IS_FIREFOX) {
-    // It is not possible to run getActiveTabURL inside the devtools when using firefox so we ask the background to execute it instead
-    const response = await browserInstance.runtime.sendMessage({ type: "getActiveTabURL" });
-    return response.result;
-  } else {
-    return await getActiveTabURL();
-  }
-}
-
-// General method for executing functions from the loaded scripts in the right frame of the page
-// using the __OWL__DEVTOOLS_GLOBAL_HOOK__. Take the function's args as an array.
-async function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
+export async function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
   const stringifiedArgs = [...args].map((arg) => {
     arg = JSON.stringify(arg);
     return arg;
@@ -1030,8 +348,7 @@ async function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
   });
 }
 
-// General method for executing code in the window using chrome.devtools.inspectedWindow.eval.
-async function evalInWindow(code, frameUrl = "top") {
+export async function evalInWindow(code, frameUrl = "top") {
   return await new Promise((resolve, reject) => {
     if (frameUrl !== "top") {
       browserInstance.devtools.inspectedWindow.eval(
@@ -1057,20 +374,15 @@ async function evalInWindow(code, frameUrl = "top") {
   });
 }
 
-function copyToClipboard(text) {
-  // This is crappy but it seems like document.execCommand is the only remaining way to
-  // copy text to clipboard in a devtools extension (even though it is marked as deprecated)
-  // since navigator.clipboard.writeText has permission issues inside iframes (and the devtools
-  // panel is mounted inside an iframe)
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    document.execCommand("copy");
-  } catch (err) {
-    console.error("Copy failed", err);
+async function loadScripts(frameUrl) {
+  return await evalInWindow(globalHook, frameUrl);
+}
+
+async function getTabURL() {
+  if (IS_FIREFOX) {
+    const response = await browserInstance.runtime.sendMessage({ type: "getActiveTabURL" });
+    return response.result;
+  } else {
+    return await getActiveTabURL();
   }
-  document.body.removeChild(textarea);
 }

--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -193,6 +193,32 @@
       };
     }
 
+    // Returns the OWL version string for the given app
+    getAppVersion(app) {
+      return app.__proto__.constructor?.version || "<2.0.8";
+    }
+
+    // Returns a normalized array of root ComponentNodes for the given app.
+    // OWL 2: main root at index 0, subRoots at index 1+.
+    // OWL 3: all roots from app.roots.
+    getRoots(app) {
+      const version = this.getAppVersion(app);
+      if (version.startsWith("3")) {
+        return [...app.roots].map((root) => root.node);
+      }
+      // OWL 2: main root at index 0, subRoots at index 1+
+      const roots = [];
+      if (app.root) {
+        roots.push(app.root);
+      }
+      if (app.subRoots) {
+        for (const subRoot of app.subRoots) {
+          roots.push(subRoot);
+        }
+      }
+      return roots;
+    }
+
     initDevtools(frame = "top") {
       if (!this.devtoolsInit) {
         document.addEventListener("mouseover", this.HTMLSelector, { capture: true });
@@ -246,35 +272,49 @@
     patchAppMethods() {
       let app;
       for (const appItem of this.apps) {
-        if (appItem.root) {
+        if (this.getRoots(appItem).length > 0) {
           app = appItem;
+          break;
         }
       }
-      if (!app.root) {
+      if (!app || this.getRoots(app).length === 0) {
         return;
       }
       const self = this;
       const originalFlush = app.scheduler.constructor.prototype.flush;
       let inFlush = false;
-      let _render = false;
+      // Per-fiber symbol to track whether _render() was actually called for this
+      // fiber's render() invocation. A shared boolean flag is unreliable in OWL 3
+      // because setCounter(0) → flush() → other fibers' render() can all run
+      // synchronously inside one render() call, resetting a shared flag before
+      // the outer render() reads it back.
+      const renderCalledKey = Symbol("owlDevtoolsRenderCalled");
       app.scheduler.constructor.prototype.flush = function () {
-        // Used to know when a render is triggered inside the flush method or not
+        // Used to know when a render is triggered inside the flush method or not.
+        // Save/restore rather than hard-reset to false so recursive flush() calls
+        // (which occur in OWL 3 when setCounter(0) fires flush() from inside
+        // _render()) do not prematurely clear the flag for the outer caller.
+        const wasInFlush = inFlush;
         inFlush = true;
         originalFlush.call(this, ...arguments);
-        inFlush = false;
+        inFlush = wasInFlush;
       };
       const originalRender = self.Fiber.prototype.render;
       self.Fiber.prototype.render = function () {
         const id = self.eventId++;
-        _render = false;
+        // Reset the per-fiber flag before calling the original render.
+        this[renderCalledKey] = false;
         let flushed = false;
         // We know if a render comes from flush before calling the render method
         if (this instanceof self.RootFiber && inFlush) {
           flushed = true;
         }
 
-        // patch the renderFn function from the node to only measure the time
-        // spent in the template, not in additional work, such as flushing scheduler
+        // Patch the renderFn to measure time and detect that an actual render
+        // happened (as opposed to a delayed render where renderFn is never called).
+        // This works for both OWL 2 (where _render() calls renderFn) and OWL 3
+        // (where render() calls renderFn directly — there is no _render() method).
+        const fiber = this;
         const node = this.node;
         const nodeRenderFn = node.renderFn;
         let time = 0;
@@ -284,12 +324,19 @@
           time = performance.now() - before;
           // unpatch the node render function
           node.renderFn = nodeRenderFn;
+          // Mark the fiber: renderFn was actually invoked (not a delayed render).
+          fiber[renderCalledKey] = true;
           return result;
         };
 
         originalRender.call(this, ...arguments);
-        if (_render && self.traceRenderings && this instanceof self.RootFiber) {
-          console.groupCollapsed(`Rendering <${this.node.name}>`);
+        // OWL 3: ComponentNode has no .name getter; use component.constructor.name instead.
+        // The ?? fallback keeps OWL 2 compatibility where node.name was a direct property.
+        const nodeName = this.node.component?.constructor?.name ?? this.node.name ?? "";
+        // Read the per-fiber flag: true means renderFn was called for this fiber.
+        const didRender = this[renderCalledKey];
+        if (didRender && self.traceRenderings && this instanceof self.RootFiber) {
+          console.groupCollapsed(`Rendering <${nodeName}>`);
           console.trace();
           console.groupEnd();
         }
@@ -299,19 +346,19 @@
           if (flushed) {
             self.eventsBatch.push({
               type: "render (flushed)",
-              component: this.node.name,
+              component: nodeName,
               key: this.node.parentKey ? this.node.parentKey : "",
               path: path,
               time: time,
               id: id,
             });
-            // if _render is called, it is a proper render (and not a delayed one)
-          } else if (_render) {
+            // if renderFn was called, it is a proper render (and not a delayed one)
+          } else if (didRender) {
             // A render on a RootFiber is a root render and can propagate other renders to its children
             if (this instanceof self.RootFiber) {
               self.eventsBatch.push({
                 type: this.deep ? "render (deep)" : "render",
-                component: this.node.name,
+                component: nodeName,
                 key: this.node.parentKey ? this.node.parentKey : "",
                 path: path,
                 time: time,
@@ -321,7 +368,7 @@
             } else if (this.node.status === 0) {
               self.eventsBatch.push({
                 type: "create",
-                component: this.node.name,
+                component: nodeName,
                 key: this.node.parentKey ? this.node.parentKey : "",
                 path: path,
                 time: time,
@@ -331,18 +378,18 @@
             } else {
               self.eventsBatch.push({
                 type: "update",
-                component: this.node.name,
+                component: nodeName,
                 key: this.node.parentKey ? this.node.parentKey : "",
                 path: path,
                 time: time,
                 id: id,
               });
             }
-            // _render has not been called so it is a delayed render that could be flushed later on
+            // renderFn not called: it is a delayed render that could be flushed later on
           } else {
             self.eventsBatch.push({
               type: "render (delayed)",
-              component: this.node.name,
+              component: nodeName,
               key: this.node.parentKey ? this.node.parentKey : "",
               path: path,
               time: time,
@@ -351,20 +398,19 @@
           }
         }
       };
-      const original_Render = self.Fiber.prototype._render;
-      self.Fiber.prototype._render = function () {
-        _render = true;
-        original_Render.call(this, ...arguments);
-      };
       // Signals when a component is destroyed
-      const originalDestroy = app.root.constructor.prototype._destroy;
-      app.root.constructor.prototype._destroy = function () {
+      // All component nodes share the same prototype, so patching one suffices
+      const firstRoot = this.getRoots(app)[0];
+      const originalDestroy = firstRoot.constructor.prototype._destroy;
+      firstRoot.constructor.prototype._destroy = function () {
         if (self.recordEvents) {
           const path = self.getComponentPath(this);
+          // OWL 3: ComponentNode has no .name; use component.constructor.name.
+          // parentKey is string|null in OWL 3; normalise null to "" for validation.
           const event = {
             type: "destroy",
-            component: this.name,
-            key: this.parentKey,
+            component: this.component?.constructor?.name ?? this.name ?? "",
+            key: this.parentKey ?? "",
             path: path,
             time: 0,
             id: self.eventId++,
@@ -446,6 +492,15 @@
       }
       this.traceRenderings = value;
       return this.traceRenderings;
+    }
+
+    // Returns whether subscription tracing is supported in the current OWL version.
+    supportsSubscriptionTracing() {
+      const apps = [...this.apps];
+      if (!apps.length) {
+        return false;
+      }
+      return !this.getAppVersion(apps[0]).startsWith("3");
     }
 
     toggleSubscriptionTracing(value) {
@@ -629,14 +684,25 @@
     HTMLSelector = (ev) => {
       if (this.enabledSelector) {
         const target = ev.target;
-        if (!this.currentSelectedElement || !target.isEqualNode(this.currentSelectedElement)) {
-          const path = this.getElementPath(target);
-          this.highlightComponent(path);
+        if (this.currentSelectedElement !== target) {
           this.currentSelectedElement = target;
-          window.top.postMessage({
-            source: "owl-devtools",
-            type: "SelectElement",
-            data: path,
+          // Throttle to one computation per animation frame: if the mouse crosses several
+          // elements in the same frame we only process the last one.
+          if (this._selectorRafId) {
+            cancelAnimationFrame(this._selectorRafId);
+          }
+          this._selectorRafId = requestAnimationFrame(() => {
+            this._selectorRafId = null;
+            if (!this.enabledSelector) {
+              return;
+            }
+            const path = this.getElementPath(this.currentSelectedElement);
+            this.highlightComponent(path);
+            window.top.postMessage({
+              source: "owl-devtools",
+              type: "SelectElement",
+              data: path,
+            });
           });
         }
       } else {
@@ -654,6 +720,10 @@
     // Diasble the HTML selector tool
     disableHTMLSelector = (ev = undefined) => {
       this.enabledSelector = false;
+      if (this._selectorRafId) {
+        cancelAnimationFrame(this._selectorRafId);
+        this._selectorRafId = null;
+      }
       if (ev) {
         if (!ev.isTrusted) {
           return;
@@ -706,6 +776,13 @@
               obj = "Exception: " + e.toString();
             }
             break;
+          case "signal":
+          case "computed":
+            obj = obj[key.value]();
+            break;
+          case "proxy":
+            obj = obj[key.value];
+            break;
           case "prototype getter":
           case "set entry":
           case "map entry":
@@ -754,6 +831,28 @@
         return this.getObject(componentNode, path.slice(index));
       }
       return "Exception: component not found";
+    }
+
+    isSignal(obj) {
+      if (typeof obj !== "function") return false;
+      for (const sym of Object.getOwnPropertySymbols(obj)) {
+        if (sym.toString() === "Symbol(Atom)" && obj[sym]?.type === "signal") return true;
+      }
+      return false;
+    }
+
+    isComputed(obj) {
+      if (typeof obj !== "function") return false;
+      for (const sym of Object.getOwnPropertySymbols(obj)) {
+        if (sym.toString() === "Symbol(Atom)" && obj[sym] && obj[sym].type !== "signal")
+          return true;
+      }
+      return false;
+    }
+
+    isReactiveProxy(obj) {
+      if (typeof obj !== "object" || obj === null) return false;
+      return this.toRaw(obj) !== obj;
     }
 
     // Returns a modified version of an object node that has compatible format with the devtools ObjectTreeElement component
@@ -905,19 +1004,25 @@
         ).target;
         path = path.slice(3);
       } else {
-        // Everything here is in component if it is not an app so remove this key of the path in the former case
-        if (objPathIndex > 1) {
+        // OWL 2 non-app paths have a "component" intermediate key to skip; OWL 3 props paths do not.
+        if (objPathIndex > 1 && path[0]?.value === "component") {
           path.shift();
         }
         // the value is either "props" or "env" here
-        if (objType !== "instance" && objType !== "hook") {
-          obj = oldTree[path[0].value].children;
-          path.shift();
-          // there is nothing otherwise but extension side it is in instance
-        } else if (objType === "instance") {
+        if (objType === "instance") {
           obj = oldTree.instance.children;
-        } else {
+        } else if (objType === "reactiveValue") {
+          obj = oldTree.reactiveValues.children;
+        } else if (objType === "hook") {
           obj = oldTree.hooks.children;
+          path.shift();
+        } else if (objType === "props") {
+          // Always use oldTree.props: OWL 3 may use "defaultProps" as the path key but all
+          // props are stored together under oldTree.props in the serialized tree.
+          obj = oldTree.props.children;
+          path.shift();
+        } else {
+          obj = oldTree[path[0].value].children;
           path.shift();
         }
         // the first element here is directly in an array instead of a children array
@@ -1133,8 +1238,11 @@
       let node;
       // If the path is longer and its first item is indeed an app number, it is a regular path
       if (!isNaN(path[0])) {
-        // The second element in the path will always be the root of the app
-        node = [...this.apps][path[0]]?.root;
+        // The second element in the path is the root index
+        const app = [...this.apps][path[0]];
+        if (!app) return null;
+        const roots = this.getRoots(app);
+        node = roots[parseInt(path[1], 10)];
         if (!node) {
           return null;
         }
@@ -1153,14 +1261,18 @@
         // are a series of component names and indexes separated by slashes
       } else {
         const simplifiedPathArray = path[0].split("/");
-        node = [...this.apps][simplifiedPathArray[0]]?.root;
-        if (node.name !== simplifiedPathArray[1]) {
+        const app = [...this.apps][simplifiedPathArray[0]];
+        if (!app) return null;
+        const roots = this.getRoots(app);
+        const rootIndex = parseInt(simplifiedPathArray[1], 10);
+        node = roots[rootIndex];
+        if (!node || this.getNodeName(node) !== simplifiedPathArray[2]) {
           return null;
         }
-        for (let i = 2; i < simplifiedPathArray.length; i += 2) {
+        for (let i = 3; i < simplifiedPathArray.length; i += 2) {
           const key = Reflect.ownKeys(node.children)[simplifiedPathArray[i]];
           node = node.children[key];
-          if (node.name !== simplifiedPathArray[i + 1]) {
+          if (this.getNodeName(node) !== simplifiedPathArray[i + 1]) {
             return null;
           }
         }
@@ -1179,38 +1291,54 @@
         path = this.getElementPath($0);
       }
       component.path = path;
-      let node = this.getComponentNode(path) || [...this.apps].find((app) => app.root)?.root;
+      let node = this.getComponentNode(path);
+      if (!node) {
+        // Fallback: find the first available root
+        for (const app of this.apps) {
+          const roots = this.getRoots(app);
+          if (roots.length > 0) {
+            node = roots[0];
+            break;
+          }
+        }
+      }
       if (!node) {
         return null;
       }
       // A path with only the app index indicates that the component is an App instead
       const isApp = path.length === 1;
       if (isApp) {
-        component.version = node.__proto__.constructor?.version
-          ? node.__proto__.constructor.version
-          : "<2.0.8";
+        component.version = this.getAppVersion(node);
       }
       // Load props of the component
-      const props = isApp ? node.props : node.component.props;
       component.props = { toggled: oldTree ? oldTree.props.toggled : true, children: [] };
       component.name = isApp
         ? node?.name
           ? `App (${node.name})`
           : "App " + (Number(path[0]) + 1)
         : node.component.constructor.name;
-      const propsPath = isApp
-        ? [...path, { type: "item", value: "props" }]
-        : [...path, { type: "item", value: "component" }, { type: "item", value: "props" }];
-      Reflect.ownKeys(props)
-        .sort(compareKeys)
-        .forEach((key) => {
+      const appVersion = this.getAppVersion([...this.apps][path[0]]);
+      const isOwl3 = appVersion.startsWith("3");
+      if (isOwl3) {
+        // In Owl 3, component.props uses getters that wrap node.props/defaultProps. Read the raw
+        // values directly from the ComponentNode so they display as plain values, not functions.
+        const rawProps = node.props || {};
+        const defaults = node.defaultProps || {};
+        const allPropKeys = [
+          ...new Set([...Reflect.ownKeys(rawProps), ...Reflect.ownKeys(defaults)]),
+        ].sort(compareKeys);
+        allPropKeys.forEach((key) => {
+          const inRaw = key in rawProps && rawProps[key] !== undefined;
+          const parentObj = inRaw ? rawProps : defaults;
+          const parentPathKey = inRaw ? "props" : "defaultProps";
+          const keyPropsPath = [...path, { type: "item", value: parentPathKey }];
           let oldBranch = oldTree?.props.children[component.props.children.length];
           const property = this.serializeObjectChild(
-            props,
+            parentObj,
             { type: "item", value: key, childIndex: component.props.children.length },
             0,
             "props",
-            propsPath,
+            keyPropsPath,
             oldBranch,
             oldTree
           );
@@ -1218,63 +1346,89 @@
             component.props.children.push(property);
           }
         });
+      } else {
+        const props = isApp ? node.props : node.component.props;
+        const propsPath = isApp
+          ? [...path, { type: "item", value: "props" }]
+          : [...path, { type: "item", value: "component" }, { type: "item", value: "props" }];
+        Reflect.ownKeys(props || {})
+          .sort(compareKeys)
+          .forEach((key) => {
+            let oldBranch = oldTree?.props.children[component.props.children.length];
+            const property = this.serializeObjectChild(
+              props,
+              { type: "item", value: key, childIndex: component.props.children.length },
+              0,
+              "props",
+              propsPath,
+              oldBranch,
+              oldTree
+            );
+            if (property) {
+              component.props.children.push(property);
+            }
+          });
+      }
+      let obj;
       // Load env of the component
       const env = isApp ? node.env : node.component.env;
-      component.env = { toggled: oldTree ? oldTree.env.toggled : false, children: [] };
-      const envPath = isApp
-        ? [...path, { type: "item", value: "env" }]
-        : [...path, { type: "item", value: "component" }, { type: "item", value: "env" }];
-      Reflect.ownKeys(env)
-        .sort(compareKeys)
-        .forEach((key) => {
-          let oldBranch = oldTree?.env.children[component.env.children.length];
-          const envElement = this.serializeObjectChild(
-            env,
-            { type: "item", value: key, childIndex: component.env.children.length },
-            0,
-            "env",
-            envPath,
-            oldBranch,
-            oldTree
-          );
-          if (envElement) {
-            component.env.children.push(envElement);
+      if (env) {
+        component.env = { toggled: oldTree ? oldTree.env.toggled : false, children: [] };
+        const envPath = isApp
+          ? [...path, { type: "item", value: "env" }]
+          : [...path, { type: "item", value: "component" }, { type: "item", value: "env" }];
+        Reflect.ownKeys(env)
+          .sort(compareKeys)
+          .forEach((key) => {
+            let oldBranch = oldTree?.env.children[component.env.children.length];
+            const envElement = this.serializeObjectChild(
+              env,
+              { type: "item", value: key, childIndex: component.env.children.length },
+              0,
+              "env",
+              envPath,
+              oldBranch,
+              oldTree
+            );
+            if (envElement) {
+              component.env.children.push(envElement);
+            }
+          });
+        // Load env getters
+        let obj = Object.getPrototypeOf(env);
+        Reflect.ownKeys(obj).forEach((key) => {
+          if (
+            key !== "__proto__" &&
+            Object.getOwnPropertyDescriptor(obj, key).hasOwnProperty("get")
+          ) {
+            let child = {
+              name: key,
+              depth: 0,
+              toggled: false,
+              objectType: "env",
+              path: [
+                ...envPath,
+                { type: "prototype getter", value: key, childIndex: component.env.children.length },
+              ],
+              contentType: "getter",
+              content: "(...)",
+              hasChildren: false,
+              children: [],
+            };
+            component.env.children.push(child);
           }
         });
-      // Load env getters
-      let obj = Object.getPrototypeOf(env);
-      Reflect.ownKeys(obj).forEach((key) => {
-        if (
-          key !== "__proto__" &&
-          Object.getOwnPropertyDescriptor(obj, key).hasOwnProperty("get")
-        ) {
-          let child = {
-            name: key,
-            depth: 0,
-            toggled: false,
-            objectType: "env",
-            path: [
-              ...envPath,
-              { type: "prototype getter", value: key, childIndex: component.env.children.length },
-            ],
-            contentType: "getter",
-            content: "(...)",
-            hasChildren: false,
-            children: [],
-          };
-          component.env.children.push(child);
-        }
-      });
-      const envPrototype = this.serializeObjectChild(
-        env,
-        { type: "prototype", childIndex: component.env.children.length },
-        0,
-        "env",
-        envPath,
-        oldTree?.env[component.env.children.length],
-        oldTree
-      );
-      component.env.children.push(envPrototype);
+        const envPrototype = this.serializeObjectChild(
+          env,
+          { type: "prototype", childIndex: component.env.children.length },
+          0,
+          "env",
+          envPath,
+          oldTree?.env[component.env.children.length],
+          oldTree
+        );
+        component.env.children.push(envPrototype);
+      }
       // Load instance of the component
       const instance = isApp ? node : node.component;
       component.instance = { toggled: oldTree ? oldTree.instance.toggled : true, children: [] };
@@ -1340,10 +1494,90 @@
       );
       component.instance.children.push(instancePrototype);
 
-      // Load subscriptions of the component
-      if (isApp) {
+      // Load reactive values of the component (owl v3 only): signals, computed, and reactive proxies
+      component.reactiveValues = {
+        toggled: oldTree ? (oldTree.reactiveValues?.toggled ?? true) : true,
+        children: [],
+      };
+      if (isOwl3 && !isApp) {
+        Reflect.ownKeys(instance)
+          .sort(compareKeys)
+          .forEach((key) => {
+            if (["env", "props"].includes(key)) return;
+            const val = instance[key];
+            let pathType, reactiveValue;
+            if (this.isSignal(val)) {
+              pathType = "signal";
+              reactiveValue = this.toRaw(val());
+            } else if (this.isComputed(val)) {
+              pathType = "computed";
+              reactiveValue = this.toRaw(val());
+            } else if (this.isReactiveProxy(val)) {
+              pathType = "proxy";
+              reactiveValue = this.toRaw(val);
+            } else {
+              return;
+            }
+            const childIndex = component.reactiveValues.children.length;
+            const reactivePath = [...instancePath, { type: pathType, value: key, childIndex }];
+            let contentType, hasChildren;
+            if (reactiveValue === null || reactiveValue === undefined) {
+              contentType = reactiveValue === null ? "object" : "undefined";
+              hasChildren = false;
+            } else if (reactiveValue instanceof Map) {
+              contentType = "map";
+              hasChildren = true;
+            } else if (reactiveValue instanceof Set) {
+              contentType = "set";
+              hasChildren = true;
+            } else if (Array.isArray(reactiveValue)) {
+              contentType = "array";
+              hasChildren = reactiveValue.length > 0;
+            } else if (typeof reactiveValue === "function") {
+              contentType = "function";
+              hasChildren = true;
+            } else if (typeof reactiveValue === "object") {
+              contentType = "object";
+              hasChildren =
+                Object.keys(reactiveValue).length > 0 ||
+                Object.getOwnPropertySymbols(reactiveValue).length > 0;
+            } else {
+              contentType = typeof reactiveValue;
+              hasChildren = false;
+            }
+            const oldBranch = oldTree?.reactiveValues?.children[childIndex];
+            const reactiveNode = {
+              name: `${typeof key === "symbol" ? key.toString() : key} (${pathType[0].toUpperCase() + pathType.slice(1)})`,
+              depth: 0,
+              toggled: oldBranch?.toggled ?? false,
+              objectType: "reactiveValue",
+              contentType,
+              content:
+                reactiveValue == null
+                  ? reactiveValue === null
+                    ? "null"
+                    : "undefined"
+                  : this.serializer.serializeContent(reactiveValue, contentType),
+              hasChildren,
+              path: reactivePath,
+              children: [],
+            };
+            if (reactiveNode.toggled) {
+              reactiveNode.children = this.loadObjectChildren(
+                reactivePath,
+                0,
+                contentType,
+                "reactiveValue",
+                oldTree
+              );
+            }
+            component.reactiveValues.children.push(reactiveNode);
+          });
+      }
+      if (isApp || isOwl3) {
+        // OWL 3 does not have node.subscriptions
         component.subscriptions = {
-          toggled: oldTree ? oldTree.subscriptions.toggled : true,
+          toggled: oldTree ? oldTree.subscriptions?.toggled : true,
           children: [],
         };
       } else {
@@ -1527,9 +1761,9 @@
     }
     // Triggers the highlight effect around the specified component.
     highlightComponent(path) {
-      // Try to highlight the root component of the app if function called on an app
+      // Try to highlight the first root component of the app if function called on an app
       if (path.length === 1) {
-        path.push("root");
+        path.push("0");
       }
       let component = this.getComponentNode(path);
       if (!component) {
@@ -1570,7 +1804,10 @@
             component.root.render();
           }
         } else if (objectType === "env") {
-          [...this.apps][path[0]].root.render(true);
+          const roots = this.getRoots([...this.apps][path[0]]);
+          for (const rootNode of roots) {
+            rootNode.render(true);
+          }
         }
       }
     }
@@ -1581,41 +1818,35 @@
         return null;
       }
       const results = this.getDOMElementsRecursive(node);
-      let hasElementInChildren = false;
+      let containsElement = false;
       for (const result of results) {
-        if (result.isEqualNode(element)) {
+        if (result === element) {
           return path;
         }
         if (result.contains(element)) {
-          hasElementInChildren = true;
+          containsElement = true;
         }
       }
-      if (hasElementInChildren) {
+      if (containsElement) {
         for (const [key, child] of Object.entries(node.children)) {
           const result = this.searchElement(child, path.concat([key]), element);
           if (result) {
             return result;
           }
         }
+        // Element is inside this component's DOM but not owned by any child component.
+        return path;
       }
       return null;
     }
     // Returns the path to the component which is currently being inspected
     getElementPath(element) {
       if (element) {
-        // Create an array with the html element and all its successive parents
-        const parentsList = [element];
-        if (element.tagName !== "BODY") {
-          while (element && element?.parentElement?.tagName !== "BODY") {
-            element = element.parentElement;
-            parentsList.push(element);
-          }
-        }
         const appsArray = [...this.apps];
-        // Try to find a correspondance between the elements in the array and the owl component, stops at first result found
-        for (const elem of parentsList) {
-          for (const [index, app] of appsArray.entries()) {
-            const inspectedPath = this.searchElement(app.root, ["root"], elem);
+        for (const [index, app] of appsArray.entries()) {
+          const roots = this.getRoots(app);
+          for (const [rootIdx, rootNode] of roots.entries()) {
+            const inspectedPath = this.searchElement(rootNode, [rootIdx.toString()], element);
             if (inspectedPath) {
               inspectedPath.unshift(index.toString());
               return inspectedPath;
@@ -1624,8 +1855,13 @@
         }
       }
       // If nothing was found, return the path of the first root component found in the apps
-      const appIndex = [...this.apps].findIndex((app) => app.root);
-      return [appIndex.toString(), "root"];
+      const appsArray = [...this.apps];
+      for (const [appIndex, app] of appsArray.entries()) {
+        if (this.getRoots(app).length > 0) {
+          return [appIndex.toString(), "0"];
+        }
+      }
+      return ["0", "0"];
     }
     // Returns the tree of components of the inspected page in a parsed format
     // Use inspectedPath to specify the path of the selected component
@@ -1648,41 +1884,43 @@
           toggled: true,
           selected: false,
           highlighted: false,
-          version: app.__proto__.constructor?.version
-            ? app.__proto__.constructor.version
-            : "<2.0.8",
+          version: this.getAppVersion(app),
           children: [],
         };
-        if (app.root) {
+        if (oldTree) {
+          appNode.toggled = oldTree.toggled;
+        }
+        // If no path is provided, it defaults to the target of the inspect element action
+        if (!inspectedPath) {
+          inspectedPath = this.getElementPath($0);
+        }
+        if (inspectedPath.join("/") === index.toString()) {
+          appNode.selected = true;
+        }
+        const roots = this.getRoots(app);
+        roots.forEach((rootNode, rootIdx) => {
           const root = {
-            name: app.root.component.constructor.name,
-            path: [index.toString(), "root"],
-            key: "",
+            name: rootNode.component.constructor.name,
+            path: [index.toString(), rootIdx.toString()],
+            key: rootIdx.toString(),
             depth: 1,
             toggled: true,
             selected: false,
             highlighted: false,
           };
-          if (oldTree) {
-            appNode.toggled = oldTree.toggled;
-            oldTree = oldTree.children[0];
+          const oldChild = oldTree?.children?.[rootIdx];
+          if (oldChild) {
+            root.toggled = oldChild.toggled;
           }
-          if (oldTree) {
-            root.toggled = oldTree.toggled;
-          }
-          // If no path is provided, it defaults to the target of the inspect element action
-          if (!inspectedPath) {
-            inspectedPath = this.getElementPath($0);
-          }
-          if (inspectedPath.join("/") === index.toString()) {
-            appNode.selected = true;
-            root.highlighted = true;
-          } else if (inspectedPath.join("/") === index.toString() + "/root") {
+          const rootPathString = index.toString() + "/" + rootIdx.toString();
+          if (inspectedPath.join("/") === rootPathString) {
             root.selected = true;
+          } else if (appNode.selected) {
+            root.highlighted = true;
           }
-          root.children = this.fillTree(app.root, root, inspectedPath.join("/"), oldTree);
+          root.children = this.fillTree(rootNode, root, inspectedPath.join("/"), oldChild);
           appNode.children.push(root);
-        }
+        });
         return appNode;
       });
       const component = this.getComponentDetails(inspectedPath, oldDetails);
@@ -1738,8 +1976,14 @@
           result.hasChildren = false;
           result.visible = true;
           const index = path.findIndex((key) => typeof key !== "string");
+          const componentNode = this.getComponentNode(
+            index <= 1 ? [path[0]] : path.slice(0, index)
+          );
+          // For subscription targets the key is always "target"; use targetName for a meaningful name
+          if (result.name === "target" && parent?.keys !== undefined && componentNode) {
+            result.name = this.targetName(parent.target, componentNode);
+          }
           if (index > 1) {
-            const componentNode = this.getComponentNode(path.slice(0, index));
             result.path = [this.getComponentSimplifiedPath(componentNode)].concat(
               path.slice(index)
             );
@@ -1761,27 +2005,42 @@
           path.unshift(componentNode.parentKey);
         }
       }
-      path.unshift("root");
+      // Walk to the root node (the one with no parent or whose parent has no parentKey)
+      let rootNode = componentNode.parent || componentNode;
+      const app = rootNode.app;
+      const roots = this.getRoots(app);
+      const rootIndex = roots.indexOf(rootNode);
+      path.unshift(rootIndex.toString());
       const appsArray = [...this.apps];
-      let index = appsArray.findIndex((app) => app === componentNode.app);
+      let index = appsArray.findIndex((a) => a === app);
       path.unshift(index.toString());
       return path;
     }
+    // Returns the display name of a component node, compatible with both owl v2 and v3
+    getNodeName(node) {
+      return node.component?.constructor?.name ?? node.name ?? "";
+    }
+
     // Returns the simplified path of the given component node (using component names and indexes)
     getComponentSimplifiedPath(componentNode) {
-      let path = componentNode.name;
+      let path = this.getNodeName(componentNode);
       if (componentNode.parentKey) {
         while (componentNode.parent) {
           const previousKey = componentNode.parentKey;
           componentNode = componentNode.parent;
-          path = `${componentNode.name}/${Reflect.ownKeys(componentNode.children).indexOf(
-            previousKey
-          )}/${path}`;
+          path = `${this.getNodeName(componentNode)}/${Reflect.ownKeys(
+            componentNode.children
+          ).indexOf(previousKey)}/${path}`;
         }
       }
+      // Walk to the root and find its index
+      let rootNode = componentNode.parent || componentNode;
+      const app = rootNode.app;
+      const roots = this.getRoots(app);
+      const rootIndex = roots.indexOf(rootNode);
       const appsArray = [...this.apps];
-      let index = appsArray.findIndex((app) => app === componentNode.app);
-      path = index.toString() + (path.length ? `/${path}` : "");
+      let appIndex = appsArray.findIndex((a) => a === app);
+      path = appIndex.toString() + "/" + rootIndex.toString() + (path.length ? `/${path}` : "");
       return path;
     }
     // Store the object into a temp window variable and log it to the console


### PR DESCRIPTION
This commit migrates the Owl devtools extension to Owl 3, upgrades the engine to support new runtimes, and optimizes core performance bottlenecks.

**Key Changes:**
* **Extension Upgrade:** The devtools application itself is now fully migrated to and powered by Owl 3 using basic plugin-based architecture.
* **Dual-Version Inspection:** Adapts the discovery and inspection layers to support Owl 3 applications seamlessly while preserving full retro-compatibility with legacy Owl 2 apps.
* **Selector Optimization:** Rewrites the element selector routine to eliminate overhead and prevent sluggishness on complex, component-heavy pages.