### PR TITLE
[IMP] owl-runtime: test and document TemplateFunction in App config

### DIFF
--- a/doc/v3/owl/reference/app.md
+++ b/doc/v3/owl/reference/app.md
@@ -50,8 +50,12 @@ The `config` object is an object with some of the following keys:
   be translated (see [translations](translations.md))
 - **`translateFn (function)`**: a function that will be called by owl to translate
   templates (see [translations](translations.md))
-- **`templates (string | xml document)`**: all the templates that will be used by
-  the components created by the application.
+- **`templates (string | xml document | Record<string, string | TemplateFunction>)`**:
+  all the templates that will be used by the components created by the
+  application. This may be a raw XML string, an `XMLDocument`, or a plain
+  object mapping template names to either a template source string or a
+  precompiled template function (as produced by the `compile_templates`
+  tool — see [Precompiling templates](precompiling_templates.md)).
 - **`getTemplate ((s: string) => Element | Function | string | void)`**: a function that will be called by owl when it
   needs a template. If undefined is returned, owl looks into the app templates.
 - **`warnIfNoStaticProps (boolean, default=false)`**: if true, Owl will log a warning

--- a/doc/v3/owl/reference/precompiling_templates.md
+++ b/doc/v3/owl/reference/precompiling_templates.md
@@ -28,3 +28,18 @@ Here is a more detailed explanation on how to compile xml files into a js file:
 5. `npm run compile_templates -- path/to/your/templates` will scan your target
    folder, find all xml files, get all templates, compile them, and generate a
    `templates.js` file.
+
+The generated `templates.js` exports a single `templates` object, whose keys
+are template names and whose values are precompiled template functions. It
+can be passed directly to the `App` (or `mount`) `templates` config:
+
+```js
+import { mount } from "@odoo/owl";
+import { templates } from "./templates.js";
+
+mount(Root, document.body, { templates });
+```
+
+The same object shape is accepted by `app.addTemplate(name, fn)` and the
+static `App.registerTemplate(name, fn)` helper, which registers a template
+globally for every subsequently created `App`.

--- a/packages/owl-runtime/tests/app/__snapshots__/app.test.ts.snap
+++ b/packages/owl-runtime/tests/app/__snapshots__/app.test.ts.snap
@@ -101,6 +101,19 @@ exports[`app > can load templates from an object name-string 1`] = `
 }"
 `;
 
+exports[`app > can mix string and precompiled templates in the templates config 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div class="from-string">hi</div>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
 exports[`app > can mount app in an iframe 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/app/app.test.ts
+++ b/packages/owl-runtime/tests/app/app.test.ts
@@ -1,3 +1,4 @@
+import { compile } from "@odoo/owl-compiler";
 import { App, Component, onWillPatch, onWillStart, props, proxy, xml } from "../../src";
 import { useApp } from "../../src/hooks";
 import { STATUS, status } from "../../src/status";
@@ -138,6 +139,45 @@ describe("app", () => {
     // Only the "hello" template is used, so the "world" template is not yet loaded
     expect(Object.keys(app.templates)).toEqual(["hello"]);
     expect(Object.keys(app.rawTemplates)).toEqual(["hello", "world"]);
+  });
+
+  test("can load precompiled templates from an object name-fn", async () => {
+    // simulates the output of the `compile_templates` script, which produces
+    // a `Record<string, TemplateFunction>` to be passed to the `App` config.
+    const templates = {
+      hello: compile(`<div class="hello">hello</div>`),
+      world: compile(`<div>world</div>`),
+    };
+    class SomeComponent extends Component {
+      static template = "hello";
+    }
+
+    const app = new App({ templates });
+    await app.createRoot(SomeComponent).mount(fixture);
+    expect(fixture.innerHTML).toBe(`<div class="hello">hello</div>`);
+    expect(Object.keys(app.rawTemplates)).toEqual(["hello", "world"]);
+  });
+
+  test("can mix string and precompiled templates in the templates config", async () => {
+    const templates = {
+      stringTpl: `<div class="from-string">hi</div>`,
+      fnTpl: compile(`<div class="from-fn">hello</div>`),
+    };
+    class FromString extends Component {
+      static template = "stringTpl";
+    }
+    class FromFn extends Component {
+      static template = "fnTpl";
+    }
+    const app = new App({ templates });
+    await app.createRoot(FromString).mount(fixture);
+    expect(fixture.innerHTML).toBe(`<div class="from-string">hi</div>`);
+    app.destroy();
+
+    fixture = makeTestFixture();
+    const app2 = new App({ templates });
+    await app2.createRoot(FromFn).mount(fixture);
+    expect(fixture.innerHTML).toBe(`<div class="from-fn">hello</div>`);
   });
 
   test("can call processTask twice in a row without crashing", async () => {

--- a/packages/owl-runtime/tests/compiler/validation.test.ts
+++ b/packages/owl-runtime/tests/compiler/validation.test.ts
@@ -1,3 +1,4 @@
+import { compile } from "@odoo/owl-compiler";
 import { TemplateSet } from "../../src/template_set";
 import { renderToString, snapshotTemplate, TestContext } from "../helpers";
 
@@ -25,6 +26,20 @@ describe("basic validation", () => {
     context.addTemplate("test", `<t/>`);
     expect(() => context.addTemplate("test", "<div/>")).not.toThrow();
     expect(context.rawTemplates.test).toBe("<t/>");
+  });
+
+  test("can add a template as a precompiled function in dev mode", () => {
+    const context = new TemplateSet({ dev: true });
+    const fn = compile(`<t/>`);
+    context.addTemplate("test", fn);
+    // Re-adding the same function reference is a no-op
+    expect(() => context.addTemplate("test", fn)).not.toThrow();
+    // Same source code (different function instance) is fine too
+    expect(() => context.addTemplate("test", compile(`<t/>`))).not.toThrow();
+    // A function with different generated code throws
+    expect(() => context.addTemplate("test", compile(`<div/>`))).toThrow("already defined");
+    // Mixing a function and a string also throws
+    expect(() => context.addTemplate("test", `<div/>`)).toThrow("already defined");
   });
 
   test("invalid xml", () => {


### PR DESCRIPTION
Follow-up to 47c55ff1, which added support for passing a `Record<string, TemplateFunction>` as the `templates` App config. Adds tests for that path (including the mixed string/function case and the duplicate-detection branch in dev mode) and updates the App and precompiling-templates references to document it.