### PR TITLE
[FIX] docs: align vitepress anchor slugification with link test

### DIFF
--- a/doc/.vitepress/config.mjs
+++ b/doc/.vitepress/config.mjs
@@ -98,6 +98,25 @@ export default defineConfig({
     ],
   ],
   markdown: {
+    anchor: {
+      // adapted from https://medium.com/@mhagemann/the-ultimate-way-to-slugify-a-url-string-in-javascript-b8e4a0d849e1
+      slugify: function (str) {
+        const a = "àáäâãåăæçèéëêǵḧìíïîḿńǹñòóöôœøṕŕßśșțùúüûǘẃẍÿź·_,:;";
+        const b = "aaaaaaaaceeeeghiiiimnnnooooooprssstuuuuuwxyz-----";
+        const p = new RegExp(a.split("").join("|"), "g");
+        return str
+          .toString()
+          .toLowerCase()
+          .replace(/\//g, "") // remove /
+          .replace(/\s+/g, "-") // Replace spaces with -
+          .replace(p, (c) => b.charAt(a.indexOf(c))) // Replace special characters
+          .replace(/&/g, "-and-") // Replace & with 'and'
+          .replace(/[^\w\-]+/g, "") // Remove all non-word characters
+          .replace(/\-\-+/g, "-") // Replace multiple - with single -
+          .replace(/^-+/, "") // Trim - from start of text
+          .replace(/-+$/, ""); // Trim - from end of text
+      }
+    },
     languages: [
       'typescript', 'javascript', 'xml', 'html', 'css',
       loadGrammar('owl.template.json'),

--- a/doc/v3/owl/migration_owl2_to_owl3.md
+++ b/doc/v3/owl/migration_owl2_to_owl3.md
@@ -47,7 +47,7 @@ Additional info is the result of grepping in odoo code base (community/enterpris
 | 19  | `t-call` not allowed on tags `!== t`                              |                    | [Note](#19-t-call-not-allowed-on-tags-t)                                |
 | 20  | `t-call` body evaluated lazily, variables passed as parameters    |                    | [Note](#20-t-call-body-evaluated-lazily-variables-passed-as-parameters) |
 | 21  | `useComponent` removed                                            | 93 calls           | [Note](#21-usecomponent-removed)                                        |
-| 22  | `onPatched` / `onWillPatch` semantics narrowed                    |                    | [Note](#22-onpatched--onwillpatch-semantics-narrowed)                   |
+| 22  | `onPatched` / `onWillPatch` semantics narrowed                    |                    | [Note](#22-onpatched-onwillpatch-semantics-narrowed)                    |
 
 ## Migration guide for each change
 


### PR DESCRIPTION
VitePress was generating heading anchor fragments differently from the logic used in our documentation link validation tests. As a result, some internal doc links were being flagged incorrectly.

This update aligns VitePress anchor slugification with the same logic used by the broken link checker.

Also fixed an internal doc link that was broken due to the fragment mismatch.

closes #1895