### PR TITLE
[FIX] devtools: convert popup to owl3

### DIFF
--- a/tools/devtools/src/popup_app/popup.js
+++ b/tools/devtools/src/popup_app/popup.js
@@ -1,17 +1,17 @@
 import { templates } from "../../assets/templates.js";
 import { getOwlStatus } from "../utils";
-const { Component, useState, onWillStart, mount, App } = owl;
+const { Component, signal, onWillStart, mount, App } = owl;
 
 class PopUpApp extends Component {
   static template = "popup.PopUpApp";
 
   setup() {
-    this.state = useState({ status: 0 });
+    this.status = signal(0);
     onWillStart(async () => {
       try {
-        this.state.status = await getOwlStatus();
+        this.status.set(await getOwlStatus());
       } catch (e) {
-        this.state.status = -1;
+        this.status.set(-1);
       }
     });
   }

--- a/tools/devtools/src/popup_app/popup_app.xml
+++ b/tools/devtools/src/popup_app/popup_app.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
   <t t-name="popup.PopUpApp">
     <div class="container m-0 p-4 text-white bg-dark" style="width: 370px">
-      <p t-if="state.status === 1">
+      <p t-if="this.status() === 1">
         Owl is detected on this page but the version seems to be outdated.
         Please upgrade to a newer version in order to use the devtools.
       </p>
-      <p t-elif="state.status === 2">
+      <p t-elif="this.status() === 2">
         Owl is detected on this page.
         Open DevTools and look for the Owl panel.
       </p>


### PR DESCRIPTION
In the migration commit to owl3 for the devtools, the popup app was completely forgotten. This commit replaces the useState with a signal so that it no longer crashes.