### PR TITLE
[IMP] devtools: resolve Firefox-specific stability and API compatibility issues

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 3,
   "description": "Chrome devtools extension for Odoo Owl framework",
   "icons": {

--- a/tools/devtools/manifest-firefox.json
+++ b/tools/devtools/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Firefox devtools extension for Odoo Owl framework",
   "manifest_version": 2,
   "browser_specific_settings": {

--- a/tools/devtools/src/devtools_app/store/components_plugin.js
+++ b/tools/devtools/src/devtools_app/store/components_plugin.js
@@ -43,15 +43,28 @@ export class ComponentsPlugin extends Plugin {
 
   async loadComponentsTree(fromOld) {
     if (IS_FIREFOX) {
-      await evalInWindow("window.$0 = $0;", this._store.activeFrame());
+      await evalInWindow("try { window.$0 = $0; } catch(e) {}");
     }
-    const [apps, details] = await evalFunctionInWindow(
-      "getComponentsTree",
+    const args =
       fromOld && this.activeComponent()
         ? [this.activeComponent().path, this.apps(), this.activeComponent()]
-        : [],
+        : [];
+    let treeResult = await evalFunctionInWindow(
+      "getComponentsTree",
+      args,
       this._store.activeFrame()
     );
+    if (treeResult === undefined) {
+      // Delayed retry on failure
+      await new Promise((r) => setTimeout(r, 500));
+      treeResult = await evalFunctionInWindow("getComponentsTree", args, this._store.activeFrame());
+      // Hard reload when even the retry fails
+      if (treeResult === undefined) {
+        this._store.refreshExtension();
+        return;
+      }
+    }
+    const [apps, details] = treeResult;
     this.apps.set(proxy(apps || []));
     if (!fromOld && this._store.expandByDefault()) {
       this.apps().forEach((tree) => expandNodes(tree, this._store.componentsToggleBlacklist()));

--- a/tools/devtools/src/devtools_app/store/store.js
+++ b/tools/devtools/src/devtools_app/store/store.js
@@ -66,11 +66,15 @@ export class StorePlugin extends Plugin {
   // -------------------------------------------------------------------------
 
   async updateIFrameList() {
-    const frames = await evalFunctionInWindow("getIFrameUrls");
     this.frameUrls.set(["top"]);
     if (this.activeFrame() !== "top") {
       this.selectFrame("top");
     }
+    // Firefox doesn't support per-frame eval, so iframe detection is not possible
+    if (IS_FIREFOX) {
+      return;
+    }
+    const frames = await evalFunctionInWindow("getIFrameUrls");
     for (const frame of frames) {
       const hasOwl = await evalInWindow("window.__OWL_DEVTOOLS__?.Fiber !== undefined;", frame);
       if (hasOwl) {
@@ -327,6 +331,10 @@ export function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
 }
 
 export function evalInWindow(code, frameUrl = "top") {
+  // Firefox does not support the frameURL option in devtools.inspectedWindow.eval
+  if (IS_FIREFOX && frameUrl !== "top") {
+    return Promise.resolve(undefined);
+  }
   return new Promise((resolve, reject) => {
     if (frameUrl !== "top") {
       browserInstance.devtools.inspectedWindow.eval(

--- a/tools/devtools/src/devtools_app/store/store.js
+++ b/tools/devtools/src/devtools_app/store/store.js
@@ -131,8 +131,12 @@ export class StorePlugin extends Plugin {
   }
 
   async refreshExtension() {
-    await loadScripts();
-    await this._resetData();
+    const loaded = await loadScripts().catch(() => false);
+    if (loaded) {
+      await this._resetData();
+    } else {
+      window.location.reload();
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -316,40 +320,14 @@ export class StorePlugin extends Plugin {
 // Standalone helper functions (exported for use by sub-plugins)
 // -------------------------------------------------------------------------
 
-export async function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
-  const stringifiedArgs = [...args].map((arg) => {
-    arg = JSON.stringify(arg);
-    return arg;
-  });
-  const argsString = "(" + stringifiedArgs.join(", ") + ");";
-  let script = `__OWL__DEVTOOLS_GLOBAL_HOOK__.${fn}${argsString}`;
-  return await new Promise((resolve, reject) => {
-    if (frameUrl !== "top") {
-      browserInstance.devtools.inspectedWindow.eval(
-        script,
-        { frameURL: frameUrl },
-        (result, isException) => {
-          if (!isException) {
-            resolve(result);
-          } else {
-            reject(script);
-          }
-        }
-      );
-    } else {
-      browserInstance.devtools.inspectedWindow.eval(script, (result, isException) => {
-        if (!isException) {
-          resolve(result);
-        } else {
-          reject(script);
-        }
-      });
-    }
-  });
+export function evalFunctionInWindow(fn, args = [], frameUrl = "top") {
+  const stringifiedArgs = [...args].map((arg) => JSON.stringify(arg));
+  const script = `__OWL__DEVTOOLS_GLOBAL_HOOK__.${fn}(${stringifiedArgs.join(", ")});`;
+  return evalInWindow(script, frameUrl);
 }
 
-export async function evalInWindow(code, frameUrl = "top") {
-  return await new Promise((resolve, reject) => {
+export function evalInWindow(code, frameUrl = "top") {
+  return new Promise((resolve, reject) => {
     if (frameUrl !== "top") {
       browserInstance.devtools.inspectedWindow.eval(
         code,


### PR DESCRIPTION
This PR stabilizes the devtools extension on Firefox by addressing two main technical hurdles:
1. **Context Disconnection:** Forces a hard reload of the devtools window when script loading fails or when the extension loses its connection to the page evaluation context following redirects.
2. **Iframe API Limits:** Adds a guard to disable iframe-specific evaluation code, as the `frameUrl` parameter used in `devtools.inspectedWindow.eval` is unsupported on Firefox.