### PR TITLE
[FIX] owl-core: accept String wrapper objects in t.string() validator

### DIFF
--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -49,7 +49,7 @@ function numberType(): number {
 
 function stringType(): string {
   return function validateString(context: ValidationContext) {
-    if (typeof context.value !== "string") {
+    if (typeof context.value !== "string" && !(context.value instanceof String)) {
       context.addIssue({ message: "value is not a string" });
     }
   } as any;

--- a/packages/owl-core/tests/validation.test.ts
+++ b/packages/owl-core/tests/validation.test.ts
@@ -441,6 +441,9 @@ test("string", () => {
   const issue = { message: "value is not a string" };
   expect(validateType("", t.string())).toEqual([]);
   expect(validateType("abc", t.string())).toEqual([]);
+  expect(validateType(new String("abc"), t.string())).toEqual([]);
+  class M extends String {}
+  expect(validateType(new M("abc"), t.string())).toEqual([]);
   expect(validateType(123, t.string())).toMatchObject([issue]);
   expect(validateType(987, t.string())).toMatchObject([issue]);
   expect(validateType(true, t.string())).toMatchObject([issue]);


### PR DESCRIPTION
Markup values (from owl-runtime's `markup()`) are instances of a class extending the native String, so their typeof is "object" — the strict typeof check rejected them as props typed `t.string()`, even though they conceptually are strings.

The validator now also accepts `value instanceof String`, which covers Markup via inheritance without owl-core needing to know about it.