### PR TITLE
[FIX] devtools: fix tree view events loading

### DIFF
--- a/tools/devtools/src/devtools_app/store/profiler_plugin.js
+++ b/tools/devtools/src/devtools_app/store/profiler_plugin.js
@@ -87,6 +87,7 @@ export class ProfilerPlugin extends Plugin {
     if (!Array.isArray(events)) {
       return;
     }
+    events = [...events].sort((a, b) => a.id - b.id);
     for (const event of events) {
       if (
         !isObjectWithShape(event, {
@@ -134,7 +135,11 @@ export class ProfilerPlugin extends Plugin {
               );
               let parent = tree[i];
               for (const key of relativePath) {
-                parent = parent.children.find((child) => child.key === key);
+                const found = parent.children.find((child) => child.key === key);
+                if (!found) {
+                  break;
+                }
+                parent = found;
               }
               eventNode.depth = parent.depth + 1;
               parent.children.push(eventNode);


### PR DESCRIPTION
This commit fixes a crash that would silently trigger in case of missing intermediate events in the tree hierarchy upon loading events. In that case, the _loadEvents method would interrupt, disrupting the flow of events registration in the tree for the whole batch. The failing case is to be expected so a failsafe is sufficient here.