### PR TITLE
[FIX] compiler: do not generate invalid template names

### DIFF
--- a/src/compiler/code_generator.ts
+++ b/src/compiler/code_generator.ts
@@ -284,7 +284,7 @@ export class CodeGenerator {
     this.ast = ast;
     this.templateName = options.name;
     if (options.name && !options.name.startsWith("__")) {
-      this.target.name = `template_${options.name.replace(/\./g, "_")}`;
+      this.target.name = `template_${options.name.replace(/[^a-zA-Z0-9_$]/g, "_")}`;
     }
     if (options.hasGlobalValues) {
       this.helpers.add("__globals__");

--- a/tests/compiler/simple_templates.test.ts
+++ b/tests/compiler/simple_templates.test.ts
@@ -176,9 +176,15 @@ describe("simple templates, mostly static", () => {
     expect(fn.toString()).toContain("function template_MyComponent(");
   });
 
-  test("compiled template function name uses dots replaced by underscores", () => {
+  test("compiled template function name replaces special characters with underscores", () => {
     const fn = compile("<div>hello</div>", { name: "app.MyComponent", hasGlobalValues: false });
     expect(fn.toString()).toContain("function template_app_MyComponent(");
+
+    const fn2 = compile("<div>hello</div>", {
+      name: "o-spreadsheet-grid",
+      hasGlobalValues: false,
+    });
+    expect(fn2.toString()).toContain("function template_o_spreadsheet_grid(");
   });
 
   test("compiled template function has default name for anonymous templates", () => {

--- a/tests/components/template_naming.test.ts
+++ b/tests/components/template_naming.test.ts
@@ -22,6 +22,20 @@ describe("template naming", () => {
     app.destroy();
   });
 
+  test("component with hyphenated template name has named template function", async () => {
+    const app = new App();
+    app.addTemplate("o-spreadsheet-grid", "<div>grid</div>");
+    class Grid extends Component {
+      static template = "o-spreadsheet-grid";
+    }
+    const root = app.createRoot(Grid);
+    await root.mount(fixture);
+    expect(fixture.innerHTML).toBe("<div>grid</div>");
+    const templateFn = app.getTemplate("o-spreadsheet-grid");
+    expect(templateFn.name).toBe("template_o_spreadsheet_grid");
+    app.destroy();
+  });
+
   test("component with inline xml template has generic template function name", async () => {
     class MyWidget extends Component {
       static template = xml`<div>hello</div>`;


### PR DESCRIPTION
A previous commit improved the template generated names to make it more explicit. However, it was a little too simple and it breaks templates that contains some characters, for example, a '-'.

This commit makes the generated name more robust by replacing all non letter and number characters by a _.