### PR TITLE
[IMP] reactivity: rename signal.invalidate to signal.trigger

### DIFF
--- a/doc/v3/owl/owl3_design.md
+++ b/doc/v3/owl/owl3_design.md
@@ -154,7 +154,7 @@ s1.set(s1() + 31);
 Setting a signal to an identical value is ignored, so it does not trigger any
 component to be updated. However, it is something that we actually need sometimes.
 For example, if we push an element in a list. In that case, we need to explicitly
-invalidate the signal to tell Owl that everything that depends on it is now
+trigger the signal to tell Owl that everything that depends on it is now
 stale.
 
 ```js
@@ -163,13 +163,13 @@ const list = signal([1, 2, 3]);
 // does not change the content of the signal
 list().push(4);
 // so we have to manually tell owl it is no longer up to date
-signal.invalidate(list);
+signal.trigger(list);
 ```
 
 Since manipulating collections of elements is a very common need, we introduce
 four functions that basically wrap the target array, object, set or map in a
 proxy (but not a nested proxy like the `proxy` function). This is useful so
-we can properly invalidate the signal whenever the content has changed.
+we can properly trigger the signal whenever the content has changed.
 
 ```js
 
@@ -181,7 +181,7 @@ mylist().push(4);
 mylist().push({nested: {object: 1}});
 
 // here, we change deeply nested state => no change is detected, a manual
-// invalidate may be necessary, if that is what we want
+// trigger may be necessary, if that is what we want
 mylist().at(-1).nested.object = 2;
 
 // same for other collections
@@ -1390,7 +1390,7 @@ class MyComponent extends Component {
     this.model = signal(
       new VeryBigModel({
         onUpdate: () => {
-          signal.invalidate(this.model);
+          signal.trigger(this.model);
         },
       })
     );

--- a/doc/v3/owl/reference/error_handling.md
+++ b/doc/v3/owl/reference/error_handling.md
@@ -92,8 +92,9 @@ onError((error) => {
 });
 ```
 
-When an unhandled error bubbles out of the rendering cycle, Owl wraps it
-in a new `OwlError` and stores the original on the `.cause` field:
+When a non-`OwlError` (e.g. a plain `TypeError` from user code) bubbles out
+of the rendering cycle unhandled, Owl wraps it in a new `OwlError` and
+stores the original on the `.cause` field:
 
 ```js
 onError((error) => {
@@ -102,6 +103,10 @@ onError((error) => {
   console.error(error.cause ?? error);
 });
 ```
+
+Errors that are already `OwlError` instances (invalid template, missing
+registry key, failed validation, ...) are propagated as-is without an extra
+wrapper, since their message already identifies the failure.
 
 `OwlError` is a plain `Error` subclass — `.message`, `.stack`, and all the
 usual tooling work as expected. Owl does not attach numeric error codes;

--- a/doc/v3/owl/reference/reactivity.md
+++ b/doc/v3/owl/reference/reactivity.md
@@ -380,21 +380,21 @@ class MyComponent extends Component {
 }
 ```
 
-## Manual Invalidation
+## Manual Trigger
 
 When using a plain `signal` (not a collection variant) that holds a mutable
 value, mutating the value in-place does not trigger updates because the
-reference hasn't changed. In that case, you can manually invalidate the signal:
+reference hasn't changed. In that case, you can manually trigger the signal:
 
 ```js
 const list = signal([1, 2, 3]);
 
 list().push(4); // mutates in-place — no update triggered
