### PR TITLE
[FIX] devtools: fix HTML selector state desync in Firefox

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -1,8 +1,8 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "manifest_version": 3,
-  "description": "Chrome devtools extension for Odoo Owl framework",
+  "description": "Chromium devtools extension for Odoo Owl framework",
   "icons": {
     "128": "assets/icon128.png"
   },

--- a/tools/devtools/manifest-firefox.json
+++ b/tools/devtools/manifest-firefox.json
@@ -1,11 +1,11 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Firefox devtools extension for Odoo Owl framework",
   "manifest_version": 2,
   "browser_specific_settings": {
     "gecko": {
-      "id": "@owl-devtools",
+      "id": "@owl-devtools-firefox",
       "strict_min_version": "74.0"
     }
   },

--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -724,10 +724,9 @@
         cancelAnimationFrame(this._selectorRafId);
         this._selectorRafId = null;
       }
-      if (ev) {
-        if (!ev.isTrusted) {
-          return;
-        }
+      // Only block propagation for real user clicks; synthetic (untrusted) clicks
+      // must still reach the cleanup path so the devtools state stays in sync.
+      if (ev && ev.isTrusted) {
         ev.stopPropagation();
         ev.preventDefault();
       }


### PR DESCRIPTION
Fixes an issue where the HTML selector remained active on Firefox due to synthetic click events. The `disableHTMLSelector` early return for untrusted events was preventing proper cleanup and signal transmission. The cleanup logic now executes for all events, while `stopPropagation` and `preventDefault` remain restricted to trusted events to preserve normal page interaction.