### PR TITLE
reactive props

### DIFF
--- a/doc/v3/owl/reference/props.md
+++ b/doc/v3/owl/reference/props.md
@@ -25,6 +25,9 @@ context of the parent. So, `this.props.message` is equal to `'hello'`.
 
 The `props` function must be called at the top level of the component class body
 (or inside `setup`). It returns an object with getters for each declared prop.
+Reading one of these getters is reactive: templates, computed values, and
+effects that read `this.props.someProp` subscribe to that prop and are notified
+when the parent applies a new value.
 
 ## Definition
 
@@ -93,6 +96,32 @@ props(["color?"], { color: "red" });
 props({ "color?": t.string() }, { color: "red" });
 ```
 
+### Reactive reads
+
+The object returned by `props()` exposes signal-backed getters. This means that
+any reactive context that reads a prop will update when that prop changes:
+
+```js
+import { Component, computed, props, types as t, xml } from "@odoo/owl";
+
+class Total extends Component {
+  static template = xml`<span t-out="this.double()"/>`;
+
+  props = props({ value: t.number() });
+  double = computed(() => this.props.value * 2);
+}
+```
+
+When the parent re-renders with a different `value`, `this.props.value` is
+updated and the `double` computed value is invalidated. The same applies to
+[`effect`](reactivity.md#effects) and [`useEffect`](reactivity.md#useeffect):
+reading `this.props.value` inside the effect subscribes the effect to future
+updates of that prop.
+
+This only applies to props accessed through `props()`. The singular
+[`prop()`](#the-prop-function) helper keeps its static, reference-stable
+semantics.
+
 ## The `prop` function
 
 `prop` (singular) is an alternative for components that only need to read a
@@ -145,8 +174,9 @@ entirely.
 ### When to use `prop()` vs `props()`
 
 Use `props()` when the child needs to observe prop changes (the parent
-re-renders with a new value and the child must reflect it), or when the child
-declares several props at once.
+re-renders with a new value and the child must reflect it), when computed values
+or effects should react to prop changes, or when the child declares several
+props at once.
 
 Use `prop()` when:
 

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -38,6 +38,10 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
   children: { [key: string]: ComponentNode } = Object.create(null);
 
   willUpdateProps: LifecycleHook[] = [];
+  // Fired right after `props` is applied to `node.props` on a parent re-render,
+  // so reactive prop notifications happen once the new values are observable
+  // (after user `onWillUpdateProps` hooks, including async ones, have run).
+  propsUpdated: LifecycleHook[] = [];
   willUnmount: LifecycleHook[] = [];
   mounted: LifecycleHook[] = [];
   willPatch: LifecycleHook[] = [];

--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -4,6 +4,8 @@ import {
   KeyedObject,
   PrettifyShape,
   ResolveObjectType,
+  signal,
+  Signal,
 } from "@odoo/owl-core";
 import { getComponentScope } from "./component_node";
 import { types } from "./types";
@@ -60,20 +62,33 @@ export function props(type?: any, defaults?: any): Props<{}> {
     node.defaultProps = Object.assign(node.defaultProps || {}, defaults);
   }
 
-  function getProp(key: string) {
-    if (node.props[key] === undefined && defaults) {
+  function resolveValue(props: Record<string, any>, key: string) {
+    if (props[key] === undefined && defaults) {
       return (defaults as any)[key];
     }
-    return node.props[key];
+    return props[key];
   }
 
+  const signals: Record<string, Signal<any>> = Object.create(null);
   const result = Object.create(null);
-  function applyPropGetters(keys: string[]) {
+  function defineProp(key: string) {
+    signals[key] = signal(resolveValue(node.props, key));
+    Reflect.defineProperty(result, key, {
+      enumerable: true,
+      configurable: true,
+      get: signals[key],
+    });
+  }
+
+  function defineProps(keys: string[]) {
     for (const key of keys) {
-      Reflect.defineProperty(result, key, {
-        enumerable: true,
-        get: getProp.bind(null, key),
-      });
+      defineProp(key);
+    }
+  }
+
+  function updateSignals(keys: string[]) {
+    for (const key of keys) {
+      signals[key].set(resolveValue(node.props, key));
     }
   }
 
@@ -81,7 +96,8 @@ export function props(type?: any, defaults?: any): Props<{}> {
     const keys: string[] = (Array.isArray(type) ? type : Object.keys(type)).map((key: string) =>
       key.endsWith("?") ? key.slice(0, -1) : key
     );
-    applyPropGetters(keys);
+    defineProps(keys);
+    node.propsUpdated.push(() => updateSignals(keys));
 
     if (app.dev) {
       if (defaults) {
@@ -113,13 +129,23 @@ export function props(type?: any, defaults?: any): Props<{}> {
     };
 
     let keys = getKeys(node.props);
-    applyPropGetters(keys);
-    node.willUpdateProps.push((np: any) => {
+    defineProps(keys);
+    node.propsUpdated.push(() => {
+      const nextKeys = getKeys(node.props);
+      const nextKeySet = new Set(nextKeys);
       for (const key of keys) {
-        Reflect.deleteProperty(result, key);
+        if (!nextKeySet.has(key)) {
+          Reflect.deleteProperty(result, key);
+          delete signals[key];
+        }
       }
-      keys = getKeys(np);
-      applyPropGetters(keys);
+      for (const key of nextKeys) {
+        if (!(key in signals)) {
+          defineProp(key);
+        }
+      }
+      updateSignals(nextKeys);
+      keys = nextKeys;
     });
   }
 

--- a/packages/owl-runtime/src/rendering/template_helpers.ts
+++ b/packages/owl-runtime/src/rendering/template_helpers.ts
@@ -311,6 +311,7 @@ function createComponent<P extends Record<string, any>>(
             () => {
               if (fiber !== node.fiber) return;
               node.props = props;
+              for (const f of node.propsUpdated) f();
               fiber.render();
             },
             (error) => {
@@ -319,6 +320,7 @@ function createComponent<P extends Record<string, any>>(
           );
         } else {
           node.props = props;
+          for (const f of node.propsUpdated) f();
           fiber.render();
         }
       }

--- a/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
@@ -856,3 +856,150 @@ exports[`no props validation and default props 2`] = `
   }
 }"
 `;
+
+exports[`reactive props (issue #1908) > a prop read only in an effect (not the template) still reacts to a value swap 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Test\`, true, false, false, ["o"]);
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = comp1({o: ctx['this'].obj()}, key + \`__1\`, node, this, null);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > a prop read only in an effect (not the template) still reacts to a value swap 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<span>hi</span>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > effect observing a prop reacts to both in-place mutation and value swap 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Test\`, true, false, false, ["o"]);
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = comp1({o: ctx['this'].obj()}, key + \`__1\`, node, this, null);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > effect observing a prop reacts to both in-place mutation and value swap 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.o.val);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > making props reactive does not introduce extra renders 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Test\`, true, false, false, ["o"]);
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = comp1({o: ctx['this'].obj()}, key + \`__1\`, node, this, null);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > making props reactive does not introduce extra renders 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].tick());
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > props() tracks new and deleted keys from t-props 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, true, []);
+  
+  return function template(ctx, node, key = "") {
+    return comp1(Object.assign({}, ctx['this'].childProps()), key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > props() tracks new and deleted keys from t-props 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].label());
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > this.props still reflects the old value inside onWillUpdateProps 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["value"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({value: ctx['this'].state.value}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`reactive props (issue #1908) > this.props still reflects the old value inside onWillUpdateProps 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.value);
+    return block1([], [b2]);
+  }
+}"
+`;

--- a/packages/owl-runtime/tests/components/props.test.ts
+++ b/packages/owl-runtime/tests/components/props.test.ts
@@ -855,3 +855,144 @@ test(".signal suffix: child receives a read-only reactive value", async () => {
   expect(childError.message).toMatch(/read-only/);
   expect(fixture.innerHTML).toBe("3");
 });
+
+describe("reactive props (issue #1908)", () => {
+  test("effect observing a prop reacts to both in-place mutation and value swap", async () => {
+    const observed: number[] = [];
+    class Test extends Component {
+      static template = xml`<span t-out="this.props.o.val"/>`;
+      props = props(["o"]);
+      setup() {
+        effect(() => observed.push(this.props.o.val));
+      }
+    }
+    class Root extends Component {
+      static template = xml`<div><Test o="this.obj()"/></div>`;
+      static components = { Test };
+      obj = signal(proxy({ val: 1 }));
+    }
+
+    const root = await mount(Root, fixture);
+    expect(observed).toEqual([1]);
+    expect(fixture.innerHTML).toBe("<div><span>1</span></div>");
+
+    // mutate the captured proxy in place
+    root.obj().val = 2;
+    await nextTick();
+    expect(observed).toEqual([1, 2]);
+    expect(fixture.innerHTML).toBe("<div><span>2</span></div>");
+
+    // swap the whole value (the case that used to update the template but not the effect)
+    root.obj.set(proxy({ val: 3 }));
+    await nextTick();
+    expect(observed).toEqual([1, 2, 3]);
+    expect(fixture.innerHTML).toBe("<div><span>3</span></div>");
+  });
+
+  test("a prop read only in an effect (not the template) still reacts to a value swap", async () => {
+    const observed: number[] = [];
+    class Test extends Component {
+      static template = xml`<span>hi</span>`;
+      props = props(["o"]);
+      setup() {
+        effect(() => observed.push(this.props.o.val));
+      }
+    }
+    class Root extends Component {
+      static template = xml`<div><Test o="this.obj()"/></div>`;
+      static components = { Test };
+      obj = signal(proxy({ val: 1 }));
+    }
+
+    const root = await mount(Root, fixture);
+    expect(observed).toEqual([1]);
+
+    root.obj().val = 2;
+    await nextTick();
+    expect(observed).toEqual([1, 2]);
+
+    root.obj.set(proxy({ val: 3 }));
+    await nextTick();
+    expect(observed).toEqual([1, 2, 3]);
+  });
+
+  test("making props reactive does not introduce extra renders", async () => {
+    let renderCount = 0;
+    const observed: number[] = [];
+    class Test extends Component {
+      static template = xml`<span t-out="this.tick()"/>`;
+      props = props(["o"]);
+      setup() {
+        effect(() => observed.push(this.props.o.val));
+      }
+      tick() {
+        renderCount++;
+        return this.props.o.val;
+      }
+    }
+    class Root extends Component {
+      static template = xml`<div><Test o="this.obj()"/></div>`;
+      static components = { Test };
+      obj = signal(proxy({ val: 1 }));
+    }
+
+    const root = await mount(Root, fixture);
+    expect(renderCount).toBe(1);
+
+    root.obj.set(proxy({ val: 2 }));
+    await nextTick();
+    expect(observed).toEqual([1, 2]);
+    expect(renderCount).toBe(2);
+
+    root.obj.set(proxy({ val: 3 }));
+    await nextTick();
+    expect(observed).toEqual([1, 2, 3]);
+    expect(renderCount).toBe(3);
+  });
+
+  test("props() tracks new and deleted keys from t-props", async () => {
+    class Child extends Component {
+      static template = xml`<span><t t-out="this.label()"/></span>`;
+      props = props();
+      label() {
+        return `${Object.keys(this.props).join(",")}:${this.props.a || ""}${this.props.b || ""}`;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child t-props="this.childProps()"/>`;
+      static components = { Child };
+      childProps = signal<Record<string, string>>({ a: "a" });
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<span>a:a</span>");
+
+    parent.childProps.set({ b: "b" });
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<span>b:b</span>");
+  });
+
+  test("this.props still reflects the old value inside onWillUpdateProps", async () => {
+    const seen: { next: number; current: number }[] = [];
+    class Child extends Component {
+      static template = xml`<span t-out="this.props.value"/>`;
+      props = props(["value"]);
+      setup() {
+        onWillUpdateProps((nextProps) => {
+          seen.push({ next: nextProps.value, current: this.props.value });
+        });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child value="this.state.value"/>`;
+      static components = { Child };
+      state = proxy({ value: 1 });
+    }
+
+    const parent = await mount(Parent, fixture);
+    parent.state.value = 2;
+    await nextTick();
+    expect(seen).toEqual([{ next: 2, current: 1 }]);
+    expect(fixture.innerHTML).toBe("<span>2</span>");
+  });
+});


### PR DESCRIPTION
Reading a prop inside an effect/computed did not react to the same changes the template reacted to. Props participated only in the forced-render channel (parent re-render -> arePropsDifferent -> wholesale node.props replacement + fiber.render), not in the reactive channel: props() getters did a plain node.props[key] read, so the prop slot was not an atom and swapping a prop value was invisible to effects/computed.

Back each declared prop key with a signal used purely as a notification atom: the getter subscribes the current computation but returns the live node.props value. Notifications fire from a new node.propsUpdated list, invoked right after node.props is applied (sync and async branches) so that reads inside onWillUpdateProps still see the old value and async hooks observe the applied value. The synchronous forced render resets the render computation to EXECUTED before the batched microtask, so no extra render is introduced.

prop() (static, reference-stable) stays non-reactive.