### PR TITLE
[FIX] playground: display correct preset name for tutorials

### DIFF
--- a/tools/playground/src/playground.js
+++ b/tools/playground/src/playground.js
@@ -72,7 +72,7 @@ class Playground extends Component {
       const project = this.project.activeProject();
       if (!project || !project.templateDesc) return "";
       if (this.project.isCurrentProjectDirty()) return "";
-      return project.templateDesc;
+      return project.tutorial ? `tutorial:${project.templateDesc}` : project.templateDesc;
     });
 
     useEffect(() => {
@@ -165,7 +165,6 @@ class Playground extends Component {
 
   async onTemplateChange(ev) {
     const desc = ev.target.value;
-    ev.target.value = this.currentTemplateValue();
     ev.target.blur();
     if (!desc) return;
 


### PR DESCRIPTION
Selecting a tutorial from the preset dropdown displayed an empty preset label due to a wrong name update. Ensure the selected tutorial name is correctly reflected in the preset selector.