### PR TITLE
[FIX] props: fix crash when validating prop with slots

### DIFF
--- a/packages/owl-core/src/validation.ts
+++ b/packages/owl-core/src/validation.ts
@@ -19,6 +19,25 @@ export interface ValidationContext {
   withKey(key: PropertyKey): ValidationContext;
 }
 
+function safeReplacer(knownObjects: any[], _key: string, value: any): any {
+  if (typeof value === "function") {
+    return value.name || "[Function]";
+  }
+  if (value && typeof value === "object") {
+    const ctor = value.constructor;
+    if (ctor && ctor !== Object && ctor !== Array) {
+      return `[Instance of ${ctor.name || "anonymous"}]`;
+    }
+
+    if (knownObjects.includes(value)) {
+      return `[Known object]`;
+    }
+    knownObjects.push(value);
+  }
+  return value;
+}
+
+
 export function assertType(
   value: any,
   validation: any,
@@ -26,16 +45,8 @@ export function assertType(
 ): void {
   const issues = validateType(value, validation);
   if (issues.length) {
-    const issueStrings = JSON.stringify(
-      issues,
-      (key, value) => {
-        if (typeof value === "function") {
-          return value.name;
-        }
-        return value;
-      },
-      2
-    );
+    const knownObjects: any[] = [];
+    const issueStrings = JSON.stringify(issues, safeReplacer.bind(null, knownObjects), 2);
     throw new OwlError(`${errorMessage}\n${issueStrings}`);
   }
 }

--- a/packages/owl-core/tests/validation.test.ts
+++ b/packages/owl-core/tests/validation.test.ts
@@ -749,3 +749,56 @@ test("complex type", () => {
     )
   ).toEqual([]);
 });
+
+test("assert wrong object and circular reference", () => {
+  const type = t.object({
+    str: t.string(),
+    circular: t.any(),
+  });
+
+  const circular = {
+    a: {} as any,
+  };
+  circular.a.circle = circular;
+  expect(() => {
+    assertType({ circular }, type);
+  }).toThrow(`Value does not match the type
+[
+  {
+    "received": {
+      "circular": {
+        "a": {
+          "circle": "[Known object]"
+        }
+      }
+    },
+    "path": [],
+    "message": "object value has missing keys",
+    "missingKeys": [
+      "str"
+    ],
+    "expectedKeys": [
+      "str",
+      "circular"
+    ]
+  }
+]`
+  );
+});
+
+test("assert class instance", () => {
+  class A {}
+  expect(() => {
+    assertType({ a: new A() }, t.object({ a: t.number() }));
+  }).toThrow(`Value does not match the type
+[
+  {
+    "received": "[Instance of A]",
+    "path": [
+      "a"
+    ],
+    "message": "value is not a number"
+  }
+]`
+  );
+});


### PR DESCRIPTION
Before this commit, the function `assertType` crashed when a component received slots and an invalid prop. Now, the validation error message appears.