### PR TITLE
[IMP] runtime: improve call stack in errors

### DIFF
--- a/docs/owl.js
+++ b/docs/owl.js
@@ -2000,51 +2000,11 @@ function untrack(fn) {
 // Maps fibers to thrown errors
 const fibersInError = new WeakMap();
 const nodeErrorHandlers = new WeakMap();
-function destroyApp(app, error) {
-    try {
-        app.destroy();
-    }
-    catch (e) {
-        // mute all errors here because we are in a corrupted state anyway
-    }
-    const e = Object.assign(new OwlError(`[Owl] Unhandled error. Destroying the root component`), {
-        cause: error,
-    });
-    return e;
-}
-function _handleError(node, error) {
-    if (!node) {
-        return false;
-    }
-    const fiber = node.fiber;
-    if (fiber) {
-        fibersInError.set(fiber, error);
-    }
-    const errorHandlers = nodeErrorHandlers.get(node);
-    if (errorHandlers) {
-        let handled = false;
-        // execute in the opposite order
-        const finalize = () => destroyApp(node.app, error);
-        for (let i = errorHandlers.length - 1; i >= 0; i--) {
-            try {
-                errorHandlers[i](error, finalize);
-                handled = true;
-                break;
-            }
-            catch (e) {
-                error = e;
-            }
-        }
-        if (handled) {
-            return true;
-        }
-    }
-    return _handleError(node.parent, error);
-}
 function handleError(params) {
     let { error } = params;
-    const node = "node" in params ? params.node : params.fiber.node;
+    let node = "node" in params ? params.node : params.fiber.node;
     const fiber = "fiber" in params ? params.fiber : node.fiber;
+    const app = node.app;
     if (fiber) {
         // resets the fibers on components if possible. This is important so that
         // new renderings can be properly included in the initial one, if any.
@@ -2056,10 +2016,43 @@ function handleError(params) {
         } while (current);
         fibersInError.set(fiber.root, error);
     }
-    const handled = _handleError(node, error);
-    if (!handled) {
-        throw destroyApp(node.app, error);
+    const finalize = () => {
+        try {
+            app.destroy();
+        }
+        catch (e) {
+            // mute all errors here because we are in a corrupted state anyway
+        }
+        return Object.assign(new OwlError(`[Owl] Unhandled error. Destroying the root component`), {
+            cause: error,
+        });
+    };
+    // Walk up the component tree looking for error handlers
+    while (node) {
+        const nodeFiber = node.fiber;
+        if (nodeFiber) {
+            fibersInError.set(nodeFiber, error);
+        }
+        const errorHandlers = nodeErrorHandlers.get(node);
+        if (errorHandlers) {
+            // execute in the opposite order
+            for (let i = errorHandlers.length - 1; i >= 0; i--) {
+                try {
+                    errorHandlers[i](error, finalize);
+                    return; // handled
+                }
+                catch (e) {
+                    error = e;
+                }
+            }
+        }
+        node = node.parent;
     }
+    // No handler found — create the OwlError, then let the app handle it.
+    // app._handleError is called after error creation, so it doesn't appear
+    // in the error's .stack property.
+    const owlError = finalize();
+    app._handleError(owlError);
 }
 
 function makeChildFiber(node, parent) {
@@ -2195,7 +2188,7 @@ class Fiber {
                 this.bdom = node.renderFn();
             }
             catch (e) {
-                node.app.handleError({ node, error: e });
+                handleError({ node, error: e });
             }
             setComputation(c);
             root.setCounter(root.counter - 1);
@@ -2265,7 +2258,7 @@ class RootFiber extends Fiber {
                 fiber.node.willUnmount = [];
             }
             this.locked = false;
-            node.app.handleError({ fiber: current || this, error: e });
+            handleError({ fiber: current || this, error: e });
         }
     }
     setCounter(newValue) {
@@ -2321,7 +2314,7 @@ class MountFiber extends RootFiber {
             }
         }
         catch (e) {
-            this.node.app.handleError({ fiber: current, error: e });
+            handleError({ fiber: current, error: e });
         }
     }
 }
