### PR TITLE
[FIX] owl-runtime: validate default props against props definition

### DIFF
--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -86,6 +86,9 @@ export function props(type?: any, defaults?: any): Props<{}> {
     if (app.dev) {
       const validation = defaults ? validateObjectWithDefaults(type, defaults) : types.object(type);
       assertType(node.props, validation, `Invalid component props (${componentName})`);
+      if(defaults){
+        assertType(defaults, validation, `Invalid default props (${componentName})`);
+      }
       node.willUpdateProps.push((np: Record<string, any>) => {
         assertType(np, validation, `Invalid component props (${componentName})`);
       });

--- a/packages/owl-runtime/tests/components/props_validation.test.ts
+++ b/packages/owl-runtime/tests/components/props_validation.test.ts
@@ -711,6 +711,21 @@ describe("props validation", () => {
     expect(fixture.innerHTML).toBe("<div><div>4</div></div>");
   });
 
+  test("default values should pass through prop validation", async () => {
+    let error: any;
+    class SubComp extends Component {
+      static template = xml`<div><t t-out="this.props.p"/></div>`;
+      props = props({ "p?": t.number() }, { p: "4" as any });
+    }
+    try {
+      await mount(SubComp, fixture, { dev: true });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toMatch("Invalid default props (SubComp)");
+  });
+
   test("mix of optional and mandatory", async () => {
     class Child extends Component {
       static template = xml` <div><t t-out="this.props.mandatory"/></div>`;


### PR DESCRIPTION
Before this commit, default props were assigned without going through props validation, which could allow invalid default values to bypass the validation system.

This commit ensures default props are validated
against the component props definition.

closes #1561