### PR TITLE
[FIX] owl-core: prevent disposed effect from running queued re-run

### DIFF
--- a/packages/owl-core/src/effect.ts
+++ b/packages/owl-core/src/effect.ts
@@ -22,6 +22,9 @@ export function effect<T>(fn: () => T) {
 
   // Remove sources and unsubscribe
   return function cleanupEffect() {
+    // Mark as executed so a queued re-run (scheduled by an earlier signal
+    // write in the same microtick) is skipped by updateComputation.
+    computation.state = ComputationState.EXECUTED;
     // In case the cleanup read an atom.
     // todo: test it
     const previousComputation = getCurrentComputation();

--- a/packages/owl-core/tests/effect.test.ts
+++ b/packages/owl-core/tests/effect.test.ts
@@ -346,6 +346,33 @@ describe("effect", () => {
       expectSpy(spy, 2, { args: [2] });
     });
 
+    test("disposing an effect after a queued signal write skips the re-run", async () => {
+      const s = signal(1);
+      const spy = vi.fn();
+      const dispose = effect(() => {
+        spy(s());
+      });
+      expectSpy(spy, 1, { args: [1] });
+      s.set(2);
+      dispose();
+      await waitScheduler();
+      expectSpy(spy, 1, { args: [1] });
+    });
+
+    test("disposing an effect skips queued re-run from a derived dependency", async () => {
+      const s = signal(1);
+      const c = computed(() => s() * 2);
+      const spy = vi.fn();
+      const dispose = effect(() => {
+        spy(c());
+      });
+      expectSpy(spy, 1, { args: [2] });
+      s.set(2);
+      dispose();
+      await waitScheduler();
+      expectSpy(spy, 1, { args: [2] });
+    });
+
     test("effect should call cleanup function", async () => {
       const state = proxy({ a: 1 });
       const spy = vi.fn();


### PR DESCRIPTION
When a signal write schedules an effect for re-execution in the next microtick and the effect is disposed synchronously before the microtask fires, the effect still re-runs once. removeSources clears the effect's source references but leaves it in the module-level observers queue with state STALE, so updateComputation falls through and calls compute().

Mark the effect as EXECUTED at the start of the dispose function so the early-return in updateComputation skips it when the queue drains. This mirrors the pattern already used for child effects in unsubscribeEffect.