### PR TITLE
[FIX] owl-compiler: avoid duplicate `t-on` handlers on unnamed default slots

### DIFF
--- a/packages/owl-compiler/src/parser.ts
+++ b/packages/owl-compiler/src/parser.ts
@@ -805,7 +805,7 @@ function parseComponent(node: Element, ctx: ParsingContext): AST | null {
     if (defaultContent && !slots.default) {
       slots.default = {
         content: defaultContent,
-        on,
+        on: null,
         attrs: null,
         attrsTranslationCtx: null,
         scope: defaultSlotScope,

--- a/packages/owl-compiler/tests/parser.test.ts
+++ b/packages/owl-compiler/tests/parser.test.ts
@@ -1225,6 +1225,39 @@ describe("qweb parser", () => {
     });
   });
 
+  test("component with event handler should not bind component event on default slot", async () => {
+    const ast = parse(`<MyComponent t-on-click="someMethod"><div/></MyComponent>`);
+    expect(ast).toEqual({
+      type: ASTType.TComponent,
+      name: "MyComponent",
+      dynamicProps: null,
+      props: null,
+      propsTranslationCtx: null,
+      isDynamic: false,
+      on: {click: "someMethod"},
+      slots: {
+        default: {
+          content: {
+            type: ASTType.DomNode,
+            tag: "div",
+            dynamicTag: null,
+            attrs: null,
+            attrsTranslationCtx: null,
+            content: [],
+            ref: null,
+            model: null,
+            on: null,
+            ns: null,
+          },
+          attrs: null,
+          attrsTranslationCtx: null,
+          on: null,
+          scope: null,
+        },
+      }
+    })
+  })
+
   test("component with event handler", async () => {
     expect(() => parse(`<MyComponent t-onclick="someMethod"/>`)).toThrow(
       "unsupported directive on Component: t-onclick"

--- a/packages/owl-runtime/tests/components/__snapshots__/event_handling.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/event_handling.test.ts.snap
@@ -183,3 +183,44 @@ exports[`event handling > t-on with handler bound to dynamic argument on a t-for
   }
 }"
 `;
+
+exports[`event handling > unnamed slot should call the event only once 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { markRaw, createComponent, createCatcher, callHandler } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, true, false, []);
+  const hdlr_fn1 = (ctx, ev) => callHandler(ctx['this'].inc, ctx, ev);
+  const catcher1 = createCatcher({"click":0});
+  
+  let block1 = createBlock(\`<div class="named"/>\`);
+  let block2 = createBlock(\`<div class="default unnamed"/>\`);
+  
+  function slot1(ctx, node, key = "") {
+    return block1();
+  }
+  
+  function slot2(ctx, node, key = "") {
+    return block2();
+  }
+  
+  return function template(ctx, node, key = "") {
+    const hdlr1 = [hdlr_fn1, ctx];
+    return catcher1(comp1({slots: markRaw({'named': {__render: slot1.bind(this), __ctx: ctx}, 'default': {__render: slot2.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null), [hdlr1]);
+  }
+}"
+`;
+
+exports[`event handling > unnamed slot should call the event only once 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'named', false, {});
+    const b3 = callSlot(ctx, node, key, 'default', false, {});
+    return multi([b2, b3]);
+  }
+}"
+`;

--- a/packages/owl-runtime/tests/components/event_handling.test.ts
+++ b/packages/owl-runtime/tests/components/event_handling.test.ts
@@ -191,4 +191,32 @@ describe("event handling", () => {
     iframeDoc.querySelector("span")!.click();
     expect(clickCount).toBe(1);
   });
+
+  test("unnamed slot should call the event only once", async () => {
+    let clickCount = 0;
+    class Child extends Component {
+      static template = xml`<t t-call-slot="named"/><t t-call-slot="default" />`;
+    }
+    class Parent extends Component {
+      static components = { Child };
+      static template = xml`
+        <Child t-on-click="this.inc">
+          <t t-set-slot="named">
+            <div class="named" />
+          </t>
+          <div class="default unnamed" />
+        </Child>
+      `;
+      inc(){
+        clickCount++;
+      }
+    }
+
+    await mount(Parent, fixture);
+    expect(clickCount).toBe(0);
+    (fixture.querySelector('.named') as HTMLDivElement).click();
+    expect(clickCount).toBe(1);
+    (fixture.querySelector('.unnamed') as HTMLDivElement).click();
+    expect(clickCount).toBe(2);
+  })
 });


### PR DESCRIPTION


When parsing component slots, unnamed default slot content inherited the component `on` handlers even though no slot definition existed.

This caused `t-on-*` handlers to be bound twice:
- once on the component itself
- once again on the generated unnamed default slot

The issue came from assigning the component `on` object to the implicit default slot during AST creation. Since implicit default slots cannot define slot events, their `on` value should be `null`.

This commit prevents duplicate event handler registration by avoiding propagation of component events to unnamed default slots.

closes #1681