### PR TITLE
[IMP] types: add t.component helper

### DIFF
--- a/doc/reference/component.md
+++ b/doc/reference/component.md
@@ -59,7 +59,7 @@ using the `props` function. The result can be stored on any property name:
 class MyComponent extends Component {
   static template = xml`<span t-out="this.myProps.name"/>`;
 
-  myProps = props({ name: t.string });
+  myProps = props({ name: t.string() });
 }
 ```
 

--- a/doc/reference/plugins.md
+++ b/doc/reference/plugins.md
@@ -155,8 +155,8 @@ options:
 
 ```js
 class ApiPlugin extends Plugin {
-  baseUrl = config("apiBaseUrl", t.string);
-  timeout = config("apiTimeout?", t.number) || 5000;
+  baseUrl = config("apiBaseUrl", t.string());
+  timeout = config("apiTimeout?", t.number()) || 5000;
 
   setup() {
     // use this.baseUrl and this.timeout

--- a/doc/reference/props.md
+++ b/doc/reference/props.md
@@ -22,7 +22,7 @@ import { Component, props, types as t, xml } from "@odoo/owl";
 
 class Child extends Component {
   static template = xml`<span t-out="this.props.message"/>`;
-  props = props({ message: t.string });
+  props = props({ message: t.string() });
 }
 
 class Parent extends Component {
@@ -89,7 +89,7 @@ is created or updated. See [Props validation](#props-validation) for details.
 ```js
 props(); // no schema
 props(["name", "age?"]); // array form
-props({ name: t.string, "age?": t.number }); // typed form
+props({ name: t.string(), "age?": t.number() }); // typed form
 ```
 
 ### Default values (second argument)
@@ -102,7 +102,7 @@ Defining a default on a mandatory prop will cause a validation error.
 
 ```js
 props(["color?"], { color: "red" });
-props({ "color?": t.string }, { color: "red" });
+props({ "color?": t.string() }, { color: "red" });
 ```
 
 ## Translatable props
@@ -166,8 +166,8 @@ class ProductList extends Component {
   static template = xml`...`;
 
   props = props({
-    count: t.number,
-    items: t.array(t.object({ id: t.number, label: t.string })),
+    count: t.number(),
+    items: t.array(t.object({ id: t.number(), label: t.string() })),
     "onSelect?": t.function(),
     size: t.selection(["small", "medium", "large"]),
   });
@@ -193,7 +193,7 @@ Or with type validation:
 class MyComponent extends Component {
   static template = xml`...`;
   props = props({
-    "someProp?": t.number,
+    "someProp?": t.number(),
     "slots?": t.object(),
   });
 }

--- a/doc/reference/resources_and_registries.md
+++ b/doc/reference/resources_and_registries.md
@@ -101,7 +101,7 @@ Pass a `validation` option to validate items on `add()`:
 ```js
 const commands = new Resource({
   name: "commands",
-  validation: t.object({ label: t.string, action: t.function() }),
+  validation: t.object({ label: t.string(), action: t.function() }),
 });
 
 commands.add({ label: "Save", action: save }); // ok

--- a/doc/reference/types_validation.md
+++ b/doc/reference/types_validation.md
@@ -6,10 +6,10 @@
 - [`validateType`](#validatetype)
 - [`assertType`](#asserttype)
 - [Validators](#validators)
-  - [`t.any`](#tany)
-  - [`t.boolean`](#tboolean)
-  - [`t.number`](#tnumber)
-  - [`t.string`](#tstring)
+  - [`t.any()`](#tany)
+  - [`t.boolean()`](#tboolean)
+  - [`t.number()`](#tnumber)
+  - [`t.string()`](#tstring)
   - [`t.array`](#tarrayelementtype)
   - [`t.object`](#tobjectshape)
   - [`t.strictObject`](#tstrictobjectshape)
@@ -20,7 +20,7 @@
   - [`t.literal`](#tliteralvalue)
   - [`t.selection`](#tselectionvalues)
   - [`t.instanceOf`](#tinstanceofconstructor)
-  - [`t.component`](#tcomponent)
+  - [`t.component()`](#tcomponent)
   - [`t.constructor`](#tconstructorconstructor)
   - [`t.signal`](#tsignaltype)
   - [`t.ref`](#treftype)
@@ -49,8 +49,8 @@ class UserCard extends Component {
     </div>`;
 
   props = props({
-    name: t.string,
-    "age?": t.number,
+    name: t.string(),
+    "age?": t.number(),
   });
 }
 ```
@@ -66,15 +66,15 @@ An empty list means the value is valid.
 ```js
 import { types as t, validateType } from "@odoo/owl";
 
-validateType(42, t.number); // [] (valid)
-validateType("hello", t.number); // [{ message: "value is not a number" }]
+validateType(42, t.number()); // [] (valid)
+validateType("hello", t.number()); // [{ message: "value is not a number" }]
 
-validateType([1, 2, 3], t.array(t.number)); // [] (valid)
-validateType([1, "two"], t.array(t.number)); // [{ message: "value is not a number" }]
+validateType([1, 2, 3], t.array(t.number())); // [] (valid)
+validateType([1, "two"], t.array(t.number())); // [{ message: "value is not a number" }]
 
 const userType = t.object({
-  name: t.string,
-  "age?": t.number,
+  name: t.string(),
+  "age?": t.number(),
 });
 
 validateType({ name: "Alice" }, userType); // [] (valid)
@@ -90,12 +90,12 @@ returning the issues list. Accepts an optional error message prefix.
 ```js
 import { types as t, assertType } from "@odoo/owl";
 
-assertType(42, t.number); // ok, does nothing
+assertType(42, t.number()); // ok, does nothing
 
-assertType("hello", t.number);
+assertType("hello", t.number());
 // throws: "Value does not match the type\n[...]"
 
-assertType("hello", t.number, "Invalid config");
+assertType("hello", t.number(), "Invalid config");
 // throws: "Invalid config\n[...]"
 ```
 
@@ -109,41 +109,41 @@ as a prop type in a component's `props` definition.
 import { types as t } from "@odoo/owl";
 ```
 
-### `t.any`
+### `t.any()`
 
 Accepts any value without validation.
 
 ```js
-t.any;
+t.any();
 // validates: 42, "hello", null, undefined, ...
 ```
 
-### `t.boolean`
+### `t.boolean()`
 
 Validates that the value is a boolean.
 
 ```js
-t.boolean;
+t.boolean();
 // validates: true, false
 // rejects:   0, "true", null
 ```
 
-### `t.number`
+### `t.number()`
 
 Validates that the value is a number.
 
 ```js
-t.number;
+t.number();
 // validates: 42, 3.14, NaN
 // rejects:   "42", null
 ```
 
-### `t.string`
+### `t.string()`
 
 Validates that the value is a string.
 
 ```js
-t.string;
+t.string();
 // validates: "hello", ""
 // rejects:   42, null
 ```
@@ -155,11 +155,11 @@ element is validated against it.
 
 ```js
 t.array(); // any array
-t.array(t.number); // array of numbers
-t.array(t.string); // array of strings
+t.array(t.number()); // array of numbers
+t.array(t.string()); // array of strings
 
-// validates: [1, 2, 3]     with t.array(t.number)
-// rejects:   [1, "two", 3] with t.array(t.number)
+// validates: [1, 2, 3]     with t.array(t.number())
+// rejects:   [1, "two", 3] with t.array(t.number())
 ```
 
 ### `t.object(shape?)`
@@ -172,7 +172,7 @@ are allowed.
 ```js
 t.object(); // any object
 t.object(["name", "age"]); // must have "name" and "age" keys
-t.object({ name: t.string, "age?": t.number }); // "name" required, "age" optional
+t.object({ name: t.string(), "age?": t.number() }); // "name" required, "age" optional
 
 // validates: { name: "Alice", age: 30, extra: true }
 // rejects:   { age: 30 }  (missing required key "name")
@@ -185,7 +185,7 @@ Accepts either an array of key names or an object mapping keys to validators.
 
 ```js
 t.strictObject(["name", "age"]); // must have exactly "name" and "age" keys
-t.strictObject({ name: t.string, "age?": t.number }); // "name" required, "age" optional
+t.strictObject({ name: t.string(), "age?": t.number() }); // "name" required, "age" optional
 
 // validates: { name: "Alice" }
 // validates: { name: "Alice", age: 30 }
@@ -199,10 +199,10 @@ value in the object is validated against it.
 
 ```js
 t.record(); // any object
-t.record(t.number); // all values must be numbers
+t.record(t.number()); // all values must be numbers
 
-// validates: { a: 1, b: 2 }     with t.record(t.number)
-// rejects:   { a: 1, b: "two" } with t.record(t.number)
+// validates: { a: 1, b: 2 }     with t.record(t.number())
+// rejects:   { a: 1, b: "two" } with t.record(t.number())
 ```
 
 ### `t.tuple(types)`
@@ -211,7 +211,7 @@ Validates that the value is an array with a fixed length, where each element
 matches its corresponding type.
 
 ```js
-t.tuple([t.string, t.number]);
+t.tuple([t.string(), t.number()]);
 
 // validates: ["hello", 42]
 // rejects:   ["hello"]           (wrong length)
@@ -226,8 +226,8 @@ runtime**, they only exist to provide TypeScript type inference.
 
 ```js
 t.function(); // any function
-t.function([t.string, t.number]); // typed params (TS inference only)
-t.function([t.string], t.boolean); // typed params and return (TS inference only)
+t.function([t.string(), t.number()]); // typed params (TS inference only)
+t.function([t.string()], t.boolean()); // typed params and return (TS inference only)
 
 // validates: () => {}, Math.max, class Foo {}
 // rejects:   42, "hello", null
@@ -241,7 +241,7 @@ only exists to provide TypeScript type inference.
 
 ```js
 t.promise(); // any promise
-t.promise(t.string); // Promise<string> (TS inference only)
+t.promise(t.string()); // Promise<string> (TS inference only)
 
 // validates: Promise.resolve(42), new Promise(() => {})
 // rejects:   42, { then() {} }
@@ -285,13 +285,13 @@ t.instanceOf(HTMLInputElement);
 // rejects:   "2024-01-01"           with t.instanceOf(Date)
 ```
 
-### `t.component`
+### `t.component()`
 
 Validates that the value is `Component` or a subclass of it. This is shorthand
 for `t.constructor(Component)`.
 
 ```js
-t.component;
+t.component();
 
 // validates: Component, MyComponent (extends Component)
 // rejects:   new Component(), "Component"
@@ -315,7 +315,7 @@ argument is used for type inference only.
 
 ```js
 t.signal(); // any signal
-t.signal(t.number); // Signal<number> (for TS inference)
+t.signal(t.number()); // Signal<number> (for TS inference)
 ```
 
 ### `t.ref(type?)`
@@ -333,12 +333,12 @@ t.ref(HTMLInputElement); // null | HTMLInputElement
 Validates that the value matches **at least one** of the given types (union).
 
 ```js
-t.or([t.string, t.number]);
-t.or([t.literal("none"), t.number]);
+t.or([t.string(), t.number()]);
+t.or([t.literal("none"), t.number()]);
 
-// validates: "hello"  with t.or([t.string, t.number])
-// validates: 42       with t.or([t.string, t.number])
-// rejects:   true     with t.or([t.string, t.number])
+// validates: "hello"  with t.or([t.string(), t.number()])
+// validates: 42       with t.or([t.string(), t.number()])
+// rejects:   true     with t.or([t.string(), t.number()])
 ```
 
 ### `t.and(types)`
@@ -346,7 +346,7 @@ t.or([t.literal("none"), t.number]);
 Validates that the value matches **all** of the given types (intersection).
 
 ```js
-t.and([t.object({ name: t.string }), t.object({ age: t.number })]);
+t.and([t.object({ name: t.string() }), t.object({ age: t.number() })]);
 
 // validates: { name: "Alice", age: 30 }
 // rejects:   { name: "Alice" }  (missing "age")
@@ -359,9 +359,9 @@ function. If the predicate returns `false`, validation fails with the given
 error message (defaults to `"value does not match custom validation"`).
 
 ```js
-t.customValidator(t.number, (v) => v >= 0, "value must be non-negative");
-t.customValidator(t.string, (v) => v.length > 0, "value must not be empty");
-t.customValidator(t.array(t.number), (v) => v.length <= 10, "too many items");
+t.customValidator(t.number(), (v) => v >= 0, "value must be non-negative");
+t.customValidator(t.string(), (v) => v.length > 0, "value must not be empty");
+t.customValidator(t.array(t.number()), (v) => v.length <= 10, "too many items");
 
 // validates: 42    with the first example
 // rejects:   -1    with the first example ("value must be non-negative")

--- a/doc/reference/types_validation.md
+++ b/doc/reference/types_validation.md
@@ -20,6 +20,7 @@
   - [`t.literal`](#tliteralvalue)
   - [`t.selection`](#tselectionvalues)
   - [`t.instanceOf`](#tinstanceofconstructor)
+  - [`t.component`](#tcomponent)
   - [`t.constructor`](#tconstructorconstructor)
   - [`t.signal`](#tsignaltype)
   - [`t.ref`](#treftype)
@@ -282,6 +283,18 @@ t.instanceOf(HTMLInputElement);
 // validates: new Date()             with t.instanceOf(Date)
 // rejects:   Date.now()             with t.instanceOf(Date)
 // rejects:   "2024-01-01"           with t.instanceOf(Date)
+```
+
+### `t.component`
+
+Validates that the value is `Component` or a subclass of it. This is shorthand
+for `t.constructor(Component)`.
+
+```js
+t.component;
+
+// validates: Component, MyComponent (extends Component)
+// rejects:   new Component(), "Component"
 ```
 
 ### `t.constructor(constructor)`

--- a/docs/playground/samples/kanban_board/main.js
+++ b/docs/playground/samples/kanban_board/main.js
@@ -2,7 +2,7 @@ import { Component, mount, signal, props, types as t } from "@odoo/owl";
 
 class KanbanCard extends Component {
   static template = "tutorial.KanbanCard";
-  props = props({ title: t.string, onDelete: t.function() });
+  props = props({ title: t.string(), onDelete: t.function() });
 }
 
 class KanbanColumn extends Component {

--- a/docs/playground/samples/plugins/form_view.js
+++ b/docs/playground/samples/plugins/form_view.js
@@ -14,7 +14,7 @@ class Field extends Component {
             <span t-out="this.props.descr"/>:
             <span t-out="this.model.record[this.props.field]"/>
         </p>`;
-    props = props({ field: t.string, descr: t.string});
+    props = props({ field: t.string(), descr: t.string()});
 
     // we can import plugins here. the model is provided by the form view,
     // and the notificationplugin is global    

--- a/docs/playground/samples/product_card/product_card.js
+++ b/docs/playground/samples/product_card/product_card.js
@@ -3,5 +3,5 @@ import { Component, props, types as t } from "@odoo/owl";
 export class ProductCard extends Component {
     static template = "example.ProductCard";
     
-    props = props({ name: t.string, price: t.number, "image?": t.string });
+    props = props({ name: t.string(), price: t.number(), "image?": t.string() });
 }

--- a/docs/playground/samples/slots/dialog.js
+++ b/docs/playground/samples/slots/dialog.js
@@ -2,7 +2,7 @@ import { Component, props, types as t } from "@odoo/owl";
 
 export class Dialog extends Component {
     static template = "example.Dialog";
-    props = props({ title: t.string, "onClose?": t.function()})
+    props = props({ title: t.string(), "onClose?": t.function()})
 
     close() {
         if (this.props.onClose) {

--- a/docs/playground/samples/tutorials/getting_started/3/product_card.js
+++ b/docs/playground/samples/tutorials/getting_started/3/product_card.js
@@ -12,10 +12,10 @@ export class ProductCard extends Component {
       </div>`;
 
     props = props({
-        name: t.string,
-        description: t.string,
-        price: t.number,
-        "image?": t.string,
+        name: t.string(),
+        description: t.string(),
+        price: t.number(),
+        "image?": t.string(),
     }, {
         image: "📦",
     });

--- a/docs/playground/samples/tutorials/getting_started/3/readme.md
+++ b/docs/playground/samples/tutorials/getting_started/3/readme.md
@@ -26,9 +26,9 @@ import { Component, props, types as t } from "@odoo/owl";
 
 class ProductCard extends Component {
   props = props({
-    name: t.string,
-    price: t.number,
-    "image?": t.string,
+    name: t.string(),
+    price: t.number(),
+    "image?": t.string(),
   });
 }
 ```
@@ -45,18 +45,18 @@ Owl will check that required props are provided and that their types match.
 
 The `types` helper supports many other types:
 
-- `t.boolean`, `t.number`, `t.string`
+- `t.boolean()`, `t.number()`, `t.string()`
 - `t.function()`
-- `t.object({ id: t.number, name: t.string })`
+- `t.object({ id: t.number(), name: t.string() })`
 - `t.signal()`
-- `t.array(t.string)`
+- `t.array(t.string())`
 
 The `props` function accepts a second argument for **default values**:
 
 ```js
 props = props({
-    name: t.string,
-    "image?": t.string,
+    name: t.string(),
+    "image?": t.string(),
 }, {
     image: "📦",
 });

--- a/docs/playground/samples/tutorials/getting_started/5/timer.js
+++ b/docs/playground/samples/tutorials/getting_started/5/timer.js
@@ -7,7 +7,7 @@ export class Timer extends Component {
       </div>`;
 
     props = props({
-        increment: t.number,
+        increment: t.number(),
     });
 
     value = signal(0);

--- a/docs/playground/samples/tutorials/hibou_os/10/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/10/window.js
@@ -4,7 +4,7 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
         "x?": t.signal(),
         "y?": t.signal(),

--- a/docs/playground/samples/tutorials/hibou_os/11/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/11/window.js
@@ -5,7 +5,7 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
         "x?": t.signal(),
         "y?": t.signal(),

--- a/docs/playground/samples/tutorials/hibou_os/12/hibou_solution.js
+++ b/docs/playground/samples/tutorials/hibou_os/12/hibou_solution.js
@@ -4,8 +4,8 @@ import { WindowManager } from "./window/window_manager";
 import { WindowManagerPlugin } from "./window/window_manager_plugin";
 
 const APP_SCHEMA = t.object({
-    name: t.string,
-    icon: t.string,
+    name: t.string(),
+    icon: t.string(),
     window: t.constructor(Component),
     "systrayItems?": t.array(t.constructor(Component)),
     "plugins?": t.array(t.constructor(Plugin)),

--- a/docs/playground/samples/tutorials/hibou_os/12/readme.md
+++ b/docs/playground/samples/tutorials/hibou_os/12/readme.md
@@ -59,8 +59,8 @@ Define the app schema in `hibou.js`:
 import { types as t } from "@odoo/owl";
 
 const APP_SCHEMA = t.object({
-    name: t.string,
-    icon: t.string,
+    name: t.string(),
+    icon: t.string(),
     window: t.constructor(Component),
     "systrayItems?": t.array(t.constructor(Component)),
     "plugins?": t.array(t.constructor(Plugin)),

--- a/docs/playground/samples/tutorials/hibou_os/13/readme.md
+++ b/docs/playground/samples/tutorials/hibou_os/13/readme.md
@@ -36,8 +36,8 @@ import { Registry, Component, types as t } from "@odoo/owl";
 export const menuItemRegistry = new Registry({
     name: "menuItem",
     validation: t.object({
-        name: t.string,
-        icon: t.string,
+        name: t.string(),
+        icon: t.string(),
         window: t.constructor(Component),
     }),
 });

--- a/docs/playground/samples/tutorials/hibou_os/13/registries.js
+++ b/docs/playground/samples/tutorials/hibou_os/13/registries.js
@@ -3,8 +3,8 @@ import { Registry, Component, Plugin, types as t } from "@odoo/owl";
 export const menuItemRegistry = new Registry({
     name: "menuItem",
     validation: t.object({
-        name: t.string,
-        icon: t.string,
+        name: t.string(),
+        icon: t.string(),
         window: t.constructor(Component),
     }),
 });

--- a/docs/playground/samples/tutorials/hibou_os/14/registries.js
+++ b/docs/playground/samples/tutorials/hibou_os/14/registries.js
@@ -3,11 +3,11 @@ import { Registry, Component, Plugin, types as t } from "@odoo/owl";
 export const menuItemRegistry = new Registry({
     name: "menuItem",
     validation: t.object({
-        name: t.string,
-        icon: t.string,
+        name: t.string(),
+        icon: t.string(),
         window: t.constructor(Component),
-        "width?": t.number,
-        "height?": t.number,
+        "width?": t.number(),
+        "height?": t.number(),
     }),
 });
 

--- a/docs/playground/samples/tutorials/hibou_os/14/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/14/window.js
@@ -5,14 +5,14 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
         "x?": t.signal(),
         "y?": t.signal(),
         "zIndex?": t.signal(),
         "component?": t.function(),
-        "width?": t.number,
-        "height?": t.number,
+        "width?": t.number(),
+        "height?": t.number(),
     });
 
     dnd = useDragAndDrop(this.props.x, this.props.y);

--- a/docs/playground/samples/tutorials/hibou_os/3/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/3/window.js
@@ -4,7 +4,7 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
     });
 }

--- a/docs/playground/samples/tutorials/hibou_os/4/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/4/window.js
@@ -4,9 +4,9 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
-        "x?": t.number,
-        "y?": t.number,
+        "x?": t.number(),
+        "y?": t.number(),
     });
 }

--- a/docs/playground/samples/tutorials/hibou_os/8/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/8/window.js
@@ -4,10 +4,10 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
-        "x?": t.number,
-        "y?": t.number,
+        "x?": t.number(),
+        "y?": t.number(),
         "zIndex?": t.signal(),
     });
 }

--- a/docs/playground/samples/tutorials/hibou_os/9/window.js
+++ b/docs/playground/samples/tutorials/hibou_os/9/window.js
@@ -4,10 +4,10 @@ export class Window extends Component {
     static template = "hibou.Window";
 
     props = props({
-        title: t.string,
+        title: t.string(),
         "onClose?": t.function(),
-        "x?": t.number,
-        "y?": t.number,
+        "x?": t.number(),
+        "y?": t.number(),
         "zIndex?": t.signal(),
         "component?": t.function(),
     });

--- a/docs/playground/samples/tutorials/todo_list/1/readme.md
+++ b/docs/playground/samples/tutorials/todo_list/1/readme.md
@@ -42,7 +42,7 @@ import { Component, props, types as t } from "@odoo/owl";
 
 class TodoItem extends Component {
     props = props({
-        todo: t.object({ id: t.number, text: t.string, completed: t.boolean }),
+        todo: t.object({ id: t.number(), text: t.string(), completed: t.boolean() }),
     });
 }
 ```

--- a/docs/playground/samples/tutorials/todo_list/1/todo_item.js
+++ b/docs/playground/samples/tutorials/todo_list/1/todo_item.js
@@ -4,6 +4,6 @@ export class TodoItem extends Component {
     static template = "tutorial.TodoItem";
 
     props = props({
-        todo: t.object({ id: t.number, text: t.string, completed: t.boolean }),
+        todo: t.object({ id: t.number(), text: t.string(), completed: t.boolean() }),
     });
 }

--- a/docs/playground/samples/tutorials/todo_list/5/readme.md
+++ b/docs/playground/samples/tutorials/todo_list/5/readme.md
@@ -16,7 +16,7 @@ Here is what you need to do:
 - Use `t-model="this.props.todo.completed"` on the checkbox to bind it
   directly to the signal
 - Update the props definition in `TodoItem` to validate `completed` as
-  `t.signal()` instead of `t.boolean`
+  `t.signal()` instead of `t.boolean()`
 - Click on the checkboxes to verify that the strikethrough styling now updates
   correctly
 
@@ -46,7 +46,7 @@ To validate a signal prop, use `t.signal()`:
 
 ```js
 props = props({
-    todo: t.object({ id: t.number, text: t.string, completed: t.signal() }),
+    todo: t.object({ id: t.number(), text: t.string(), completed: t.signal() }),
 });
 ```
 

--- a/docs/playground/samples/tutorials/todo_list/5/todo_item_solution.js
+++ b/docs/playground/samples/tutorials/todo_list/5/todo_item_solution.js
@@ -4,6 +4,6 @@ export class TodoItem extends Component {
     static template = "tutorial.TodoItem";
 
     props = props({
-        todo: t.object({ id: t.number, text: t.string, completed: t.signal() }),
+        todo: t.object({ id: t.number(), text: t.string(), completed: t.signal() }),
     });
 }

--- a/docs/playground/samples/tutorials/todo_list/7/todo_item_solution.js
+++ b/docs/playground/samples/tutorials/todo_list/7/todo_item_solution.js
@@ -4,7 +4,7 @@ export class TodoItem extends Component {
     static template = "tutorial.TodoItem";
 
     props = props({
-        todo: t.object({ id: t.number, text: t.string, completed: t.signal() }),
+        todo: t.object({ id: t.number(), text: t.string(), completed: t.signal() }),
         "onDelete?": t.function(),
     });
 }

--- a/docs/playground/samples/tutorials/todo_list/8/readme.md
+++ b/docs/playground/samples/tutorials/todo_list/8/readme.md
@@ -80,5 +80,5 @@ does not need to know how the plugin works internally.
 ## Bonus Exercises
 
 - Validate the `text` argument in `addTodo` using the `assertType` function
-  from Owl: `assertType(text, t.string)`. This ensures the plugin's API is
+  from Owl: `assertType(text, t.string())`. This ensures the plugin's API is
   called correctly and helps catch bugs early.

--- a/docs/playground/samples/tutorials/todo_list/8/todo_item_solution.js
+++ b/docs/playground/samples/tutorials/todo_list/8/todo_item_solution.js
@@ -5,7 +5,7 @@ export class TodoItem extends Component {
     static template = "tutorial.TodoItem";
 
     props = props({
-        todo: t.object({ id: t.number, text: t.string, completed: t.signal() }),
+        todo: t.object({ id: t.number(), text: t.string(), completed: t.signal() }),
     });
 
     todoList = plugin(TodoListPlugin);

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -250,10 +250,10 @@ class SomeComponent extends Component {
   static template = "...";
 
   props = props({
-      name: t.string,
-      "visible?": t.boolean,
-      "immediate?": t.boolean,
-      "leaveDuration?": t.number,
+      name: t.string(),
+      "visible?": t.boolean(),
+      "immediate?": t.boolean(),
+      "leaveDuration?": t.number(),
       "onLeave?": t.function(),
       // no need to grab the slot prop here
   }, {
@@ -371,7 +371,7 @@ class C extends Component {
 class C extends Component {
   static template = "...";
   
-  props = props({ counter: t.signal(t.number) });
+  props = props({ counter: t.signal(t.number()) });
   isLarge = computed(() => this.props.counter() > 10);
 }
 ```
@@ -402,7 +402,7 @@ class C extends Component {
 class C extends Component {
   static template = "...";
   
-  props = props({ resId: t.signal(t.number) });
+  props = props({ resId: t.signal(t.number()) });
   someText = signal("");
 
   setup() {
@@ -423,7 +423,7 @@ no really good way to solve the issue other than with a `useEffect`.
 class C extends Component {
   static template = "...";
   
-  props = props({ resId: t.signal(t.number) });
+  props = props({ resId: t.signal(t.number()) });
 
   setup() {
     useEffect(async () => {
@@ -442,7 +442,7 @@ issue properly, we will provide a `asyncComputed` helper in Odoo:
 class C extends Component {
   static template = "...";
   
-  props = props({ resId: t.signal(t.number) });
+  props = props({ resId: t.signal(t.number()) });
   state = asyncComputed(() => this.loadRecord(this.props.resId()));
 }
 ```
@@ -714,7 +714,7 @@ const c = useComponent();
 // do something with c.props
 
 // owl 3
-const props = props({ value: t.string});
+const props = props({ value: t.string()});
 // do something with props
 
 ```

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "preplayground:watch": "npm run build",
     "playground:watch": "npm-run-all  --parallel playground:serve \"build:* -- --watch\"",
     "prettier": "prettier {src/*.ts,src/**/*.ts,tests/*.ts,tests/**/*.ts,doc/*.md,doc/**/*.md,tools/devtools/**/*.js} --write",
+    "prettier-fast": "git diff-tree --no-commit-id --name-only -r HEAD --diff-filter=d | xargs prettier --write",
     "check-formatting": "prettier {src/*.ts,src/**/*.ts,tests/*.ts,tests/**/*.ts,doc/*.md,doc/**/*.md,tools/devtools/**/*.js} --check",
     "lint": "eslint src/**/*.ts tests/**/*.ts",
     "release": "node tools/release.cjs",

--- a/release_notes.md
+++ b/release_notes.md
@@ -451,7 +451,7 @@ class MyComponent extends Component {
 
   // now, this.props is an object with the two keys a and b, and IDEs can
   // infer that this.props.a is a string, and this.props.b is a optional number
-  props = props({ a: t.string, "b?": t.number });
+  props = props({ a: t.string(), "b?": t.number() });
 }
 ```
 
@@ -463,7 +463,7 @@ import { Component, props } from "@odoo/owl";
 class MyComponent extends Component {
   static template = "mytemplate";
 
-  props = props({ a: t.string, "b?": t.number });
+  props = props({ a: t.string(), "b?": t.number() });
   otherProps = props({ c: t.instanceOf(SomeClass) });
 
   // no description here => we get all props received by the component
@@ -476,7 +476,7 @@ class MyComponent extends Component {
   // we can define default values as well, as second argument:
   myProp = props(
     {
-      "foo?": t.boolean,
+      "foo?": t.boolean(),
     },
     {
       foo: true,
@@ -532,10 +532,10 @@ class SomeComponent extends Component {
 
   props = props(
     {
-      name: t.string,
-      "visible?": t.boolean,
-      "immediate?": t.boolean,
-      "leaveDuration?": t.number,
+      name: t.string(),
+      "visible?": t.boolean(),
+      "immediate?": t.boolean(),
+      "leaveDuration?": t.number(),
       "onLeave?": t.function(),
       // no need to grab the slot prop here
     },
@@ -873,8 +873,8 @@ static props = {
 
 // owl 3.x
 props = props({
-  "mode?": t.string,
-  "readonly?": t.boolean,
+  "mode?": t.string(),
+  "readonly?": t.boolean(),
   "onChange?": t.function(),
   "onBlur?": t.function(),
 });
@@ -882,12 +882,12 @@ props = props({
 // other examples
 props = props({
   someObject: t.object({
-    id: t.string,
-    values: t.union([t.array(), t.number])
+    id: t.string(),
+    values: t.union([t.array(), t.number()])
   }),
 });
 
-assertType(myObj, t.object({ id: t.number, text: t.string}));
+assertType(myObj, t.object({ id: t.number(), text: t.string()}));
 ```
 
 ### onWillUpdateProps is removed
@@ -908,7 +908,7 @@ the signal from a performance standpoint.
 ```js
 class Child extends Component {
   static template = xml`<t t-out="this.double()"/>`;
-  props = props({ count: t.signal(t.number) });
+  props = props({ count: t.signal(t.number()) });
 
   // double is always updated
   double = computed(() => 2 * this.props.count());
@@ -1684,7 +1684,7 @@ class Counter extends Component {
         Count: <t t-out="this.props.count()"/>
       </div>`;
 
-  props = props({ count: t.signal(t.number) });
+  props = props({ count: t.signal(t.number()) });
 
   increment() {
     this.props.count.set(this.props.count() + 1);
@@ -1773,7 +1773,7 @@ class Notification extends Component {
             <div><t t-out="this.props.notification.message"/></div>
         </div>`;
   props = props({
-    notification: t.object({ title: t.string, message: t.string }),
+    notification: t.object({ title: t.string(), message: t.string() }),
   });
 }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -26,25 +26,33 @@ type UnionToIntersection<U> = (U extends any ? (_: U) => any : never) extends (_
   ? I
   : never;
 
-const anyType: any = function validateAny() {} as any;
+function anyType(): any {
+  return function validateAny() {} as any;
+}
 
-const booleanType: boolean = function validateBoolean(context: ValidationContext) {
-  if (typeof context.value !== "boolean") {
-    context.addIssue({ message: "value is not a boolean" });
-  }
-} as any;
+function booleanType(): boolean {
+  return function validateBoolean(context: ValidationContext) {
+    if (typeof context.value !== "boolean") {
+      context.addIssue({ message: "value is not a boolean" });
+    }
+  } as any;
+}
 
-const numberType: number = function validateNumber(context: ValidationContext) {
-  if (typeof context.value !== "number") {
-    context.addIssue({ message: "value is not a number" });
-  }
-} as any;
+function numberType(): number {
+  return function validateNumber(context: ValidationContext) {
+    if (typeof context.value !== "number") {
+      context.addIssue({ message: "value is not a number" });
+    }
+  } as any;
+}
 
-const stringType: string = function validateString(context: ValidationContext) {
-  if (typeof context.value !== "string") {
-    context.addIssue({ message: "value is not a string" });
-  }
-} as any;
+function stringType(): string {
+  return function validateString(context: ValidationContext) {
+    if (typeof context.value !== "string") {
+      context.addIssue({ message: "value is not a string" });
+    }
+  } as any;
+}
 
 function arrayType(): any[];
 function arrayType<T>(elementType: T): T[];
@@ -285,7 +293,9 @@ function reactiveValueType(type?: any): ReactiveValue<any> {
   } as any;
 }
 
-const componentType: typeof Component = constructorType(Component as any) as any;
+function componentType(): typeof Component {
+  return constructorType(Component as any) as any;
+}
 
 function ref(): HTMLElement | null;
 function ref<T extends Constructor<HTMLElement>>(type: T): InstanceType<T> | null;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,3 +1,4 @@
+import { Component } from "./component";
 import { atomSymbol, ReactiveValue } from "./reactivity/computations";
 import { ValidationContext, ValidationIssue } from "./validation";
 
@@ -284,6 +285,8 @@ function reactiveValueType(type?: any): ReactiveValue<any> {
   } as any;
 }
 
+const componentType: typeof Component = constructorType(Component as any) as any;
+
 function ref(): HTMLElement | null;
 function ref<T extends Constructor<HTMLElement>>(type: T): InstanceType<T> | null;
 function ref(type?: any): any {
@@ -295,6 +298,7 @@ export const types = {
   any: anyType,
   array: arrayType,
   boolean: booleanType,
+  component: componentType,
   constructor: constructorType,
   customValidator: customValidator,
   function: functionType,

--- a/tests/components/basics.test.ts
+++ b/tests/components/basics.test.ts
@@ -159,8 +159,8 @@ describe("basics", () => {
       static template = xml`<span>simple vnode</span>`;
       props = props(
         {
-          a: t.any,
-          "b?": t.number,
+          a: t.any(),
+          "b?": t.number(),
         },
         { b: 1 }
       );

--- a/tests/components/plugins.test.ts
+++ b/tests/components/plugins.test.ts
@@ -214,11 +214,11 @@ test("components start plugins at their level", async () => {
 
 test("components can give config to plugins", async () => {
   class PluginA extends Plugin {
-    inputA = config("inputAlias", t.string);
+    inputA = config("inputAlias", t.string());
   }
 
   class PluginB extends Plugin {
-    inputB = config("otherInput", t.number);
+    inputB = config("otherInput", t.number());
     other = 1;
   }
 
@@ -239,7 +239,7 @@ test("components can give config to plugins", async () => {
 
 test("plugin config are validated", async () => {
   class PluginA extends Plugin {
-    inputA = config("input", t.string);
+    inputA = config("input", t.string());
   }
 
   class Test extends Component {
@@ -258,7 +258,7 @@ test("plugin config are validated", async () => {
 
 test("optional plugin config work as expected (value given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input?", t.string) || "abc";
+    inputA = config("input?", t.string()) || "abc";
   }
 
   class Test extends Component {
@@ -271,7 +271,7 @@ test("optional plugin config work as expected (value given)", async () => {
 
 test("optional plugin config work as expected (no value given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input?", t.string) || "abc";
+    inputA = config("input?", t.string()) || "abc";
   }
 
   class Test extends Component {
@@ -284,7 +284,7 @@ test("optional plugin config work as expected (no value given)", async () => {
 
 test("optional plugin config work as expected (no config given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input?", t.string) || "abc";
+    inputA = config("input?", t.string()) || "abc";
   }
 
   class Test extends Component {
@@ -333,7 +333,7 @@ test("shadow plugin", async () => {
 
 test("components can register resources", async () => {
   class PluginA extends Plugin {
-    colors = new Resource({ name: "colors", validation: t.string });
+    colors = new Resource({ name: "colors", validation: t.string() });
 
     value = computed(() => {
       return this.colors.items().join("|");

--- a/tests/components/props_validation.test.ts
+++ b/tests/components/props_validation.test.ts
@@ -111,9 +111,9 @@ describe("props validation", () => {
 
   test("validate simple types", async () => {
     const Tests = [
-      { type: t.number, ok: 1, ko: "1" },
-      { type: t.boolean, ok: true, ko: "1" },
-      { type: t.string, ok: "1", ko: 1 },
+      { type: t.number(), ok: 1, ko: "1" },
+      { type: t.boolean(), ok: true, ko: "1" },
+      { type: t.string(), ok: "1", ko: 1 },
       { type: t.object(), ok: {}, ko: "1" },
       { type: t.instanceOf(Date), ok: new Date(), ko: "1" },
       { type: t.function(), ok: () => {}, ko: "1" },
@@ -171,7 +171,7 @@ describe("props validation", () => {
   test("can validate a prop with multiple types", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.or([t.string, t.boolean]) });
+      props = props({ p: t.or([t.string(), t.boolean()]) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -213,7 +213,7 @@ describe("props validation", () => {
   test("can validate an optional props", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ "p?": t.string });
+      props = props({ "p?": t.string() });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -255,7 +255,7 @@ describe("props validation", () => {
   test("can validate an array with given primitive type", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.array(t.string) });
+      props = props({ p: t.array(t.string()) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -299,7 +299,7 @@ describe("props validation", () => {
   test("can validate an array with multiple sub element types", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.array(t.or([t.string, t.boolean])) });
+      props = props({ p: t.array(t.or([t.string(), t.boolean()])) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -349,7 +349,7 @@ describe("props validation", () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
       props = props({
-        p: t.object({ id: t.number, url: t.string }),
+        p: t.object({ id: t.number(), url: t.string() }),
       });
     }
     class Parent extends Component {
@@ -397,8 +397,8 @@ describe("props validation", () => {
       static template = xml`<div>hey</div>`;
       props = props({
         p: t.object({
-          id: t.number,
-          url: t.or([t.boolean, t.array(t.number)]),
+          id: t.number(),
+          url: t.or([t.boolean(), t.array(t.number())]),
         }),
       });
     }
@@ -438,7 +438,7 @@ describe("props validation", () => {
     class TestComponent extends Component {
       static template = xml``;
       props = props({
-        myprop: t.array(t.object({ "num?": t.number })),
+        myprop: t.array(t.object({ "num?": t.number() })),
       });
     }
     let error: Error;
@@ -466,7 +466,9 @@ describe("props validation", () => {
     class TestComponent extends Component {
       static template = xml``;
       props = props({
-        size: t.customValidator(t.string, (e: string) => ["small", "medium", "large"].includes(e)),
+        size: t.customValidator(t.string(), (e: string) =>
+          ["small", "medium", "large"].includes(e)
+        ),
       });
     }
     let error: Error;
@@ -496,7 +498,7 @@ describe("props validation", () => {
     class TestComponent extends Component {
       static template = xml``;
       props = props({
-        n: t.customValidator(t.number, validator),
+        n: t.customValidator(t.number(), validator),
       });
     }
     let error: Error | undefined;
@@ -572,7 +574,7 @@ describe("props validation", () => {
   test("props: can be defined with a type any", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any });
+      props = props({ message: t.any() });
     }
     await expect(
       mount(SubComp, fixture, {
@@ -641,7 +643,7 @@ describe("props validation", () => {
   test.skip("props: extra props cause an error, part 2", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any });
+      props = props({ message: t.any() });
     }
 
     await expect(
@@ -669,7 +671,7 @@ describe("props validation", () => {
   test("optional prop do not cause an error if value is undefined", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ "message?": t.string });
+      props = props({ "message?": t.string() });
     }
 
     await expect(
@@ -710,7 +712,7 @@ describe("props validation", () => {
     let error: Error;
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number });
+      props = props({ p: t.number() });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.state.p"/></div>`;
@@ -733,7 +735,7 @@ describe("props validation", () => {
     // need to do something about errors catched in render
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ "p?": t.number }, { p: 4 });
+      props = props({ "p?": t.number() }, { p: 4 });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.state.p"/></div>`;
@@ -753,8 +755,8 @@ describe("props validation", () => {
     class Child extends Component {
       static template = xml` <div><t t-out="this.props.mandatory"/></div>`;
       props = props({
-        "optional?": t.string,
-        mandatory: t.number,
+        "optional?": t.string(),
+        mandatory: t.number(),
       });
     }
     class Parent extends Component {
@@ -787,7 +789,7 @@ describe("props validation", () => {
     class Child extends Component {
       static template = xml`<div>hey</div>`;
       props = props({
-        message: t.string,
+        message: t.string(),
       });
     }
     class Parent extends Component {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -531,7 +531,7 @@ describe("sub plugin managers", () => {
 describe("plugins and resources", () => {
   test("can define a resource type", () => {
     class A extends Plugin {
-      colors = new Resource({ name: "colors", validation: t.string });
+      colors = new Resource({ name: "colors", validation: t.string() });
     }
     class B extends Plugin {
       a = plugin(A);
@@ -554,7 +554,7 @@ describe("plugins and resources", () => {
 
   test("resources from child plugins are available in parent plugins", () => {
     class A extends Plugin {
-      colors = new Resource({ name: "colors", validation: t.string });
+      colors = new Resource({ name: "colors", validation: t.string() });
     }
     class B extends Plugin {
       setup() {
@@ -583,7 +583,7 @@ describe("plugins and resources", () => {
 
   test("resources are derived values, can be seen from effect", async () => {
     class A extends Plugin {
-      colors = new Resource({ name: "colors", validation: t.string });
+      colors = new Resource({ name: "colors", validation: t.string() });
     }
 
     class B extends Plugin {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -100,7 +100,7 @@ describe("registry", () => {
     const registry = new Registry({
       name: "test",
       validation: t.object({
-        blip: t.string,
+        blip: t.string(),
       }),
     });
 

--- a/tests/resource.test.ts
+++ b/tests/resource.test.ts
@@ -67,7 +67,7 @@ test("validation schema", async () => {
   const resource = new Resource({
     name: "test",
     validation: t.object({
-      blip: t.string,
+      blip: t.string(),
     }),
   });
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -3,22 +3,22 @@ import { assertType, Component, computed, signal, types as t, validateType } fro
 class A {}
 
 test("simple assertion", () => {
-  expect(() => assertType("hey", t.string)).not.toThrow();
+  expect(() => assertType("hey", t.string())).not.toThrow();
   expect(() => assertType({}, t.object())).not.toThrow();
   expect(() => assertType([], t.array())).not.toThrow();
-  expect(() => assertType(1, t.boolean)).toThrow("Value does not match the type");
+  expect(() => assertType(1, t.boolean())).toThrow("Value does not match the type");
 });
 
 test("validateType", () => {
-  expect(validateType("abc", t.string)).toMatchObject([]);
-  expect(validateType("abc", t.number)).toMatchObject([{ message: "value is not a number" }]);
-  expect(validateType(undefined, t.number)).toMatchObject([{ message: "value is not a number" }]);
-  expect(validateType(1, t.number)).toEqual([]);
+  expect(validateType("abc", t.string())).toMatchObject([]);
+  expect(validateType("abc", t.number())).toMatchObject([{ message: "value is not a number" }]);
+  expect(validateType(undefined, t.number())).toMatchObject([{ message: "value is not a number" }]);
+  expect(validateType(1, t.number())).toEqual([]);
 });
 
 test("and", () => {
-  const a = t.object({ a: t.string });
-  const b = t.object({ b: t.number });
+  const a = t.object({ a: t.string() });
+  const b = t.object({ b: t.number() });
   expect(validateType({}, t.and([a, b]))).toMatchObject([
     { message: "object value has missing keys", missingKeys: ["a"] },
     { message: "object value has missing keys", missingKeys: ["b"] },
@@ -40,20 +40,20 @@ test("and", () => {
 });
 
 test("any", () => {
-  expect(validateType("", t.any)).toEqual([]);
-  expect(validateType("abc", t.any)).toEqual([]);
-  expect(validateType(true, t.any)).toEqual([]);
-  expect(validateType(false, t.any)).toEqual([]);
-  expect(validateType(123, t.any)).toEqual([]);
-  expect(validateType(987, t.any)).toEqual([]);
-  expect(validateType(undefined, t.any)).toEqual([]);
-  expect(validateType(null, t.any)).toEqual([]);
-  expect(validateType({}, t.any)).toEqual([]);
-  expect(validateType({ a: 1, b: "", c: { a: true } }, t.any)).toEqual([]);
-  expect(validateType([{ a: 1 }, { b: 2 }], t.any)).toEqual([]);
-  expect(validateType(() => {}, t.any)).toEqual([]);
-  expect(validateType(A, t.any)).toEqual([]);
-  expect(validateType(new A(), t.any)).toEqual([]);
+  expect(validateType("", t.any())).toEqual([]);
+  expect(validateType("abc", t.any())).toEqual([]);
+  expect(validateType(true, t.any())).toEqual([]);
+  expect(validateType(false, t.any())).toEqual([]);
+  expect(validateType(123, t.any())).toEqual([]);
+  expect(validateType(987, t.any())).toEqual([]);
+  expect(validateType(undefined, t.any())).toEqual([]);
+  expect(validateType(null, t.any())).toEqual([]);
+  expect(validateType({}, t.any())).toEqual([]);
+  expect(validateType({ a: 1, b: "", c: { a: true } }, t.any())).toEqual([]);
+  expect(validateType([{ a: 1 }, { b: 2 }], t.any())).toEqual([]);
+  expect(validateType(() => {}, t.any())).toEqual([]);
+  expect(validateType(A, t.any())).toEqual([]);
+  expect(validateType(new A(), t.any())).toEqual([]);
 });
 
 test("array", () => {
@@ -69,30 +69,30 @@ test("array", () => {
   expect(validateType(["abc"], t.array())).toEqual([]);
   expect(validateType(["abc", 123], t.array())).toEqual([]);
   expect(validateType(["abc", 123, false], t.array())).toEqual([]);
-  expect(validateType(["abc"], t.array(t.string))).toEqual([]);
-  expect(validateType([123, "abc"], t.array(t.string))).toMatchObject([
+  expect(validateType(["abc"], t.array(t.string()))).toEqual([]);
+  expect(validateType([123, "abc"], t.array(t.string()))).toMatchObject([
     { message: "value is not a string", path: [0] },
   ]);
-  expect(validateType(["abc", "def"], t.array(t.string))).toEqual([]);
-  expect(validateType(["abc", 321], t.array(t.string))).toMatchObject([
+  expect(validateType(["abc", "def"], t.array(t.string()))).toEqual([]);
+  expect(validateType(["abc", 321], t.array(t.string()))).toMatchObject([
     { message: "value is not a string", path: [1] },
   ]);
 });
 
 test("boolean", () => {
   const issue = { message: "value is not a boolean" };
-  expect(validateType(true, t.boolean)).toEqual([]);
-  expect(validateType(false, t.boolean)).toEqual([]);
-  expect(validateType("", t.boolean)).toMatchObject([issue]);
-  expect(validateType("abc", t.boolean)).toMatchObject([issue]);
-  expect(validateType(123, t.boolean)).toMatchObject([issue]);
-  expect(validateType(987, t.boolean)).toMatchObject([issue]);
-  expect(validateType(undefined, t.boolean)).toMatchObject([issue]);
-  expect(validateType(null, t.boolean)).toMatchObject([issue]);
-  expect(validateType({}, t.boolean)).toMatchObject([issue]);
-  expect(validateType([], t.boolean)).toMatchObject([issue]);
-  expect(validateType(A, t.boolean)).toMatchObject([issue]);
-  expect(validateType(new A(), t.boolean)).toMatchObject([issue]);
+  expect(validateType(true, t.boolean())).toEqual([]);
+  expect(validateType(false, t.boolean())).toEqual([]);
+  expect(validateType("", t.boolean())).toMatchObject([issue]);
+  expect(validateType("abc", t.boolean())).toMatchObject([issue]);
+  expect(validateType(123, t.boolean())).toMatchObject([issue]);
+  expect(validateType(987, t.boolean())).toMatchObject([issue]);
+  expect(validateType(undefined, t.boolean())).toMatchObject([issue]);
+  expect(validateType(null, t.boolean())).toMatchObject([issue]);
+  expect(validateType({}, t.boolean())).toMatchObject([issue]);
+  expect(validateType([], t.boolean())).toMatchObject([issue]);
+  expect(validateType(A, t.boolean())).toMatchObject([issue]);
+  expect(validateType(new A(), t.boolean())).toMatchObject([issue]);
 });
 
 test("constructor", () => {
@@ -130,16 +130,16 @@ test("constructor", () => {
 test("component", () => {
   class MyComponent extends Component {}
   const issue = { message: "value is not 'Component' or an extension" };
-  expect(validateType(Component, t.component)).toEqual([]);
-  expect(validateType(MyComponent, t.component)).toEqual([]);
-  expect(validateType(true, t.component)).toMatchObject([issue]);
-  expect(validateType("abc", t.component)).toMatchObject([issue]);
-  expect(validateType(A, t.component)).toMatchObject([issue]);
-  expect(validateType(new MyComponent(null as any), t.component)).toMatchObject([issue]);
+  expect(validateType(Component, t.component())).toEqual([]);
+  expect(validateType(MyComponent, t.component())).toEqual([]);
+  expect(validateType(true, t.component())).toMatchObject([issue]);
+  expect(validateType("abc", t.component())).toMatchObject([issue]);
+  expect(validateType(A, t.component())).toMatchObject([issue]);
+  expect(validateType(new MyComponent(null as any), t.component())).toMatchObject([issue]);
 });
 
 test("customValidator", () => {
-  const validator = t.customValidator(t.string, (size) => ["sm", "md", "lg"].includes(size));
+  const validator = t.customValidator(t.string(), (size) => ["sm", "md", "lg"].includes(size));
   expect(validateType(123, validator)).toMatchObject([{ message: "value is not a string" }]);
   expect(validateType("sm", validator)).toEqual([]);
   expect(validateType("md", validator)).toEqual([]);
@@ -150,7 +150,7 @@ test("customValidator", () => {
   expect(
     validateType(
       "small",
-      t.customValidator(t.string, (size) => ["sm", "md", "lg"].includes(size), "Invalid")
+      t.customValidator(t.string(), (size) => ["sm", "md", "lg"].includes(size), "Invalid")
     )
   ).toMatchObject([{ message: "Invalid" }]);
 });
@@ -170,8 +170,8 @@ describe("function", () => {
   });
 
   test("parameters and return types are not checked", () => {
-    expect(validateType(() => {}, t.function([t.string], t.boolean))).toEqual([]);
-    expect(validateType(function () {}, t.function([t.string], t.boolean))).toEqual([]);
+    expect(validateType(() => {}, t.function([t.string()], t.boolean()))).toEqual([]);
+    expect(validateType(function () {}, t.function([t.string()], t.boolean()))).toEqual([]);
   });
 });
 
@@ -230,18 +230,18 @@ test("literal", () => {
 
 test("number", () => {
   const issue = { message: "value is not a number" };
-  expect(validateType(123, t.number)).toEqual([]);
-  expect(validateType(987, t.number)).toEqual([]);
-  expect(validateType(true, t.number)).toMatchObject([issue]);
-  expect(validateType(false, t.number)).toMatchObject([issue]);
-  expect(validateType("", t.number)).toMatchObject([issue]);
-  expect(validateType("abc", t.number)).toMatchObject([issue]);
-  expect(validateType(undefined, t.number)).toMatchObject([issue]);
-  expect(validateType(null, t.number)).toMatchObject([issue]);
-  expect(validateType({}, t.number)).toMatchObject([issue]);
-  expect(validateType([], t.number)).toMatchObject([issue]);
-  expect(validateType(A, t.number)).toMatchObject([issue]);
-  expect(validateType(new A(), t.number)).toMatchObject([issue]);
+  expect(validateType(123, t.number())).toEqual([]);
+  expect(validateType(987, t.number())).toEqual([]);
+  expect(validateType(true, t.number())).toMatchObject([issue]);
+  expect(validateType(false, t.number())).toMatchObject([issue]);
+  expect(validateType("", t.number())).toMatchObject([issue]);
+  expect(validateType("abc", t.number())).toMatchObject([issue]);
+  expect(validateType(undefined, t.number())).toMatchObject([issue]);
+  expect(validateType(null, t.number())).toMatchObject([issue]);
+  expect(validateType({}, t.number())).toMatchObject([issue]);
+  expect(validateType([], t.number())).toMatchObject([issue]);
+  expect(validateType(A, t.number())).toMatchObject([issue]);
+  expect(validateType(new A(), t.number())).toMatchObject([issue]);
 });
 
 describe("object", () => {
@@ -269,38 +269,38 @@ describe("object", () => {
     ]);
     expect(validateType({}, t.object({}))).toEqual([]);
     expect(validateType({ a: 1 }, t.object({}))).toEqual([]);
-    expect(validateType({ a: 1 }, t.object({ a: t.number }))).toEqual([]);
-    expect(validateType({ a: 1 }, t.object({ a: t.string }))).toMatchObject([
+    expect(validateType({ a: 1 }, t.object({ a: t.number() }))).toEqual([]);
+    expect(validateType({ a: 1 }, t.object({ a: t.string() }))).toMatchObject([
       { message: "value is not a string", path: ["a"] },
     ]);
-    expect(validateType({ b: 1 }, t.object({ a: t.string }))).toMatchObject([
+    expect(validateType({ b: 1 }, t.object({ a: t.string() }))).toMatchObject([
       { message: "object value has missing keys", path: [], missingKeys: ["a"] },
     ]);
-    expect(validateType({ a: 1, b: "b" }, t.object({ b: t.string }))).toEqual([]);
+    expect(validateType({ a: 1, b: "b" }, t.object({ b: t.string() }))).toEqual([]);
   });
 
   test("shaped object with optional key", () => {
-    expect(validateType({}, t.object({ a: t.number }))).toMatchObject([
+    expect(validateType({}, t.object({ a: t.number() }))).toMatchObject([
       { message: "object value has missing keys", path: [], missingKeys: ["a"] },
     ]);
-    expect(validateType({}, t.object({ "a?": t.number }))).toEqual([]);
-    expect(validateType({}, t.object({ a: t.number, "b?": t.number }))).toMatchObject([
+    expect(validateType({}, t.object({ "a?": t.number() }))).toEqual([]);
+    expect(validateType({}, t.object({ a: t.number(), "b?": t.number() }))).toMatchObject([
       { message: "object value has missing keys", path: [], missingKeys: ["a"] },
     ]);
-    expect(validateType({ a: 1 }, t.object({ a: t.number, "b?": t.number }))).toEqual([]);
-    expect(validateType({ a: 1, b: 1 }, t.object({ a: t.number, "b?": t.number }))).toMatchObject(
-      []
-    );
+    expect(validateType({ a: 1 }, t.object({ a: t.number(), "b?": t.number() }))).toEqual([]);
     expect(
-      validateType({ a: 1, b: "abc" }, t.object({ a: t.number, "b?": t.number }))
+      validateType({ a: 1, b: 1 }, t.object({ a: t.number(), "b?": t.number() }))
+    ).toMatchObject([]);
+    expect(
+      validateType({ a: 1, b: "abc" }, t.object({ a: t.number(), "b?": t.number() }))
     ).toMatchObject([{ message: "value is not a number", path: ["b"] }]);
   });
 
   test("shaped object with nested object", () => {
     const type = t.object({
-      a: t.number,
+      a: t.number(),
       b: t.object({
-        c: t.string,
+        c: t.string(),
       }),
     });
 
@@ -378,57 +378,57 @@ describe("promise", () => {
   });
 
   test("return type is not checked", () => {
-    expect(validateType(Promise.resolve(""), t.promise(t.string))).toEqual([]);
-    expect(validateType(Promise.resolve(123), t.promise(t.string))).toEqual([]);
-    expect(validateType(Promise.resolve(true), t.promise(t.string))).toEqual([]);
+    expect(validateType(Promise.resolve(""), t.promise(t.string()))).toEqual([]);
+    expect(validateType(Promise.resolve(123), t.promise(t.string()))).toEqual([]);
+    expect(validateType(Promise.resolve(true), t.promise(t.string()))).toEqual([]);
   });
 });
 
 test("signal", () => {
   const issue = { message: "value is not a reactive value" };
-  expect(validateType(123, t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType("abc", t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType(true, t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType(() => {}, t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType(function () {}, t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType(A, t.signal(t.string))).toMatchObject([issue]);
+  expect(validateType(123, t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType("abc", t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType(true, t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType(() => {}, t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType(function () {}, t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType(A, t.signal(t.string()))).toMatchObject([issue]);
   class B {
     set() {}
   }
-  expect(validateType(B, t.signal(t.string))).toMatchObject([issue]);
-  expect(validateType(signal(1), t.signal(t.number))).toEqual([]);
+  expect(validateType(B, t.signal(t.string()))).toMatchObject([issue]);
+  expect(validateType(signal(1), t.signal(t.number()))).toEqual([]);
   expect(
     validateType(
       computed(() => 1),
-      t.signal(t.number)
+      t.signal(t.number())
     )
   ).toEqual([]);
 });
 
 test("record", () => {
-  expect(validateType("abc", t.record(t.string))).toMatchObject([
+  expect(validateType("abc", t.record(t.string()))).toMatchObject([
     { message: "value is not an object", path: [] },
   ]);
-  expect(validateType(123, t.record(t.string))).toMatchObject([
+  expect(validateType(123, t.record(t.string()))).toMatchObject([
     { message: "value is not an object", path: [] },
   ]);
-  expect(validateType(true, t.record(t.string))).toMatchObject([
+  expect(validateType(true, t.record(t.string()))).toMatchObject([
     { message: "value is not an object", path: [] },
   ]);
-  expect(validateType({}, t.record(t.string))).toEqual([]);
-  expect(validateType({ a: "abc" }, t.record(t.string))).toEqual([]);
-  expect(validateType({ a: "abc", b: "def" }, t.record(t.string))).toEqual([]);
-  expect(validateType({ a: 123 }, t.record(t.string))).toMatchObject([
+  expect(validateType({}, t.record(t.string()))).toEqual([]);
+  expect(validateType({ a: "abc" }, t.record(t.string()))).toEqual([]);
+  expect(validateType({ a: "abc", b: "def" }, t.record(t.string()))).toEqual([]);
+  expect(validateType({ a: 123 }, t.record(t.string()))).toMatchObject([
     { message: "value is not a string", path: ["a"] },
   ]);
-  expect(validateType({ a: 123, b: "def" }, t.record(t.string))).toMatchObject([
+  expect(validateType({ a: 123, b: "def" }, t.record(t.string()))).toMatchObject([
     { message: "value is not a string", path: ["a"] },
   ]);
-  expect(validateType({ a: 123, b: 123 }, t.record(t.string))).toMatchObject([
+  expect(validateType({ a: 123, b: 123 }, t.record(t.string()))).toMatchObject([
     { message: "value is not a string", path: ["a"] },
     { message: "value is not a string", path: ["b"] },
   ]);
-  expect(validateType({ a: 123, b: 123 }, t.record(t.number))).toEqual([]);
+  expect(validateType({ a: 123, b: 123 }, t.record(t.number()))).toEqual([]);
 });
 
 test("strictObject", () => {
@@ -442,120 +442,122 @@ test("strictObject", () => {
   expect(validateType({ a: 1 }, t.strictObject({}))).toMatchObject([
     { message: "object value has unknown keys", unknownKeys: ["a"] },
   ]);
-  expect(validateType({}, t.strictObject({ a: t.number }))).toMatchObject([
+  expect(validateType({}, t.strictObject({ a: t.number() }))).toMatchObject([
     { message: "object value has missing keys", missingKeys: ["a"] },
   ]);
-  expect(validateType({ a: 1 }, t.strictObject({ a: t.number }))).toEqual([]);
+  expect(validateType({ a: 1 }, t.strictObject({ a: t.number() }))).toEqual([]);
 });
 
 test("string", () => {
   const issue = { message: "value is not a string" };
-  expect(validateType("", t.string)).toEqual([]);
-  expect(validateType("abc", t.string)).toEqual([]);
-  expect(validateType(123, t.string)).toMatchObject([issue]);
-  expect(validateType(987, t.string)).toMatchObject([issue]);
-  expect(validateType(true, t.string)).toMatchObject([issue]);
-  expect(validateType(false, t.string)).toMatchObject([issue]);
-  expect(validateType(undefined, t.string)).toMatchObject([issue]);
-  expect(validateType(null, t.string)).toMatchObject([issue]);
-  expect(validateType({}, t.string)).toMatchObject([issue]);
-  expect(validateType([], t.string)).toMatchObject([issue]);
-  expect(validateType(A, t.string)).toMatchObject([issue]);
-  expect(validateType(new A(), t.string)).toMatchObject([issue]);
+  expect(validateType("", t.string())).toEqual([]);
+  expect(validateType("abc", t.string())).toEqual([]);
+  expect(validateType(123, t.string())).toMatchObject([issue]);
+  expect(validateType(987, t.string())).toMatchObject([issue]);
+  expect(validateType(true, t.string())).toMatchObject([issue]);
+  expect(validateType(false, t.string())).toMatchObject([issue]);
+  expect(validateType(undefined, t.string())).toMatchObject([issue]);
+  expect(validateType(null, t.string())).toMatchObject([issue]);
+  expect(validateType({}, t.string())).toMatchObject([issue]);
+  expect(validateType([], t.string())).toMatchObject([issue]);
+  expect(validateType(A, t.string())).toMatchObject([issue]);
+  expect(validateType(new A(), t.string())).toMatchObject([issue]);
 });
 
 test("tuple", () => {
-  expect(validateType(["abc"], t.tuple([t.string]))).toEqual([]);
-  expect(validateType([], t.tuple([t.string]))).toMatchObject([
+  expect(validateType(["abc"], t.tuple([t.string()]))).toEqual([]);
+  expect(validateType([], t.tuple([t.string()]))).toMatchObject([
     { message: "tuple value does not have the correct length" },
   ]);
-  expect(validateType([123], t.tuple([t.string]))).toMatchObject([
+  expect(validateType([123], t.tuple([t.string()]))).toMatchObject([
     { message: "value is not a string", path: [0] },
   ]);
-  expect(validateType(["abc", 123], t.tuple([t.string]))).toMatchObject([
+  expect(validateType(["abc", 123], t.tuple([t.string()]))).toMatchObject([
     { message: "tuple value does not have the correct length" },
   ]);
-  expect(validateType("", t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType("", t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType("abc", t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType("abc", t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType(123, t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(123, t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType(987, t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(987, t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType(true, t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(true, t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType({}, t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType({}, t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not an array" },
   ]);
-  expect(validateType(["abc", 123], t.tuple([t.string, t.number]))).toEqual([]);
-  expect(validateType([123, "abc"], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(["abc", 123], t.tuple([t.string(), t.number()]))).toEqual([]);
+  expect(validateType([123, "abc"], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not a string", path: [0] },
     { message: "value is not a number", path: [1] },
   ]);
-  expect(validateType(["abc"], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(["abc"], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "tuple value does not have the correct length" },
   ]);
-  expect(validateType([123], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType([123], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "tuple value does not have the correct length" },
   ]);
-  expect(validateType(["abc", true], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(["abc", true], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not a number", path: [1] },
   ]);
-  expect(validateType([true, 123], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType([true, 123], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "value is not a string", path: [0] },
   ]);
-  expect(validateType(["abc", 123, true], t.tuple([t.string, t.number]))).toMatchObject([
+  expect(validateType(["abc", 123, true], t.tuple([t.string(), t.number()]))).toMatchObject([
     { message: "tuple value does not have the correct length" },
   ]);
-  expect(validateType(["abc", 123, true], t.tuple([t.string, t.number, t.boolean]))).toEqual([]);
-  expect(validateType(["abc", 123, 123], t.tuple([t.string, t.number, t.boolean]))).toMatchObject([
-    { message: "value is not a boolean", path: [2] },
-  ]);
+  expect(validateType(["abc", 123, true], t.tuple([t.string(), t.number(), t.boolean()]))).toEqual(
+    []
+  );
+  expect(
+    validateType(["abc", 123, 123], t.tuple([t.string(), t.number(), t.boolean()]))
+  ).toMatchObject([{ message: "value is not a boolean", path: [2] }]);
 });
 
 test("or", () => {
-  expect(validateType("", t.or([t.string, t.number]))).toEqual([]);
-  expect(validateType("abc", t.or([t.string, t.number]))).toEqual([]);
-  expect(validateType(123, t.or([t.string, t.number]))).toEqual([]);
-  expect(validateType(987, t.or([t.string, t.number]))).toEqual([]);
-  expect(validateType(true, t.or([t.string, t.number]))).toMatchObject([
+  expect(validateType("", t.or([t.string(), t.number()]))).toEqual([]);
+  expect(validateType("abc", t.or([t.string(), t.number()]))).toEqual([]);
+  expect(validateType(123, t.or([t.string(), t.number()]))).toEqual([]);
+  expect(validateType(987, t.or([t.string(), t.number()]))).toEqual([]);
+  expect(validateType(true, t.or([t.string(), t.number()]))).toMatchObject([
     {
       message: "value does not match union type",
       subIssues: [{ message: "value is not a string" }, { message: "value is not a number" }],
     },
   ]);
-  expect(validateType({}, t.or([t.string, t.number]))).toMatchObject([
+  expect(validateType({}, t.or([t.string(), t.number()]))).toMatchObject([
     {
       message: "value does not match union type",
       subIssues: [{ message: "value is not a string" }, { message: "value is not a number" }],
     },
   ]);
-  expect(validateType([], t.or([t.string, t.number]))).toMatchObject([
+  expect(validateType([], t.or([t.string(), t.number()]))).toMatchObject([
     {
       message: "value does not match union type",
       subIssues: [{ message: "value is not a string" }, { message: "value is not a number" }],
     },
   ]);
-  expect(validateType([], t.or([t.string, t.array(t.number)]))).toEqual([]);
-  expect(validateType([""], t.or([t.string, t.array(t.number)]))).toMatchObject([
+  expect(validateType([], t.or([t.string(), t.array(t.number())]))).toEqual([]);
+  expect(validateType([""], t.or([t.string(), t.array(t.number())]))).toMatchObject([
     { message: "value is not a number", path: [0] },
   ]);
 });
 
 test("complex type", () => {
   const complexType = t.object({
-    "a?": t.number,
+    "a?": t.number(),
     b: t.array(
       t.object({
         a: t.instanceOf(A),
-        "b?": t.or([t.number, t.literal(false)]),
-        c: t.tuple([t.string, t.string]),
+        "b?": t.or([t.number(), t.literal(false)]),
+        c: t.tuple([t.string(), t.string()]),
       })
     ),
   });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,4 +1,4 @@
-import { assertType, computed, signal, types as t, validateType } from "../src";
+import { assertType, Component, computed, signal, types as t, validateType } from "../src";
 
 class A {}
 
@@ -125,6 +125,17 @@ test("constructor", () => {
   expect(validateType(new C(), t.constructor(A))).toMatchObject([issue]);
   expect(validateType([], t.constructor(A))).toMatchObject([issue]);
   expect(validateType(() => {}, t.constructor(A))).toMatchObject([issue]);
+});
+
+test("component", () => {
+  class MyComponent extends Component {}
+  const issue = { message: "value is not 'Component' or an extension" };
+  expect(validateType(Component, t.component)).toEqual([]);
+  expect(validateType(MyComponent, t.component)).toEqual([]);
+  expect(validateType(true, t.component)).toMatchObject([issue]);
+  expect(validateType("abc", t.component)).toMatchObject([issue]);
+  expect(validateType(A, t.component)).toMatchObject([issue]);
+  expect(validateType(new MyComponent(null as any), t.component)).toMatchObject([issue]);
 });
 
 test("customValidator", () => {


### PR DESCRIPTION
It is expected to be a common need to validate that the type of a value is a component constructor. To make it a better experience, we add in this commit a helper t.component to do just that.