### PR TITLE
[IMP] plugins: add sequence-based batched startup

### DIFF
--- a/doc/v3/owl/reference/plugins.md
+++ b/doc/v3/owl/reference/plugins.md
@@ -260,6 +260,38 @@ destroyed before initialization completes. Pass it to `fetch` or check
 `abortSignal.throwIfAborted()` between awaits to short-circuit abandoned work.
 See [Scope](./scope.md) for the full cancellation model.
 
+## Startup Order
+
+Sometimes a few foundational plugins must be fully loaded before other plugins
+even run their `setup()` — for example, a session plugin whose data every other
+plugin reads. The `static sequence` number (default: `50`, lower starts first,
+like resources and registries) controls this:
+
+```js
+class SessionPlugin extends Plugin {
+  static sequence = 10; // foundational: starts before the others
+
+  setup() {
+    onWillStart(async () => {
+      this.user = await loadSession();
+    });
+  }
+}
+```
+
+Plugins are started in batches of equal sequence, in ascending order. All
+`onWillStart` callbacks of a batch settle before the next batch is even
+instantiated, so a plugin with the default sequence can read `SessionPlugin`'s
+data synchronously in its own `setup()`. Within a batch, `onWillStart`
+callbacks still run in parallel.
+
+Two things to keep in mind:
+
+- An explicit dependency wins over sequence: calling `plugin(X)` starts `X`
+  immediately, even if `X` has a higher sequence number.
+- If an `onWillStart` callback in a batch rejects, the remaining batches are
+  not started and the mount is rejected.
+
 ## Lifecycle and Cleanup
 
 Plugins follow a simple lifecycle:

