### PR TITLE
[FIX] owl: deduplicate owl-core in umbrella bundle

### DIFF
--- a/packages/owl/build.mjs
+++ b/packages/owl/build.mjs
@@ -38,6 +38,13 @@ async function buildVariant(entry, suffix) {
     bundle: true,
     define,
     target: "es2022",
+    // Force owl-core to resolve to its built dist file. Without this, esbuild
+    // picks up the `paths` mapping in owl-runtime/tsconfig.json and pulls
+    // owl-core's source in addition to its dist via owl-compiler — bundling
+    // owl-core twice.
+    alias: {
+      "@odoo/owl-core": "../owl-core/dist/owl-core.es.js",
+    },
   };
 
   await Promise.all([


### PR DESCRIPTION
esbuild picked up the `paths` mapping in owl-runtime/tsconfig.json when bundling owl-runtime's dist, resolving `@odoo/owl-core` to its source files. owl-compiler's dist has no such mapping, so it resolved owl-core to its built dist instead. Result: owl-core was bundled twice (~430 lines).

Add an esbuild `alias` in owl/build.mjs to force `@odoo/owl-core` to resolve to its dist regardless of any sibling tsconfig paths.

owl.es.js: 7042 -> 6609 lines.