@@ -2399,7 +2392,7 @@ class ComponentNode {
             await Promise.all(promises);
         }
         catch (e) {
-            this.app.handleError({ node: this, error: e });
+            handleError({ node: this, error: e });
             return;
         }
         if (this.status === 0 /* STATUS.NEW */ && this.fiber === fiber) {
@@ -2489,7 +2482,7 @@ class ComponentNode {
                 }
             }
             catch (e) {
-                this.app.handleError({ error: e, node: this });
+                handleError({ error: e, node: this });
             }
         }
         for (const computation of this.computations) {
@@ -5870,8 +5863,33 @@ class Scheduler {
             node._destroy();
         }
         this.cancelledNodes.clear();
-        for (let task of this.tasks) {
-            this.processFiber(task);
+        for (let fiber of this.tasks) {
+            if (fiber.root !== fiber) {
+                this.tasks.delete(fiber);
+                continue;
+            }
+            const hasError = fibersInError.has(fiber);
+            if (hasError && fiber.counter !== 0) {
+                this.tasks.delete(fiber);
+                continue;
+            }
+            if (fiber.node.status === 3 /* STATUS.DESTROYED */) {
+                this.tasks.delete(fiber);
+                continue;
+            }
+            if (fiber.counter === 0) {
+                if (!hasError) {
+                    fiber.complete();
+                }
+                // at this point, the fiber should have been applied to the DOM, so we can
+                // remove it from the task list. If it is not the case, it means that there
+                // was an error and an error handler triggered a new rendering that recycled
+                // the fiber, so in that case, we actually want to keep the fiber around,
+                // otherwise it will just be ignored.
+                if (fiber.appliedToDom) {
+                    this.tasks.delete(fiber);
+                }
+            }
         }
         for (let task of this.tasks) {
             if (task.node.status === 3 /* STATUS.DESTROYED */) {
@@ -5879,34 +5897,6 @@ class Scheduler {
             }
         }
         this.processing = false;
-    }
-    processFiber(fiber) {
-        if (fiber.root !== fiber) {
-            this.tasks.delete(fiber);
-            return;
-        }
-        const hasError = fibersInError.has(fiber);
-        if (hasError && fiber.counter !== 0) {
-            this.tasks.delete(fiber);
-            return;
-        }
-        if (fiber.node.status === 3 /* STATUS.DESTROYED */) {
-            this.tasks.delete(fiber);
-            return;
-        }
-        if (fiber.counter === 0) {
-            if (!hasError) {
-                fiber.complete();
-            }
-            // at this point, the fiber should have been applied to the DOM, so we can
-            // remove it from the task list. If it is not the case, it means that there
-            // was an error and an error handler triggered a new rendering that recycled
-            // the fiber, so in that case, we actually want to keep the fiber around,
-            // otherwise it will just be ignored.
-            if (fiber.appliedToDom) {
-                this.tasks.delete(fiber);
-            }
-        }
     }
 }
 
@@ -6007,8 +5997,8 @@ class App extends TemplateSet {
         this.scheduler.processTasks();
         apps.delete(this);
     }
-    handleError(...args) {
-        return handleError(...args);
+    _handleError(error) {
+        throw error;
     }
 }
 async function mount(C, target, config = {}) {
@@ -6066,14 +6056,20 @@ const mainEventHandler = (data, ev, currentTarget) => {
 //  hooks
 // -----------------------------------------------------------------------------
 function decorate(node, f, hookName) {
-    const result = f.bind(node.component);
     if (node.app.dev) {
-        const suffix = f.name ? ` <${f.name}>` : "";
-        Reflect.defineProperty(result, "name", {
-            value: hookName + suffix,
-        });
+        const component = node.component;
+        const componentName = component ? component.constructor.name : "Component";
+        const name = `${componentName}.${hookName}`;
+        // Create a named wrapper so the name appears in stack traces.
+        // V8 uses computed property keys as inferred function names.
+        const wrapper = {
+            [name]() {
+                return f.call(component);
+            },
+        };
+        return wrapper[name];
     }
-    return result;
+    return f.bind(node.component);
 }
 function onWillStart(fn) {
     const { node } = getContext("component");
@@ -6331,22 +6327,30 @@ class Registry {
     }
 }
 
-const anyType = function validateAny() { };
-const booleanType = function validateBoolean(context) {
-    if (typeof context.value !== "boolean") {
-        context.addIssue({ message: "value is not a boolean" });
-    }
-};
-const numberType = function validateNumber(context) {
-    if (typeof context.value !== "number") {
-        context.addIssue({ message: "value is not a number" });
-    }
-};
-const stringType = function validateString(context) {
-    if (typeof context.value !== "string") {
-        context.addIssue({ message: "value is not a string" });
-    }
-};
+function anyType() {
+    return function validateAny() { };
+}
+function booleanType() {
+    return function validateBoolean(context) {
+        if (typeof context.value !== "boolean") {
+            context.addIssue({ message: "value is not a boolean" });
+        }
+    };
+}
+function numberType() {
+    return function validateNumber(context) {
+        if (typeof context.value !== "number") {
+            context.addIssue({ message: "value is not a number" });
+        }
+    };
+}
+function stringType() {
+    return function validateString(context) {
+        if (typeof context.value !== "string") {
+            context.addIssue({ message: "value is not a string" });
+        }
+    };
+}
 function arrayType(elementType) {
     return function validateArray(context) {
         if (!Array.isArray(context.value)) {
@@ -6537,6 +6541,9 @@ function reactiveValueType(type) {
         }
     };
 }
+function componentType() {
+    return constructorType(Component);
+}
 function ref(type) {
     return union([literalType(null), instanceType(type)]);
 }
@@ -6545,6 +6552,7 @@ const types = {
     any: anyType,
     array: arrayType,
     boolean: booleanType,
+    component: componentType,
     constructor: constructorType,
     customValidator: customValidator,
     function: functionType,
@@ -6771,6 +6779,6 @@ TemplateSet.prototype._compileTemplate = function _compileTemplate(name, templat
 export { App, Component, EventBus, OwlError, Plugin, Registry, Resource, __info__, assertType, batched, blockDom, computed, config, effect, htmlEscape, markRaw, markup, mount, onError, onMounted, onPatched, onWillDestroy, onWillPatch, onWillStart, onWillUnmount, onWillUpdateProps, plugin, props, providePlugins, proxy, signal, status, toRaw, types, untrack, useApp, useContext, useEffect, useListener, useResource, validateType, whenReady, xml };
 
 
-__info__.date = '2026-04-08T13:31:02.500Z';
-__info__.hash = '2e9164e';
+__info__.date = '2026-04-09T13:05:14.047Z';
+__info__.hash = 'abbb2fb';
 __info__.url = 'https://github.com/odoo/owl';

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -5,7 +5,7 @@ import { saveContext } from "./context";
 import { PluginConstructor, PluginManager, startPlugins } from "./plugin_manager";
 import { GetProps } from "./props";
 import { proxy, toRaw } from "./reactivity/proxy";
-import { handleError, nodeErrorHandlers } from "./rendering/error_handling";
+import { nodeErrorHandlers } from "./rendering/error_handling";
 import { Fiber, MountOptions, RootFiber } from "./rendering/fibers";
 import { Scheduler } from "./rendering/scheduler";
 import { Resource } from "./resource";
@@ -167,8 +167,8 @@ export class App extends TemplateSet {
     apps.delete(this);
   }
 
-  handleError(...args: Parameters<typeof handleError>) {
-    return handleError(...args);
+  _handleError(error: any) {
+    throw error;
   }
 }
 

--- a/src/runtime/component_node.ts
+++ b/src/runtime/component_node.ts
@@ -11,7 +11,7 @@ import {
   getCurrentComputation,
   setComputation,
 } from "./reactivity/computations";
-import { fibersInError } from "./rendering/error_handling";
+import { fibersInError, handleError } from "./rendering/error_handling";
 import { Fiber, makeChildFiber, makeRootFiber, MountFiber, MountOptions } from "./rendering/fibers";
 import { STATUS } from "./status";
 
@@ -109,7 +109,7 @@ export class ComponentNode implements VNode<ComponentNode> {
       setComputation(prev);
       await Promise.all(promises!);
     } catch (e) {
-      this.app.handleError({ node: this, error: e });
+      handleError({ node: this, error: e });
       return;
     }
     if (this.status === STATUS.NEW && this.fiber === fiber) {
@@ -204,7 +204,7 @@ export class ComponentNode implements VNode<ComponentNode> {
           cb.call(component);
         }
       } catch (e) {
-        this.app.handleError({ error: e, node: this });
+        handleError({ error: e, node: this });
       }
     }
     for (const computation of this.computations) {

--- a/src/runtime/lifecycle_hooks.ts
+++ b/src/runtime/lifecycle_hooks.ts
@@ -7,14 +7,20 @@ import { nodeErrorHandlers } from "./rendering/error_handling";
 // -----------------------------------------------------------------------------
 
 function decorate(node: ComponentNode, f: Function, hookName: string) {
-  const result = f.bind(node.component);
   if (node.app.dev) {
-    const suffix = f.name ? ` <${f.name}>` : "";
-    Reflect.defineProperty(result, "name", {
-      value: hookName + suffix,
-    });
+    const component = node.component;
+    const componentName = component ? component.constructor.name : "Component";
+    const name = `${componentName}.${hookName}`;
+    // Create a named wrapper so the name appears in stack traces.
+    // V8 uses computed property keys as inferred function names.
+    const wrapper = {
+      [name]() {
+        return f.call(component);
+      },
+    };
+    return wrapper[name];
   }
-  return result;
+  return f.bind(node.component);
 }
 
 export function onWillStart(fn: () => Promise<void> | void | any) {

--- a/src/runtime/rendering/error_handling.ts
+++ b/src/runtime/rendering/error_handling.ts
@@ -1,5 +1,4 @@
 import { OwlError } from "../../common/owl_error";
-import type { App } from "../app";
 import type { ComponentNode } from "../component_node";
 import type { Fiber } from "./fibers";
 
@@ -10,54 +9,12 @@ export const nodeErrorHandlers: WeakMap<
   ((error: any, finalize: Function) => void)[]
 > = new WeakMap();
 
-function destroyApp(app: App, error: Error): OwlError {
-  try {
-    app.destroy();
-  } catch (e) {
-    // mute all errors here because we are in a corrupted state anyway
-  }
-  const e = Object.assign(new OwlError(`[Owl] Unhandled error. Destroying the root component`), {
-    cause: error,
-  });
-  return e;
-}
-
-function _handleError(node: ComponentNode | null, error: any): boolean {
-  if (!node) {
-    return false;
-  }
-  const fiber = node.fiber;
-  if (fiber) {
-    fibersInError.set(fiber, error);
-  }
-
-  const errorHandlers = nodeErrorHandlers.get(node);
-  if (errorHandlers) {
-    let handled = false;
-    // execute in the opposite order
-    const finalize = () => destroyApp(node.app, error);
-    for (let i = errorHandlers.length - 1; i >= 0; i--) {
-      try {
-        errorHandlers[i](error, finalize);
-        handled = true;
-        break;
-      } catch (e) {
-        error = e;
-      }
-    }
-
-    if (handled) {
-      return true;
-    }
-  }
-  return _handleError(node.parent, error);
-}
-
 type ErrorParams = { error: any } & ({ node: ComponentNode } | { fiber: Fiber });
 export function handleError(params: ErrorParams) {
   let { error } = params;
-  const node = "node" in params ? params.node : params.fiber.node;
-  const fiber = "fiber" in params ? params.fiber : node.fiber;
+  let node: ComponentNode | null = "node" in params ? params.node : params.fiber.node;
+  const fiber = "fiber" in params ? params.fiber : node!.fiber;
+  const app = node!.app;
 
   if (fiber) {
     // resets the fibers on components if possible. This is important so that
@@ -72,8 +29,42 @@ export function handleError(params: ErrorParams) {
     fibersInError.set(fiber.root!, error);
   }
 
-  const handled = _handleError(node, error);
-  if (!handled) {
-    throw destroyApp(node.app, error);
+  const finalize = () => {
+    try {
+      app.destroy();
+    } catch (e) {
+      // mute all errors here because we are in a corrupted state anyway
+    }
+    return Object.assign(new OwlError(`[Owl] Unhandled error. Destroying the root component`), {
+      cause: error,
+    });
+  };
+
+  // Walk up the component tree looking for error handlers
+  while (node) {
+    const nodeFiber = node.fiber;
+    if (nodeFiber) {
+      fibersInError.set(nodeFiber, error);
+    }
+
+    const errorHandlers = nodeErrorHandlers.get(node);
+    if (errorHandlers) {
+      // execute in the opposite order
+      for (let i = errorHandlers.length - 1; i >= 0; i--) {
+        try {
+          errorHandlers[i](error, finalize);
+          return; // handled
+        } catch (e) {
+          error = e;
+        }
+      }
+    }
+    node = node.parent;
   }
+
+  // No handler found — create the OwlError, then let the app handle it.
+  // app._handleError is called after error creation, so it doesn't appear
+  // in the error's .stack property.
+  const owlError = finalize();
+  app._handleError(owlError);
 }

--- a/src/runtime/rendering/fibers.ts
+++ b/src/runtime/rendering/fibers.ts
@@ -3,7 +3,7 @@ import { BDom, mount } from "../blockdom";
 import type { ComponentNode } from "../component_node";
 import { getCurrentComputation, removeSources, setComputation } from "../reactivity/computations";
 import { STATUS } from "../status";
-import { fibersInError } from "./error_handling";
+import { fibersInError, handleError } from "./error_handling";
 
 export function makeChildFiber(node: ComponentNode, parent: Fiber): Fiber {
   let current = node.fiber;
@@ -142,7 +142,7 @@ export class Fiber {
         (this.bdom as any) = true;
         this.bdom = node.renderFn();
       } catch (e) {
-        node.app.handleError({ node, error: e });
+        handleError({ node, error: e });
       }
       setComputation(c);
       root.setCounter(root.counter - 1);
@@ -217,7 +217,7 @@ export class RootFiber extends Fiber {
         fiber.node.willUnmount = [];
       }
       this.locked = false;
-      node.app.handleError({ fiber: current || this, error: e });
+      handleError({ fiber: current || this, error: e });
     }
   }
 
@@ -281,7 +281,7 @@ export class MountFiber extends RootFiber {
         }
       }
     } catch (e) {
-      this.node.app.handleError({ fiber: current as Fiber, error: e });
+      handleError({ fiber: current as Fiber, error: e });
     }
   }
 }

--- a/src/runtime/rendering/scheduler.ts
+++ b/src/runtime/rendering/scheduler.ts
@@ -68,8 +68,33 @@ export class Scheduler {
       node._destroy();
     }
     this.cancelledNodes.clear();
-    for (let task of this.tasks) {
-      this.processFiber(task);
+    for (let fiber of this.tasks) {
+      if (fiber.root !== fiber) {
+        this.tasks.delete(fiber);
+        continue;
+      }
+      const hasError = fibersInError.has(fiber);
+      if (hasError && fiber.counter !== 0) {
+        this.tasks.delete(fiber);
+        continue;
+      }
+      if (fiber.node.status === STATUS.DESTROYED) {
+        this.tasks.delete(fiber);
+        continue;
+      }
+      if (fiber.counter === 0) {
+        if (!hasError) {
+          fiber.complete();
+        }
+        // at this point, the fiber should have been applied to the DOM, so we can
+        // remove it from the task list. If it is not the case, it means that there
+        // was an error and an error handler triggered a new rendering that recycled
+        // the fiber, so in that case, we actually want to keep the fiber around,
+        // otherwise it will just be ignored.
+        if (fiber.appliedToDom) {
+          this.tasks.delete(fiber);
+        }
+      }
     }
     for (let task of this.tasks) {
       if (task.node.status === STATUS.DESTROYED) {
@@ -77,35 +102,5 @@ export class Scheduler {
       }
     }
     this.processing = false;
-  }
-
-  processFiber(fiber: RootFiber) {
-    if (fiber.root !== fiber) {
-      this.tasks.delete(fiber);
-      return;
-    }
-    const hasError = fibersInError.has(fiber);
-    if (hasError && fiber.counter !== 0) {
-      this.tasks.delete(fiber);
-      return;
-    }
-    if (fiber.node.status === STATUS.DESTROYED) {
-      this.tasks.delete(fiber);
-      return;
-    }
-
-    if (fiber.counter === 0) {
-      if (!hasError) {
-        fiber.complete();
-      }
-      // at this point, the fiber should have been applied to the DOM, so we can
-      // remove it from the task list. If it is not the case, it means that there
-      // was an error and an error handler triggered a new rendering that recycled
-      // the fiber, so in that case, we actually want to keep the fiber around,
-      // otherwise it will just be ignored.
-      if (fiber.appliedToDom) {
-        this.tasks.delete(fiber);
-      }
-    }
   }
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -277,7 +277,7 @@ expect.extend({
 });
 
 export function nextAppError(app: any) {
-  const { handleError } = app;
+  const { _handleError } = app;
   const rootPromises = [...app.roots].map((r) => r.promise);
 
   let settled = false;
@@ -285,19 +285,15 @@ export function nextAppError(app: any) {
   const done = (error: any, restore = true) => {
     if (settled) return;
     settled = true;
-    if (restore) app.handleError = handleError;
+    if (restore) app._handleError = _handleError;
     resolve(error);
   };
 
   let resolve: (value: any) => void;
   const result = new Promise((res) => (resolve = res));
 
-  app.handleError = (...args: Parameters<typeof handleError>) => {
-    try {
-      handleError.call(app, ...args);
-    } catch (e) {
-      done(e);
-    }
+  app._handleError = (error: any) => {
+    done(error);
   };
 
   for (const p of rootPromises) {


### PR DESCRIPTION
In this commit, we reduce the number of frames in errors, to make it easier to understand. We also add a named wrapper function for lifecycle hooks so we can have the important context when debugging. An error could look like this now:

OwlError: [Owl] Unhandled error. Destroying the root component
    at finalize (owl.js:2026:30)
    at Array.<anonymous> (owl.js:5981:32)
    at handleError (owl.js:2041:37)
    at MountFiber.complete (owl.js:2317:13)
    at Scheduler.processTasks (owl.js:5882:27)
    at owl.js:5853:64
Caused by: Error: boom
    at ProductCard.<anonymous> (543e3ccd-78ac-4a27-9132-94af59b65ed1:9:19)
    at ProductCard.onMounted (owl.js:6067:26)
    at MountFiber.complete (owl.js:2311:25)
    at Scheduler.processTasks (owl.js:5882:27)
    at owl.js:5853:64