### PR TITLE
[FIX] devtools: fix selected element scrollIntoView

### DIFF
--- a/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
+++ b/tools/devtools/src/devtools_app/devtools_window/components_tab/tree_element/tree_element.js
@@ -32,8 +32,6 @@ export class TreeElement extends Component {
         if (this.components.activeSelector() || !isElementInCenterViewport(el)) {
           el.scrollIntoView({ block: "center", behavior: "smooth" });
         }
-      }
-      if (el) {
         this.components.selectedElement.set(el);
       }
     });


### PR DESCRIPTION
This commit fixes an issue where the components plugin would get its selectedElement by multiple TreeElements at the same time due to a mistake in the owl 3 migration. This would break the scrollIntoView of the selected element until app reset as long as a component was selected twice.