### PR TITLE
[IMP] build: skip sibling type builds when building owl.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:runtime": "npm run build -w packages/owl-core && npm run build -w packages/owl-runtime",
     "build:compiler": "npm run build -w packages/owl-core && npm run build -w packages/owl-compiler",
     "build:core": "npm run build -w packages/owl-core",
-    "build:types": "npm run build:types -w packages/owl-core && npm run build:types -w packages/owl-compiler && npm run build:types -w packages/owl-runtime && npm run build:types -w packages/owl",
+    "build:types": "npm run build:types -w packages/owl",
     "build:devtools": "node tools/devtools/build.mjs",
     "dev:devtools-chrome": "node tools/devtools/build.mjs --browser=chrome",
     "dev:devtools-firefox": "node tools/devtools/build.mjs --browser=firefox",

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -66,10 +66,14 @@ export {
 export {
   types,
   constructorType,
+  type Constructor,
   type GetOptionalEntries,
   type KeyedObject,
+  type LiteralTypes,
   type PrettifyShape,
   type ResolveObjectType,
+  type ResolveOptionalEntries,
+  type UnionToIntersection,
 } from "./types";
 
 // Registry / Resource

--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -1,7 +1,7 @@
 import { atomSymbol, type ReactiveValue } from "./computations";
 import { ValidationContext, ValidationIssue } from "./validation";
 
-type Constructor<T = any> = { new (...args: any[]): T };
+export type Constructor<T = any> = { new (...args: any[]): T };
 
 export type GetOptionalEntries<T> = {
   [K in keyof T as K extends `${infer P}?` ? P : never]?: T[K];
@@ -10,7 +10,7 @@ type GetRequiredEntries<T> = {
   [K in keyof T as K extends `${string}?` ? never : K]: T[K];
 };
 export type PrettifyShape<T> = T extends Function ? T : { [K in keyof T]: T[K] };
-type ResolveOptionalEntries<T> = PrettifyShape<GetRequiredEntries<T> & GetOptionalEntries<T>>;
+export type ResolveOptionalEntries<T> = PrettifyShape<GetRequiredEntries<T> & GetOptionalEntries<T>>;
 
 export type KeyedObject<K extends string[]> = {
   [P in K[number]]: any;
@@ -21,7 +21,9 @@ export type ResolveObjectType<T extends {}> = ResolveShapedObject<
   T extends string[] ? KeyedObject<T> : T
 >;
 
-type UnionToIntersection<U> = (U extends any ? (_: U) => any : never) extends (_: infer I) => void
+export type UnionToIntersection<U> = (U extends any ? (_: U) => any : never) extends (
+  _: infer I
+) => void
   ? I
   : never;
 
@@ -126,7 +128,7 @@ function intersection<T extends any[]>(types: T): UnionToIntersection<T[number]>
   } as any;
 }
 
-type LiteralTypes = number | string | boolean | null | undefined;
+export type LiteralTypes = number | string | boolean | null | undefined;
 function literalType<const T extends LiteralTypes>(literal: T): T {
   return function validateLiteral(context: ValidationContext) {
     if (context.value !== literal) {

--- a/packages/owl/build.mjs
+++ b/packages/owl/build.mjs
@@ -51,7 +51,7 @@ async function buildVariant(entry, suffix) {
 function buildTypes() {
   mkdirSync("dist/types", { recursive: true });
   execSync(
-    "npx dts-bundle-generator --project tsconfig.json -o dist/types/owl.d.ts src/index.ts --no-banner",
+    "npx dts-bundle-generator --project tsconfig.types.json -o dist/types/owl.d.ts src/index.ts --no-banner",
     { stdio: "inherit" }
   );
 }

--- a/packages/owl/tsconfig.types.json
+++ b/packages/owl/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@odoo/owl-core": ["../owl-core/src/index.ts"],
+      "@odoo/owl-compiler": ["../owl-compiler/src/index.ts"],
+      "@odoo/owl-runtime": ["../owl-runtime/src/index.ts"]
+    }
+  }
+}


### PR DESCRIPTION
The root build:types ran dts-bundle-generator four times: once per sibling package (owl-core, owl-compiler, owl-runtime), then once on the umbrella owl package. Only @odoo/owl is published, and the umbrella bundle inlines the sibling types anyway, so the three sibling passes were wasted work — ~22s of a ~31s wall clock.

Point the umbrella's dts-bundle-generator at sibling src via tsconfig paths (the same mapping tsconfig.tests.json already uses) and drop the sibling build:types steps from the root script. To keep the generated owl.d.ts byte-identical, promote four internal aliases from owl-core/types.ts (Constructor, LiteralTypes, ResolveOptionalEntries, UnionToIntersection) to exports — without them dts-bundle-generator inlines their expansions instead of keeping the named references.

build:types now runs in ~9s.