--- a/packages/owl-core/src/plugin_manager.ts
+++ b/packages/owl-core/src/plugin_manager.ts
@@ -8,6 +8,7 @@ import { untrack } from "./computations";
 export interface PluginConstructor {
   new (...args: any[]): Plugin;
   id: string;
+  sequence: number;
 }
 
 export class Plugin {
@@ -18,6 +19,14 @@ export class Plugin {
   static set id(shadowId: string) {
     this._shadowId = shadowId;
   }
+
+  // Plugins passed to `startPlugins` are started in batches of equal sequence,
+  // ascending (lower first), like Resource/Registry. Each batch's onWillStart
+  // callbacks fully settle before the next batch is instantiated, so
+  // foundational plugins (low sequence) are ready before later plugins even
+  // run their setup. Explicit `plugin(X)` dependencies bypass batching and
+  // start immediately.
+  static sequence = 50;
 
   __owl__: PluginManager;
 
@@ -37,11 +46,13 @@ export class PluginManager extends Scope {
   config: Record<string, any>;
   plugins: Record<string, Plugin>;
 
-  // Resolves once all pending plugin willStart callbacks have settled. The
-  // scope transitions to MOUNTED as the last step of this chain. Consumers
-  // (the root's mount(), providePlugins) await this before treating the
-  // manager as ready. `willStart` itself is inherited from Scope.
+  // Resolves once all batches of plugins have started and their willStart
+  // callbacks have settled. The scope transitions to MOUNTED as the last step
+  // of this chain. Consumers (the root's mount(), providePlugins) await this
+  // before treating the manager as ready. `willStart` itself is inherited
+  // from Scope.
   ready: Promise<void> = Promise.resolve();
+  private hasPendingReady = false;
 
   constructor(app: any, options: PluginManagerOptions = {}) {
     super(app);
@@ -91,26 +102,83 @@ export class PluginManager extends Scope {
   }
 
   startPlugins(pluginConstructors: PluginConstructor[]): void {
-    scopeStack.push(this);
-    try {
-      for (const pluginConstructor of pluginConstructors) {
-        this.startPlugin(pluginConstructor);
+    const fresh = pluginConstructors.filter((ctor) => {
+      if (!ctor.id || this.plugins.hasOwnProperty(ctor.id)) {
+        // already started (or invalid): startPlugin throws on missing ids and
+        // id conflicts, and is a no-op otherwise
+        this.startPlugin(ctor);
+        return false;
       }
-    } finally {
-      scopeStack.pop();
+      return true;
+    });
+    if (!fresh.length) {
+      return;
     }
-    const pending = this.willStart.splice(0);
-    if (pending.length) {
-      this.ready = Promise.all(pending.map((fn) => fn())).then(() => {
-        if (this.status < STATUS.MOUNTED) {
-          this.status = STATUS.MOUNTED;
+    // Sort ascending by sequence and group plugins of equal sequence into
+    // batches. A batch's willStart callbacks all settle before the next batch
+    // is even instantiated, so foundational (low sequence) plugins are fully
+    // ready before later plugins run their setup.
+    fresh.sort((p1, p2) => p1.sequence - p2.sequence);
+    const batches: PluginConstructor[][] = [];
+    for (const ctor of fresh) {
+      const batch = batches[batches.length - 1];
+      if (batch && batch[0].sequence === ctor.sequence) {
+        batch.push(ctor);
+      } else {
+        batches.push([ctor]);
+      }
+    }
+
+    // Instantiate one batch synchronously (its own scopeStack push/pop, never
+    // spanning an await) and return its pending willStart promise, if any.
+    const startBatch = (batch: PluginConstructor[]): Promise<unknown> | null => {
+      scopeStack.push(this);
+      try {
+        for (const ctor of batch) {
+          this.startPlugin(ctor);
         }
-      });
-    } else if (this.status < STATUS.MOUNTED) {
-      // Fast path: no async init, transition synchronously so consumers that
-      // read `status` right after `startPlugins` see MOUNTED immediately.
-      this.status = STATUS.MOUNTED;
+      } finally {
+        scopeStack.pop();
+      }
+      const pending = this.willStart.splice(0);
+      return pending.length ? Promise.all(pending.map((fn) => fn())) : null;
+    };
+
+    // Chain onto a still-pending `ready` (re-entrant call, e.g. a plugin added
+    // to a Resource while startup is in flight) so new plugins wait for the
+    // previous batches.
+    let chain: Promise<unknown> | null = this.hasPendingReady ? this.ready : null;
+    for (const batch of batches) {
+      if (chain) {
+        // Later batches are instantiated inside the previous batch's `then` so
+        // that a rejection skips them entirely.
+        chain = chain.then(() => startBatch(batch));
+      } else {
+        // No async work pending so far: start the batch synchronously.
+        chain = startBatch(batch);
+      }
     }
+    if (!chain) {
+      if (this.status < STATUS.MOUNTED) {
+        // Fast path: no async init, transition synchronously so consumers that
+        // read `status` right after `startPlugins` see MOUNTED immediately.
+        this.status = STATUS.MOUNTED;
+      }
+      return;
+    }
+    this.hasPendingReady = true;
+    const ready = (this.ready = chain.then(() => {
+      if (this.status < STATUS.MOUNTED) {
+        this.status = STATUS.MOUNTED;
+      }
+      if (this.ready === ready) {
+        this.hasPendingReady = false;
+      }
+      // Note: no rejection handler here. On failure, `ready` stays rejected
+      // and `hasPendingReady` stays true, so later startPlugins calls chain
+      // onto the rejected promise and are skipped, and the error surfaces as
+      // an unhandled rejection when no consumer awaits `ready`.
+    }));
   }
 }
 

--- a/packages/owl-runtime/tests/components/__snapshots__/plugins.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/plugins.test.ts.snap
@@ -262,6 +262,32 @@ exports[`plugins added to resource starts automatically 1`] = `
 }"
 `;
 
+exports[`providePlugins respects plugin sequence 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`providePlugins respects plugin sequence 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<span>child</span>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
 exports[`shadow plugin 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/plugins.test.ts
+++ b/packages/owl-runtime/tests/components/plugins.test.ts
@@ -5,6 +5,7 @@ import {
   config,
   mount,
   onWillDestroy,
+  onWillStart,
   plugin,
   Plugin,
   PluginConstructor,
@@ -18,6 +19,7 @@ import {
   xml,
 } from "../../src";
 import {
+  makeDeferred,
   makeTestFixture,
   nextMicroTick,
   snapshotEverything,
@@ -434,4 +436,51 @@ test("components mounted by plugin", async () => {
 
   await mount(R, fixture, { plugins: [P] });
   expect(fixture.innerHTML).toBe("defabc");
+});
+
+test("providePlugins respects plugin sequence", async () => {
+  const rpc = makeDeferred<string>();
+  const steps: string[] = [];
+
+  class Foundation extends Plugin {
+    static sequence = 10;
+    data: string | null = null;
+    setup() {
+      onWillStart(async () => {
+        this.data = await rpc;
+      });
+    }
+  }
+
+  class Feature extends Plugin {
+    foundation = plugin(Foundation);
+    setup() {
+      steps.push(`feature:setup (data=${this.foundation.data})`);
+    }
+  }
+
+  class Child extends Component {
+    static template = xml`<span>child</span>`;
+  }
+
+  class Parent extends Component {
+    static template = xml`<Child/>`;
+    static components = { Child };
+    setup() {
+      providePlugins([Feature, Foundation]);
+    }
+  }
+
+  const app = new App();
+  const mounted = app.createRoot(Parent).mount(fixture);
+  await nextTick();
+  // Feature's setup waits for Foundation, which delays the component render
+  expect(steps.splice(0)).toEqual([]);
+  expect(fixture.innerHTML).toBe("");
+
+  rpc.resolve("hello");
+  await mounted;
+  expect(steps.splice(0)).toEqual(["feature:setup (data=hello)"]);
+  expect(fixture.innerHTML).toBe("<span>child</span>");
+  app.destroy();
 });

--- a/packages/owl-runtime/tests/plugins.test.ts
+++ b/packages/owl-runtime/tests/plugins.test.ts
@@ -803,6 +803,297 @@ describe("onWillStart in plugins", () => {
   });
 });
 
+describe("plugin sequence", () => {
+  test("default sequence is 50 and can be overridden", () => {
+    class P extends Plugin {}
+    class Q extends Plugin {
+      static sequence = 10;
+    }
+    expect(P.sequence).toBe(50);
+    expect(Q.sequence).toBe(10);
+  });
+
+  test("plugins start in ascending sequence order, array order within a batch", () => {
+    const steps: string[] = [];
+
+    class A extends Plugin {
+      static sequence = 10;
+      setup() {
+        steps.push("A");
+      }
+    }
+    class B extends Plugin {
+      setup() {
+        steps.push("B");
+      }
+    }
+    class C extends Plugin {
+      setup() {
+        steps.push("C");
+      }
+    }
+    class D extends Plugin {
+      static sequence = 100;
+      setup() {
+        steps.push("D");
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([D, C, B, A]);
+    expect(steps).toEqual(["A", "C", "B", "D"]);
+  });
+
+  test("all-synchronous batches start synchronously and mount immediately", () => {
+    const steps: string[] = [];
+
+    class A extends Plugin {
+      static sequence = 10;
+      setup() {
+        steps.push("A");
+      }
+    }
+    class B extends Plugin {
+      setup() {
+        steps.push("B");
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([B, A]);
+    // no async init: both batches start synchronously, fast path preserved
+    expect(steps).toEqual(["A", "B"]);
+    expect(manager.status).toBe(STATUS.MOUNTED);
+  });
+
+  test("lower-sequence batch fully resolves before next batch starts", async () => {
+    const rpc = makeDeferred<string>();
+    const steps: string[] = [];
+
+    class Foundation extends Plugin {
+      static id = "foundation";
+      static sequence = 10;
+      data: string | null = null;
+      setup() {
+        steps.push("foundation:setup");
+        onWillStart(async () => {
+          steps.push("foundation:willStart");
+          this.data = await rpc;
+        });
+      }
+    }
+
+    class Feature extends Plugin {
+      foundation = plugin(Foundation);
+      setup() {
+        steps.push(`feature:setup (data=${this.foundation.data})`);
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([Feature, Foundation]);
+    expect(steps.splice(0)).toEqual(["foundation:setup", "foundation:willStart"]);
+    expect(manager.getPlugin(Feature)).toBe(null);
+
+    rpc.resolve("hello");
+    await manager.ready;
+    // Feature's setup only ran once Foundation was fully loaded
+    expect(steps.splice(0)).toEqual(["feature:setup (data=hello)"]);
+    expect(manager.status).toBe(STATUS.MOUNTED);
+    manager.destroy();
+  });
+
+  test("same-sequence plugins run their willStarts in parallel", async () => {
+    const rpc1 = makeDeferred<number>();
+    const rpc2 = makeDeferred<number>();
+    const started: string[] = [];
+
+    class A extends Plugin {
+      setup() {
+        onWillStart(async () => {
+          started.push("a:start");
+          await rpc1;
+        });
+      }
+    }
+    class B extends Plugin {
+      setup() {
+        onWillStart(async () => {
+          started.push("b:start");
+          await rpc2;
+        });
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([A, B]);
+    expect(started).toEqual(["a:start", "b:start"]);
+
+    rpc1.resolve(1);
+    rpc2.resolve(2);
+    await manager.ready;
+    expect(manager.status).toBe(STATUS.MOUNTED);
+    manager.destroy();
+  });
+
+  test("explicit plugin() dependency starts immediately regardless of sequence", () => {
+    const steps: string[] = [];
+
+    class Z extends Plugin {
+      static sequence = 99;
+      setup() {
+        steps.push("Z");
+      }
+    }
+    class A extends Plugin {
+      static sequence = 10;
+      z = plugin(Z);
+      setup() {
+        steps.push("A");
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([A, Z]);
+    expect(steps).toEqual(["Z", "A"]);
+    expect(manager.status).toBe(STATUS.MOUNTED);
+  });
+
+  test("rejection in an early batch skips later batches", async () => {
+    const steps: string[] = [];
+
+    class Broken extends Plugin {
+      static sequence = 10;
+      setup() {
+        onWillStart(async () => {
+          throw new Error("boom");
+        });
+      }
+    }
+    class Feature extends Plugin {
+      setup() {
+        steps.push("feature:setup");
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([Broken, Feature]);
+    await expect(manager.ready).rejects.toMatchObject({ message: "boom" });
+    expect(steps).toEqual([]);
+    expect(manager.getPlugin(Feature)).toBe(null);
+    expect(manager.status).not.toBe(STATUS.MOUNTED);
+    manager.destroy();
+  });
+
+  test("status flips to MOUNTED only after the last batch", async () => {
+    const rpc = makeDeferred<number>();
+
+    class A extends Plugin {
+      static sequence = 10;
+      setup() {
+        onWillStart(() => rpc);
+      }
+    }
+    class B extends Plugin {}
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([A, B]);
+    expect(manager.status).toBe(STATUS.NEW);
+
+    rpc.resolve(1);
+    await manager.ready;
+    expect(manager.status).toBe(STATUS.MOUNTED);
+    manager.destroy();
+  });
+
+  test("destroy order is reverse of sequence order", () => {
+    const steps: string[] = [];
+
+    class A extends Plugin {
+      static sequence = 10;
+      setup() {
+        onWillDestroy(() => steps.push("destroy A"));
+      }
+    }
+    class B extends Plugin {
+      setup() {
+        onWillDestroy(() => steps.push("destroy B"));
+      }
+    }
+
+    const manager = new PluginManager(new App());
+    manager.startPlugins([B, A]);
+    manager.destroy();
+    expect(steps).toEqual(["destroy B", "destroy A"]);
+  });
+
+  test("plugin added to resource while startup is pending waits for previous batches", async () => {
+    const rpc = makeDeferred<string>();
+    const steps: string[] = [];
+
+    class A extends Plugin {
+      setup() {
+        steps.push("A:setup");
+        onWillStart(() => rpc);
+      }
+    }
+    class B extends Plugin {
+      setup() {
+        steps.push("B:setup");
+      }
+    }
+
+    const plugins = new Resource({ validation: t.constructor(Plugin) }).add(A);
+    const app = new App({ plugins });
+    expect(steps.splice(0)).toEqual(["A:setup"]);
+
+    plugins.add(B);
+    await nextMicroTick();
+    // A's willStart is still pending: B must wait for it
+    expect(steps.splice(0)).toEqual([]);
+
+    rpc.resolve("done");
+    await app.pluginManager.ready;
+    expect(steps.splice(0)).toEqual(["B:setup"]);
+    expect(app.pluginManager.status).toBe(STATUS.MOUNTED);
+    app.destroy();
+  });
+
+  test("sequence works with plugins given to the App", async () => {
+    const rpc = makeDeferred<string>();
+    const steps: string[] = [];
+
+    class Foundation extends Plugin {
+      static sequence = 10;
+      setup() {
+        onWillStart(() => rpc);
+      }
+    }
+    class Feature extends Plugin {
+      setup() {
+        steps.push("feature:setup");
+      }
+    }
+
+    class Root extends Component {
+      static template = xml`<span>ok</span>`;
+    }
+
+    const fixture = makeTestFixture();
+    const app = new App({ plugins: [Feature, Foundation] });
+    const mounted = app.createRoot(Root).mount(fixture);
+    await nextTick();
+    expect(steps.splice(0)).toEqual([]);
+    expect(fixture.innerHTML).toBe("");
+
+    rpc.resolve("ok");
+    await mounted;
+    expect(steps.splice(0)).toEqual(["feature:setup"]);
+    expect(fixture.innerHTML).toBe("<span>ok</span>");
+    app.destroy();
+  });
+});
+
 test("can use useListener in a plugin", () => {
   let n: number = 0;
   const bus = new EventTarget();


### PR DESCRIPTION
Plugins now have a `static sequence` number (default 50, lower first, like Resource/Registry). `startPlugins` sorts plugins by sequence and groups equal values into batches: a batch's onWillStart callbacks all settle before the next batch is even instantiated, so foundational plugins (e.g. a session plugin) are fully loaded before later plugins run their setup.

Notes:
- batches with no async work still start synchronously, preserving the fast path where status flips to MOUNTED right after startPlugins
- a rejected batch skips the remaining batches and rejects `ready`
- explicit `plugin(X)` dependencies bypass batching and start immediately
- plugins added (via Resource) while startup is in flight chain onto the pending `ready` and wait for the previous batches