-signal.invalidate(list); // manually notify subscribers
+signal.trigger(list); // manually notify subscribers
 ```
 
 In general, prefer collection signals (`signal.Array`, `signal.Object`, etc.)
-which handle this automatically. Use `signal.invalidate` only when collection
+which handle this automatically. Use `signal.trigger` only when collection
 signals are not appropriate for your use case.
 
 ## Escape Hatches

--- a/packages/owl-core/src/signal.ts
+++ b/packages/owl-core/src/signal.ts
@@ -41,7 +41,7 @@ function buildSignal<T>(value: T, set: (atom: Atom) => T): Signal<T> {
   return readSignal;
 }
 
-function invalidateSignal(signal: Signal<any>): void {
+function triggerSignal(signal: Signal<any>): void {
   if (typeof signal !== "function" || (signal as any)[atomSymbol]?.type !== "signal") {
     throw new OwlError(`Value is not a signal (${signal})`);
   }
@@ -89,7 +89,7 @@ export function signal<T>(value: NoInfer<T>, options: SignalOptions<T>): Signal<
 export function signal<T>(value: T): Signal<T> {
   return buildSignal<T>(value, (atom) => atom.value);
 }
-signal.invalidate = invalidateSignal;
+signal.trigger = triggerSignal;
 signal.Array = signalArray;
 signal.Map = signalMap;
 signal.Object = signalObject;

--- a/packages/owl-core/tests/signals.test.ts
+++ b/packages/owl-core/tests/signals.test.ts
@@ -24,7 +24,7 @@ test("updating a signal trigger an effect", async () => {
   expectSpy(e.spy, 2, { result: 22 });
 });
 
-test("invalidate a signal", async () => {
+test("trigger a signal", async () => {
   const s = signal(1);
   const e = spyEffect(() => s());
   e();
@@ -33,14 +33,14 @@ test("invalidate a signal", async () => {
   expectSpy(e.spy, 1, { result: 1 });
   await waitScheduler();
   expectSpy(e.spy, 1, { result: 1 });
-  signal.invalidate(s);
+  signal.trigger(s);
   expectSpy(e.spy, 1, { result: 1 });
   await waitScheduler();
   expectSpy(e.spy, 2, { result: 1 });
 
   const fakeSignal = () => {};
   fakeSignal.set = () => {};
-  expect(() => signal.invalidate(fakeSignal)).toThrow(/Value is not a signal/);
+  expect(() => signal.trigger(fakeSignal)).toThrow(/Value is not a signal/);
 });
 
 describe("signal.Array", () => {

--- a/packages/owl-runtime/src/app.ts
+++ b/packages/owl-runtime/src/app.ts
@@ -78,6 +78,7 @@ export class App extends TemplateSet {
   scheduler = new Scheduler();
   roots: Set<Root<any>> = new Set();
   pluginManager: PluginManager;
+  destroyed = false;
 
   constructor(config: AppConfig = {}) {
     super(config);
@@ -213,6 +214,7 @@ export class App extends TemplateSet {
     this.pluginManager.destroy();
     this.scheduler.processTasks();
     apps.delete(this);
+    this.destroyed = true;
   }
 
   _handleError(error: any) {

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -4,8 +4,12 @@ import {
   createComputation,
   disposeComputation,
   getCurrentComputation,
+  isAbortError,
   OwlError,
+  Scope,
+  scopeStack,
   setComputation,
+  useScope,
 } from "@odoo/owl-core";
 import type { App } from "./app";
 import { BDom, VNode } from "./blockdom";
@@ -13,7 +17,6 @@ import { Component, ComponentConstructor } from "./component";
 import { PluginManager } from "@odoo/owl-core";
 import { fibersInError, handleError } from "./rendering/error_handling";
 import { Fiber, makeRootFiber, MountFiber } from "./rendering/fibers";
-import { isAbortError, Scope, scopeStack, useScope } from "./scope";
 import { STATUS } from "./status";
 
 // -----------------------------------------------------------------------------

--- a/packages/owl-runtime/src/hooks.ts
+++ b/packages/owl-runtime/src/hooks.ts
@@ -1,7 +1,6 @@
-import { effect, Signal } from "@odoo/owl-core";
+import { effect, Signal, useScope } from "@odoo/owl-core";
 import { App } from "./app";
 import { onWillDestroy } from "./lifecycle_hooks";
-import { useScope } from "./scope";
 
 // -----------------------------------------------------------------------------
 // useEffect

--- a/packages/owl-runtime/src/index.ts
+++ b/packages/owl-runtime/src/index.ts
@@ -78,7 +78,7 @@ export { config, plugin, providePlugins } from "./plugin_hooks";
 export type { PluginInstance } from "./plugin_hooks";
 export { Plugin } from "@odoo/owl-core";
 export type { PluginConstructor } from "@odoo/owl-core";
-export { getScope, Scope, useScope } from "./scope";
+export { getScope, Scope, useScope } from "@odoo/owl-core";
 
 export const __info__: Record<string, string> = {
   version: App.version,

--- a/packages/owl-runtime/src/lifecycle_hooks.ts
+++ b/packages/owl-runtime/src/lifecycle_hooks.ts
@@ -1,6 +1,6 @@
+import { Scope, useScope } from "@odoo/owl-core";
 import { ComponentNode, getComponentScope } from "./component_node";
 import { nodeErrorHandlers } from "./rendering/error_handling";
-import { Scope, useScope } from "./scope";
 
 // -----------------------------------------------------------------------------
 //  hooks

--- a/packages/owl-runtime/src/plugin_hooks.ts
+++ b/packages/owl-runtime/src/plugin_hooks.ts
@@ -5,10 +5,10 @@ import {
   PluginManager,
   Resource,
   startPlugins,
+  useScope,
 } from "@odoo/owl-core";
 import { ComponentNode, getComponentScope } from "./component_node";
 import { onWillDestroy, onWillStart } from "./lifecycle_hooks";
-import { useScope } from "./scope";
 import { STATUS } from "./status";
 import { types } from "./types";
 

--- a/packages/owl-runtime/src/rendering/error_handling.ts
+++ b/packages/owl-runtime/src/rendering/error_handling.ts
@@ -47,6 +47,9 @@ function invokeErrorHandlers(
 // would mark the outer tree's fibers as in-error and stall its mount).
 export function forwardErrorToParent(boundary: ComponentNode) {
   return (error: any, finalize: Function): void => {
+    if (boundary.app.destroyed) {
+      throw error;
+    }
     const { handled } = invokeErrorHandlers(boundary, error, finalize, false);
     if (!handled) {
       boundary.app._handleError(finalize());
@@ -60,6 +63,14 @@ export function handleError(params: ErrorParams) {
   let node: ComponentNode | null = "node" in params ? params.node : params.fiber.node;
   const fiber = "fiber" in params ? params.fiber : node!.fiber;
   const app = node!.app;
+
+  // Once the app has been destroyed (e.g. by a prior unhandled error), stop
+  // re-running error handling as the stack unwinds through ancestor renders.
+  // Otherwise each catch frame would re-wrap the already-thrown OwlError,
+  // producing nested "Caused by" chains for every component level.
+  if (app.destroyed) {
+    throw error;
+  }
 
   if (fiber) {
     // resets the fibers on components if possible. This is important so that
@@ -79,6 +90,11 @@ export function handleError(params: ErrorParams) {
       app.destroy();
     } catch (e) {
       // mute all errors here because we are in a corrupted state anyway
+    }
+    // If the error is already an OwlError, it already conveys a clear,
+    // framework-specific message — no need to wrap it in another OwlError.
+    if (error instanceof OwlError) {
+      return error;
     }
     return Object.assign(new OwlError(`[Owl] Unhandled error. Destroying the root component`), {
       cause: error,

--- a/packages/owl-runtime/src/scope.ts
+++ b/packages/owl-runtime/src/scope.ts
@@ -1,7 +1,0 @@
-export {
-  Scope,
-  scopeStack,
-  getScope,
-  useScope,
-  isAbortError,
-} from "@odoo/owl-core";

--- a/packages/owl-runtime/src/template_set.ts
+++ b/packages/owl-runtime/src/template_set.ts
@@ -1,9 +1,8 @@
-import { OwlError } from "@odoo/owl-core";
+import { getScope, OwlError } from "@odoo/owl-core";
 import { compile, CustomDirectives, Template, TemplateFunction } from "@odoo/owl-compiler";
 import { createBlock, html, list, multi, text, toggler } from "./blockdom";
 import { helpers } from "./rendering/template_helpers";
 import { ComponentNode } from "./component_node";
-import { getScope } from "./scope";
 
 const bdom = { text, createBlock, list, multi, html, toggler };
 

--- a/packages/owl-runtime/tests/components/__snapshots__/error_handling.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/error_handling.test.ts.snap
@@ -1,5 +1,46 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`basics > a sync re-render error deep in the tree is only wrapped once 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Parent\`, true, false, false, ["flag"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({flag: ctx['this'].state.flag}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`basics > a sync re-render error deep in the tree is only wrapped once 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["flag"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({flag: ctx['this'].props.flag}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`basics > a sync re-render error deep in the tree is only wrapped once 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.flag&&ctx['this'].state.this.will.crash);
+    return block1([], [b2]);
+  }
+}"
+`;
+
 exports[`basics > display a nice error if a component is not a component 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/basics.test.ts
+++ b/packages/owl-runtime/tests/components/basics.test.ts
@@ -231,7 +231,7 @@ describe("basics", () => {
       error = e;
     }
     expect(error!).toBeDefined();
-    expect(error!.cause.message).toBe("Cannot mount a component on a detached dom node");
+    expect(error!.message).toBe("Cannot mount a component on a detached dom node");
     expect(getConsoleOutput()).toEqual([]);
   });
 

--- a/packages/owl-runtime/tests/components/error_handling.test.ts
+++ b/packages/owl-runtime/tests/components/error_handling.test.ts
@@ -10,7 +10,7 @@ import {
   proxy,
   xml,
 } from "../../src";
-import { useScope } from "../../src/scope";
+import { useScope } from "@odoo/owl-core";
 import {
   logStep,
   makeTestFixture,

--- a/packages/owl-runtime/tests/components/error_handling.test.ts
+++ b/packages/owl-runtime/tests/components/error_handling.test.ts
@@ -69,8 +69,7 @@ describe("basics", () => {
       .catch((e: Error) => (error = e));
     await mountProm;
     expect(error!).toBeDefined();
-    expect(error!.message).toBe("[Owl] Unhandled error. Destroying the root component");
-    expect(error!.cause!.message).toBe(
+    expect(error!.message).toBe(
       'Cannot find the definition of component "SomeMispelledComponent"'
     );
     expect(getConsoleOutput()).toEqual([]);
@@ -88,8 +87,7 @@ describe("basics", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.message).toBe("[Owl] Unhandled error. Destroying the root component");
-    expect(error!.cause.message).toBe(
+    expect(error!.message).toBe(
       'Cannot find the definition of component "SomeMispelledComponent"'
     );
     expect(getConsoleOutput()).toEqual([]);
@@ -107,8 +105,7 @@ describe("basics", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.message).toBe("[Owl] Unhandled error. Destroying the root component");
-    expect(error!.cause.message).toBe(
+    expect(error!.message).toBe(
       '"SomeComponent" is not a Component. It must inherit from the Component class'
     );
   });
@@ -123,10 +120,43 @@ describe("basics", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.message).toBe("[Owl] Unhandled error. Destroying the root component");
-    expect(error!.cause.message).toBe(
+    expect(error!.message).toBe(
       'Cannot find the definition of component "MissingChild", missing static components key in parent'
     );
+  });
+
+  test("a sync re-render error deep in the tree is only wrapped once", async () => {
+    class Child extends Component {
+      static template = xml`<div><t t-out="this.props.flag and this.state.this.will.crash"/></div>`;
+      props = props();
+    }
+    class Parent extends Component {
+      static template = xml`<Child flag="this.props.flag"/>`;
+      static components = { Child };
+      props = props();
+    }
+    class GrandParent extends Component {
+      static template = xml`<Parent flag="this.state.flag"/>`;
+      static components = { Parent };
+      state = { flag: false };
+    }
+    const gp = await mount(GrandParent, fixture);
+    gp.state.flag = true;
+
+    // Can't use nextAppError here: it monkey-patches _handleError which
+    // breaks the throw-through cascade we're testing. Instead, let the sync
+    // re-render error reject the render promise directly.
+    let error: any;
+    try {
+      await render(gp);
+    } catch (e) {
+      error = e;
+    }
+    expect(error!.message).toBe("[Owl] Unhandled error. Destroying the root component");
+    expect(error!.cause.message).toMatch(/Cannot read propert/);
+    // As the throw unwinds through Parent and GrandParent renders, their
+    // handleError frames must not re-wrap the already-wrapped error.
+    expect(error!.cause.cause).toBeUndefined();
   });
 
   test("display a nice error if the root component template fails to compile", async () => {
@@ -186,7 +216,7 @@ function(app, bdom, helpers) {
       error = e as Error;
     }
     expect(error!).toBeDefined();
-    expect(error!.cause.message).toBe(expectedErrorMessage);
+    expect(error!.message).toBe(expectedErrorMessage);
   });
 
   test("simple catchError", async () => {
@@ -623,7 +653,7 @@ describe("can catch errors", () => {
     } catch (e: any) {
       error = e;
     }
-    expect(error!.cause.message).toBe(`No active scope`);
+    expect(error!.message).toBe(`No active scope`);
   });
 
   test("Errors have the right cause", async () => {

--- a/packages/owl-runtime/tests/components/prop.test.ts
+++ b/packages/owl-runtime/tests/components/prop.test.ts
@@ -169,7 +169,7 @@ describe("dev mode", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid prop 'value' in 'Child'");
+    expect(error.message).toMatch("Invalid prop 'value' in 'Child'");
   });
 
   test("throws if prop reference changes on re-render", async () => {
@@ -188,7 +188,7 @@ describe("dev mode", () => {
     parent.state.todo = new Todo(); // different reference
     render(parent);
     const error = await nextAppError(parent.__owl__.app);
-    expect(error.cause.message).toMatch("Prop 'todo' changed in component 'Child'");
+    expect(error.message).toMatch("Prop 'todo' changed in component 'Child'");
   });
 
   test("does not throw if signal reference is stable across re-renders", async () => {

--- a/packages/owl-runtime/tests/components/props_validation.test.ts
+++ b/packages/owl-runtime/tests/components/props_validation.test.ts
@@ -37,7 +37,7 @@ describe("props validation", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
 
     error = undefined;
     try {
@@ -65,7 +65,7 @@ describe("props validation", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("validate props for root component", async () => {
@@ -117,7 +117,7 @@ describe("props validation", () => {
         error = e;
       }
       expect(error).toBeDefined();
-      expect(error.cause.message).toMatch(`Invalid component props (SubComp)`);
+      expect(error.message).toMatch(`Invalid component props (SubComp)`);
 
       error = undefined;
       state = { p: test.ok };
@@ -136,7 +136,7 @@ describe("props validation", () => {
         error = e;
       }
       expect(error).toBeDefined();
-      expect(error.cause.message).toMatch(`Invalid component props (SubComp)`);
+      expect(error.message).toMatch(`Invalid component props (SubComp)`);
     }
   });
 
@@ -175,7 +175,7 @@ describe("props validation", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("can validate an optional props", async () => {
@@ -213,7 +213,7 @@ describe("props validation", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("can validate an array with given primitive type", async () => {
@@ -250,7 +250,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e as Error;
     }
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
     try {
       state = { p: [1] };
       await mount(Parent, fixture, { test: true });
@@ -302,7 +302,7 @@ describe("props validation", () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("can validate an object with simple shape", async () => {
@@ -341,7 +341,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error!.message).toMatch("Invalid component props (SubComp)");
     error = undefined;
     state = { p: { id: 1 } };
     try {
@@ -349,7 +349,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error!.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("can validate recursively complicated prop def", async () => {
@@ -391,7 +391,7 @@ describe("props validation", () => {
     } catch (e: any) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error!.message).toMatch("Invalid component props (SubComp)");
   });
 
   test("can validate optional attributes in nested sub props", async () => {
@@ -664,7 +664,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (SubComp)");
+    expect(error!.message).toMatch("Invalid component props (SubComp)");
   });
 
   test.skip("props are validated whenever component is updated", async () => {
@@ -729,7 +729,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (Child)");
+    expect(error!.message).toMatch("Invalid component props (Child)");
   });
 
   test("additional props are allowed (array)", async () => {
@@ -782,7 +782,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (Child)");
+    expect(error!.message).toMatch("Invalid component props (Child)");
   });
 
   test("can use custom class as type", async () => {
@@ -823,7 +823,7 @@ describe("props validation", () => {
     } catch (e) {
       error = e;
     }
-    expect(error!.cause.message).toMatch("Invalid component props (Child)");
+    expect(error!.message).toMatch("Invalid component props (Child)");
   });
 });
 
@@ -892,6 +892,6 @@ describe("default props", () => {
       error = e;
     }
     expect(error!).toBeDefined();
-    expect(error!.cause.message).toMatch("Invalid component props (Child)");
+    expect(error!.message).toMatch("Invalid component props (Child)");
   });
 });

--- a/packages/owl-runtime/tests/components/t_foreach.test.ts
+++ b/packages/owl-runtime/tests/components/t_foreach.test.ts
@@ -321,7 +321,7 @@ describe("list of components", () => {
     } catch (e) {
       error = e;
     }
-    expect(error.cause.message).toBe("Got duplicate key in t-foreach: child");
+    expect(error.message).toBe("Got duplicate key in t-foreach: child");
     expect(getConsoleOutput()).toEqual([]);
   });
 
@@ -345,7 +345,7 @@ describe("list of components", () => {
     } catch (e) {
       error = e;
     }
-    expect(error.cause.message).toBe("Got duplicate key in t-foreach: [object Object]");
+    expect(error.message).toBe("Got duplicate key in t-foreach: [object Object]");
     expect(getConsoleOutput()).toEqual([]);
   });
 

--- a/packages/owl-runtime/tests/components/t_model.test.ts
+++ b/packages/owl-runtime/tests/components/t_model.test.ts
@@ -77,7 +77,7 @@ describe("t-model directive", () => {
       error = e as Error;
     }
     expect(error!).toBeDefined();
-    expect(error!.cause.message).toBe(
+    expect(error!.message).toBe(
       `Invalid t-model expression: expression should evaluate to a function with a 'set' method defined on it`
     );
   });

--- a/tools/playground/samples/web_client/core/orm.js
+++ b/tools/playground/samples/web_client/core/orm.js
@@ -56,7 +56,7 @@ class Field {
     }
     dp.changes()[this.index] = value;
     this.table.dirtyRecords().add(dp.record.id);
-    signal.invalidate(dp.changes);
+    signal.trigger(dp.changes);
   }
   getValue(dp) {
     const index = this.index;
@@ -456,7 +456,7 @@ export class ORM {
             changes[table.fieldToIndex[k]] = update[k];
           }
         }
-        signal.invalidate(dp.changes);
+        signal.trigger(dp.changes);
         table.dirtyRecords().add(id);
       }
     }


### PR DESCRIPTION
The name "invalidate" described the internal effect rather than the user's intent; "trigger" makes the API clearer at the call site when manually notifying subscribers after an in-place mutation.

closes #1870