### PR TITLE
[FIX] playground: fix HtmlEditor demo issues in OWL3 playground

### DIFF
--- a/tools/playground/samples/html_editor/html_editor/html_editor.js
+++ b/tools/playground/samples/html_editor/html_editor/html_editor.js
@@ -1,18 +1,18 @@
-import { Component, signal, useEffect } from "@odoo/owl";
+import { Component, signal, onMounted, props, types as t } from "@odoo/owl";
 
 export class HtmlEditor extends Component {
   static template = "demo.HtmlEditor";
-  static props = {
-    html: { type: Object, optional: true },
-  };
+  props = props({
+    "html?": t.signal(),
+  });
 
   setup() {
     this.editorRef = signal(null);
 
-    useEffect(() => {
+    onMounted(() => {
       const el = this.editorRef();
       if (el && this.props.html) {
-        el.innerHTML = this.props.html.value;
+        el.innerHTML = this.props.html();
       }
     });
   }

--- a/tools/playground/samples/html_editor/html_editor/html_editor.xml
+++ b/tools/playground/samples/html_editor/html_editor/html_editor.xml
@@ -16,9 +16,9 @@
         <button t-on-click="this.insertLink" title="Insert link">🔗</button>
       </div>
       <div class="editor-content" contenteditable="true" t-ref="this.editorRef" t-on-input="this.updateHtml"/>
-      <details class="html-output">
+      <details class="html-output" t-if="this.props.html">
         <summary>HTML Output</summary>
-        <pre t-out="this.props.html.value"/>
+        <pre t-out="this.props.html()"/>
       </details>
     </div>
   </t>

--- a/tools/playground/samples/html_editor/main.js
+++ b/tools/playground/samples/html_editor/main.js
@@ -1,5 +1,5 @@
 import { Component, mount, signal, xml } from "@odoo/owl";
-import { HtmlEditor } from "./html_editor/html_editor.js";
+import { HtmlEditor } from "./html_editor.js";
 
 class Root extends Component {
   static template = xml`<HtmlEditor html="this.html"/>`;


### PR DESCRIPTION
Before:
- HtmlEditor component import path was incorrect (extra `html_editor` directory)
- Deprecated OWL2-style props definition caused props to be undefined
- Optional `html` prop was not safely handled, leading to potential runtime errors

After:
- Corrected the import path for the HtmlEditor component
- Migrated props definition to OWL3 standards to ensure proper initialization
- Safely handled the optional `html` prop and render output only when available

These changes restore the demo functionality and align it with OWL3 conventions.