### PR TITLE
[FIX] lifecycle: catch rejections in async onWillUpdateProps hooks

### DIFF
--- a/packages/owl-runtime/src/rendering/template_helpers.ts
+++ b/packages/owl-runtime/src/rendering/template_helpers.ts
@@ -14,6 +14,7 @@ import { html } from "../blockdom/index";
 import { Component } from "../component";
 import { ComponentNode } from "../component_node";
 import { Markup } from "../utils";
+import { handleError } from "./error_handling";
 import { Fiber, makeChildFiber } from "./fibers";
 
 const ObjectCreate = Object.create;
@@ -291,11 +292,16 @@ function createComponent<P extends Record<string, any>>(
         }
         if (promises) {
           const p = promises.length === 1 ? promises[0] : Promise.all(promises);
-          p.then(() => {
-            if (fiber !== node.fiber) return;
-            node.props = props;
-            fiber.render();
-          });
+          p.then(
+            () => {
+              if (fiber !== node.fiber) return;
+              node.props = props;
+              fiber.render();
+            },
+            (error) => {
+              handleError({ node, error });
+            }
+          );
         } else {
           node.props = props;
           fiber.render();

--- a/packages/owl-runtime/tests/components/__snapshots__/error_handling.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/error_handling.test.ts.snap
@@ -1656,3 +1656,84 @@ exports[`errors and promises > wrapped errors in async code are correctly caught
   }
 }"
 `;
+
+exports[`errors in onWillUpdateProps > async error in onWillUpdateProps is caught by child's own onError 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["val"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {val: ctx['this'].state.val};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`errors in onWillUpdateProps > async error in onWillUpdateProps is caught by child's own onError 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`errors in onWillUpdateProps > async error in onWillUpdateProps is caught by parent onError 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["val"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {val: ctx['this'].state.val};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`errors in onWillUpdateProps > async error in onWillUpdateProps is caught by parent onError 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`errors in onWillUpdateProps > sync error in onWillUpdateProps is caught by parent onError 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["val"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {val: ctx['this'].state.val};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`errors in onWillUpdateProps > sync error in onWillUpdateProps is caught by parent onError 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;

--- a/packages/owl-runtime/tests/components/error_handling.test.ts
+++ b/packages/owl-runtime/tests/components/error_handling.test.ts
@@ -6,6 +6,7 @@ import {
   onWillPatch,
   onWillStart,
   onWillUnmount,
+  onWillUpdateProps,
   proxy,
   xml,
 } from "../../src";
@@ -1753,5 +1754,93 @@ describe("can catch errors", () => {
         "Root:patched",
       ]
     `);
+  });
+});
+
+describe("errors in onWillUpdateProps", () => {
+  test("sync error in onWillUpdateProps is caught by parent onError", async () => {
+    let error: any;
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = props();
+      setup() {
+        onWillUpdateProps(() => {
+          throw new Error("sync boom");
+        });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child val="this.state.val"/>`;
+      static components = { Child };
+      state = proxy({ val: 0 });
+      setup() {
+        onError((e) => (error = e));
+      }
+    }
+
+    const parent = await mount(Parent, fixture, { test: true });
+    parent.state.val = 1; // triggers child re-render → onWillUpdateProps throws
+    render(parent);
+    await nextTick();
+    expect(error).toBeDefined();
+    expect(error.message).toBe("sync boom");
+  });
+
+  test("async error in onWillUpdateProps is caught by parent onError", async () => {
+    let error: any;
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = props();
+      setup() {
+        onWillUpdateProps(async () => {
+          await Promise.resolve();
+          throw new Error("async boom");
+        });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child val="this.state.val"/>`;
+      static components = { Child };
+      state = proxy({ val: 0 });
+      setup() {
+        onError((e) => (error = e));
+      }
+    }
+
+    const parent = await mount(Parent, fixture, { test: true });
+    parent.state.val = 1;
+    render(parent);
+    await nextTick();
+    await nextTick();
+    expect(error).toBeDefined();
+    expect(error.message).toBe("async boom");
+  });
+
+  test("async error in onWillUpdateProps is caught by child's own onError", async () => {
+    let error: any;
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = props();
+      setup() {
+        onError((e) => (error = e));
+        onWillUpdateProps(async () => {
+          await Promise.resolve();
+          throw new Error("async boom from child");
+        });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child val="this.state.val"/>`;
+      static components = { Child };
+      state = proxy({ val: 0 });
+    }
+
+    const parent = await mount(Parent, fixture, { test: true });
+    parent.state.val = 1;
+    render(parent);
+    await nextTick();
+    await nextTick();
+    expect(error).toBeDefined();
+    expect(error.message).toBe("async boom from child");
   });
 });


### PR DESCRIPTION
Async onWillUpdateProps hooks that threw were never caught: the promise chain in template_helpers only wired up a .then() success handler, so rejections escaped as unhandled promise rejections, bypassing onError entirely. Sync throws already worked because they propagated through the parent's renderFn into fiber.render()'s try/catch.

Wire a rejection handler on the same promise, routing through handleError({ node, error }) — matching the onWillStart precedent, so the child's own onError fires first, then ancestors up the tree.