### PR TITLE
[IMP] compiler: improve expression parser scoping and template string handling

### DIFF
--- a/packages/owl-compiler/src/inline_expressions.ts
+++ b/packages/owl-compiler/src/inline_expressions.ts
@@ -269,12 +269,24 @@ interface ProcessedExpr {
  * Processes a javascript expression: compiles variable lookups and detects
  * top-level arrow functions with their free variables, all in a single pass.
  */
-export function processExpr(expr: string): ProcessedExpr {
-  const localVars = new Set<string>();
+export function processExpr(expr: string, seededLocals?: Set<string>): ProcessedExpr {
+  // scope entries carry the stack depth at which they were created
+  const scopeStack: { vars: Set<string>; depth: number }[] = [];
+
+  // Seed outer locals
+  // depth: -Infinity so this scope never gets popped
+  if (seededLocals?.size) {
+    scopeStack.push({ vars: seededLocals, depth: -Infinity });
+  }
+
   const tokens = tokenize(expr);
   let i = 0;
   let stack = []; // to track last opening (, [ or {
   let topLevelArrowIndex = -1;
+
+  function isLocal(name: string) {
+    return scopeStack.some((s) => s.vars.has(name));
+  }
 
   while (i < tokens.length) {
     let token = tokens[i];
@@ -292,6 +304,14 @@ export function processExpr(expr: string): ProcessedExpr {
       case "RIGHT_BRACKET":
       case "RIGHT_PAREN":
         stack.pop();
+        // Pop arrow scopes whose body has ended (stack dropped below creation depth)
+        while (
+          scopeStack.length > 0 &&
+          stack.length < scopeStack[scopeStack.length - 1].depth
+        ) {
+          scopeStack.pop();
+        }
+        break;
     }
 
     let isVar = token.type === "SYMBOL" && !RESERVED_WORDS.includes(token.value);
@@ -316,10 +336,17 @@ export function processExpr(expr: string): ProcessedExpr {
         }
       }
     }
+
     if (token.type === "TEMPLATE_STRING") {
-      token.value = token.replace!((expr: any) => compileExpr(expr));
+      const currentLocals = new Set<string>();
+      for (const scope of scopeStack) {
+        for (const v of scope.vars) currentLocals.add(v);
+      }
+      token.value = token.replace!((expr: any) => compileExpr(expr, currentLocals));
     }
+
     if (nextToken && nextToken.type === "OPERATOR" && nextToken.value === "=>") {
+      const newScope = new Set<string>();
       if (stack.length === 0) {
         topLevelArrowIndex = i + 1;
       }
@@ -327,34 +354,33 @@ export function processExpr(expr: string): ProcessedExpr {
         let j = i - 1;
         while (j > 0 && tokens[j].type !== "LEFT_PAREN") {
           if (tokens[j].type === "SYMBOL" && tokens[j].originalValue) {
-            tokens[j].value = tokens[j].originalValue!;
-            localVars.add(tokens[j].value);
+            newScope.add(tokens[j].originalValue!);
+            tokens[j].value = `_${tokens[j].originalValue}`;
+            tokens[j].isLocal = true;
           }
           j--;
         }
       } else {
-        localVars.add(token.value);
+        // Single param without parens (e => ...): token.value is still the
+        // raw identifier here, before the isVar block below transforms it.
+        // The isVar block will then see isLocal=true and prefix with _.
+        newScope.add(token.value);
       }
+      // record current stack depth so we know when this scope expires
+      scopeStack.push({ vars: newScope, depth: stack.length });
     }
 
     if (isVar) {
       token.varName = token.value;
-      if (!localVars.has(token.value)) {
+      if (!isLocal(token.value)) {
         token.originalValue = token.value;
         token.value = `ctx['${token.value}']`;
+      } else {
+        token.value = `_${token.value}`;
+        token.isLocal = true;
       }
     }
     i++;
-  }
-
-  // Mark all variables that have been used locally.
-  // This assumes the expression has only one scope (incorrect but "good enough for now")
-  for (const token of tokens) {
-    if (token.type === "SYMBOL" && token.varName && localVars.has(token.value)) {
-      token.originalValue = token.value;
-      token.value = `_${token.value}`;
-      token.isLocal = true;
-    }
   }
 
   // Collect free variables from arrow function body
@@ -375,8 +401,8 @@ export function processExpr(expr: string): ProcessedExpr {
   return { expr: compiled, freeVariables };
 }
 
-export function compileExpr(expr: string): string {
-  return processExpr(expr).expr;
+export function compileExpr(expr: string,  seededLocals?: Set<string>): string {
+  return processExpr(expr, seededLocals).expr;
 }
 
 export const INTERP_REGEXP = /\{\{.*?\}\}|\#\{.*?\}/g;

--- a/packages/owl-compiler/tests/inline_expressions.test.ts
+++ b/packages/owl-compiler/tests/inline_expressions.test.ts
@@ -178,6 +178,7 @@ describe("expression evaluation", () => {
     expect(compileExpr("(ev) => { myFunc(v1, v2, ev.target.value); }")).toBe(
       "(_ev)=>{ctx['myFunc'](ctx['v1'],ctx['v2'],_ev.target.value);}"
     );
+    expect(compileExpr("list.map((e) => ({a: e,b:(e),c:d,d:e}))")).toBe("ctx['list'].map((_e)=>({a:_e,b:(_e),c:ctx['d'],d:_e}))")
   });
   test("processExpr: free variables detection", () => {
     const freeVars = (expr: string) => processExpr(expr).freeVariables;
@@ -193,8 +194,7 @@ describe("expression evaluation", () => {
     expect(freeVars("this.doSomething(item)")).toBeNull();
   });
 
-  test.skip("arrow functions: not yet supported", () => {
-    // e is added to localvars in inline_expression but not removed after the arrow func body
+  test("arrow functions: not yet supported", () => {
     expect(compileExpr("(e => e)(e)")).toBe("(_e=>_e)(ctx['e'])");
   });
 
@@ -225,6 +225,9 @@ describe("expression evaluation", () => {
     expect(compileExpr("`hey`")).toBe("`hey`");
     expect(compileExpr("`hey ${you}`")).toBe("`hey ${ctx['you']}`");
     expect(compileExpr("`hey ${1 + 2}`")).toBe("`hey ${1+2}`");
+    expect(compileExpr("`${e.target.name}`")).toBe("`${ctx['e'].target.name}`"),
+    expect(compileExpr("(e) => `${e.target.name}`")).toBe("(_e)=>`${_e.target.name}`")
+    expect(compileExpr("items.map(x => `${x.label}: ${title}`)")).toBe("ctx['items'].map(_x=>`${_x.label}: ${ctx['title']}`)")
   });
 
   test("works with short object description and lists ", () => {


### PR DESCRIPTION
The current expression parser uses a flat local variable tracking mechanism, which leads to incorrect behavior in nested arrow functions and template string interpolations.

This commit introduces a scope stack to properly track variable scopes across nested expressions. It also propagates local variables into template string interpolations to ensure correct variable resolution.

Key improvements:
- Proper handling of nested arrow function scopes
- Correct tracking of local variables using a scope stack
- Support for seeded locals in template string expressions
- Prevent incorrect context lookups inside template strings