### PR TITLE
[FIX] blockdom: null attribute

### DIFF
--- a/packages/owl/src/runtime/blockdom/attributes.ts
+++ b/packages/owl/src/runtime/blockdom/attributes.ts
@@ -23,6 +23,7 @@ const wordRegexp = /\s+/;
 function setAttribute(this: HTMLElement, key: string, value: any) {
   switch (value) {
     case false:
+    case null:
     case undefined:
       removeAttribute.call(this, key);
       break;


### PR DESCRIPTION
A `null` value behaves different to `false` and `undefined` in the rendering of a `t-att`. Here we match the behaviour