### PR TITLE
[FIX] owl: properly handle detaching refs

### DIFF
--- a/packages/owl-compiler/src/code_generator.ts
+++ b/packages/owl-compiler/src/code_generator.ts
@@ -688,7 +688,11 @@ export class CodeGenerator {
     if (ast.ref) {
       const refExpr = compileExpr(ast.ref);
       this.helpers.add("createRef");
-      const setRefStr = `createRef(${refExpr})`;
+      // `node` is the component that physically hosts this element (for slot
+      // content it is the innermost host, threaded through callSlot). createRef
+      // registers the ref there so it is cleared if the element is removed
+      // without this block's own remove() running (bulk removal).
+      const setRefStr = `createRef(${refExpr}, node)`;
       const idx = block!.insertData(setRefStr, "ref");
       attrs["block-ref"] = String(idx);
     }

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -47,6 +47,11 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
   willPatch: LifecycleHook[] = [];
   patched: LifecycleHook[] = [];
   signalComputation: ComputationAtom;
+  // t-ref signals bound to an element hosted by this component, mapped to their
+  // atom (so the element can be read without subscribing). Swept by isConnected
+  // after each patch and after this subtree is removed, to unset a ref pointing
+  // at a bulk-removed element (slot host, enclosing t-if) — see sweepRefs.
+  trackedRefs: Map<{ set(v: null): void }, { value: HTMLElement | null }> | null = null;
 
   constructor(
     C: ComponentConstructor,
@@ -190,9 +195,15 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
 
   destroy() {
     let shouldRemove = this.status === STATUS.MOUNTED;
-    this._destroy();
+    removalDepth++;
+    try {
+      this._destroy();
+    } finally {
+      removalDepth--;
+    }
     if (shouldRemove) {
       this.bdom!.remove();
+      sweepRemovedRefs();
     }
   }
 
@@ -203,11 +214,47 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
         cb.call(component);
       }
     }
+    // While a removal is in progress, collect ref-bearing nodes on the way down
+    // (we are walking the whole subtree anyway for willUnmount). They are swept
+    // once their dom is detached, by whoever drives the outermost removal — see
+    // sweepRemovedRefs. A removed component's own remove() is not always called
+    // (a block can bulk-remove it), so it cannot be relied on to sweep itself.
+    if (removalDepth && this.trackedRefs) {
+      (removed ||= []).push(this);
+    }
     for (let childKey in this.children) {
       this.children[childKey]._destroy();
     }
     this.finalize((e) => handleError({ error: e, node: this }));
     disposeComputation(this.signalComputation);
+  }
+
+  /**
+   * Unset any tracked t-ref whose element is no longer in the document, and stop
+   * tracking it (createRef re-registers it on the next render if the element
+   * comes back). `isConnected` is the discriminator: a ref the block's own
+   * remove() failed to clear (bulk removal) points at a detached element and is
+   * cleared, while a ref a surviving sibling just took over (t-if/t-else with a
+   * shared signal) points at a still-connected element and is left alone.
+   *
+   * Called after this component's dom settles: at the tail of `_patch` (before
+   * user `onPatched`), so an element removed in place is caught, and — for the
+   * nodes collected during `_destroy` — after a removed subtree is detached.
+   */
+  sweepRefs() {
+    const refs = this.trackedRefs;
+    if (!refs) {
+      return;
+    }
+    for (const [ref, atom] of refs) {
+      const el = atom.value;
+      if (!el) {
+        refs.delete(ref);
+      } else if (!el.isConnected) {
+        ref.set(null);
+        refs.delete(ref);
+      }
+    }
   }
 
   /**
@@ -229,7 +276,14 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
     } else {
       // if we get here, this is the component that handled the error and rerendered
       // itself, so we can simply patch the dom
-      this.bdom!.patch(this.fiber!.bdom, false);
+      removalDepth++;
+      try {
+        this.bdom!.patch(this.fiber!.bdom, false);
+      } finally {
+        removalDepth--;
+      }
+      this.sweepRefs();
+      sweepRemovedRefs();
       this.fiber!.appliedToDom = true;
       this.fiber = null;
     }
@@ -262,6 +316,15 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
     this.bdom!.moveBeforeVNode(other ? other.bdom : null, afterNode);
   }
 
+  /**
+   * Register a t-ref signal bound to an element this component hosts, so its
+   * lifecycle can clear it (see sweepRefs / _destroy). Idempotent — re-tracking
+   * the same signal on each render just refreshes its atom.
+   */
+  trackRef(ref: { set(v: null): void }, atom: { value: HTMLElement | null }) {
+    (this.trackedRefs ||= new Map()).set(ref, atom);
+  }
+
   patch() {
     if (this.fiber && this.fiber.parent) {
       // we only patch here renderings coming from above. renderings initiated
@@ -279,7 +342,14 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
     }
     const fiber = this.fiber!;
     this.children = fiber.childrenMap;
-    this.bdom!.patch(fiber.bdom!, hasChildren);
+    removalDepth++;
+    try {
+      this.bdom!.patch(fiber.bdom!, hasChildren);
+    } finally {
+      removalDepth--;
+    }
+    this.sweepRefs();
+    sweepRemovedRefs();
     fiber.appliedToDom = true;
     this.fiber = null;
   }
@@ -290,6 +360,30 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
 
   remove() {
     this.bdom!.remove();
+  }
+}
+
+// While a removal is in progress (a component patch that drops a subtree, or a
+// destroy), the ref-bearing nodes of the removed subtree(s) accumulate in this
+// single global list, then get swept once their dom is detached. `removalDepth`
+// counts how deeply removals are nested — removals re-enter, e.g. a Portal or
+// Suspense destroys its sub-root from onWillDestroy mid-patch — and only the
+// outermost one (depth back to 0) does the sweep, so a nested removal never
+// clears the list out from under the one driving it. The list is lazy, so a
+// patch that removes nothing allocates nothing.
+let removalDepth = 0;
+let removed: ComponentNode[] | null = null;
+
+// Sweep the collected nodes if this is the outermost removal and anything was
+// collected. Their dom is detached by now, so sweepRefs's isConnected check
+// correctly unsets refs left dangling by a bulk removal.
+function sweepRemovedRefs() {
+  if (removalDepth === 0 && removed) {
+    const nodes = removed;
+    removed = null;
+    for (let i = 0; i < nodes.length; i++) {
+      nodes[i].sweepRefs();
+    }
   }
 }
 

--- a/packages/owl-runtime/src/rendering/template_helpers.ts
+++ b/packages/owl-runtime/src/rendering/template_helpers.ts
@@ -146,7 +146,7 @@ export function safeOutput(value: any, defaultValue?: any): ReturnType<typeof to
   return toggler(safeKey, block);
 }
 
-function createRef(ref: any) {
+function createRef(ref: any, node: ComponentNode) {
   if (!ref) {
     throw new OwlError(`Ref is undefined or null`);
   }
@@ -169,6 +169,15 @@ function createRef(ref: any) {
           if (atom.value === prevEl) ref.set(null);
         }
       : () => ref.set(null);
+    // The block-ref callback above only fires when this block's own remove() is
+    // called. When an enclosing block is removed in bulk (e.g. a slot host),
+    // the callback is skipped and the signal would keep pointing at a detached
+    // element. Track the ref on its host component, which clears it on unmount
+    // and sweeps detached refs after each patch. `node` is the host even for
+    // forwarded slot content (createRef sees the innermost host via callSlot).
+    if (atom) {
+      node.trackRef(ref, atom);
+    }
   } else {
     throw new OwlError(
       `Ref should implement either a 'set' function or 'add' and 'delete' functions`

--- a/packages/owl-runtime/tests/app/__snapshots__/sub_root.test.ts.snap
+++ b/packages/owl-runtime/tests/app/__snapshots__/sub_root.test.ts.snap
@@ -30,7 +30,7 @@ exports[`destroy a subroot while another component is mounted in main app 2`] = 
   
   return function template(ctx, node, key = "") {
     const b2 = text(\`a\`);
-    let ref1 = createRef(ctx['this'].ref);
+    let ref1 = createRef(ctx['this'].ref, node);
     const b3 = block3([ref1]);
     return multi([b2, b3]);
   }

--- a/packages/owl-runtime/tests/compiler/__snapshots__/misc.test.ts.snap
+++ b/packages/owl-runtime/tests/compiler/__snapshots__/misc.test.ts.snap
@@ -266,9 +266,9 @@ exports[`misc > other complex template 1`] = `
     let prop2 = new String((ctx['search'].value) === 0 ? 0 : ((ctx['search'].value) || ""));
     let hdlr4 = [hdlr_fn4, ctx];
     let hdlr5 = [hdlr_fn5, ctx];
-    let ref1 = createRef(ctx['search_input']);
+    let ref1 = createRef(ctx['search_input'], node);
     let hdlr6 = [hdlr_fn6, ctx];
-    let ref2 = createRef(ctx['settings_menu']);
+    let ref2 = createRef(ctx['settings_menu'], node);
     if (ctx['triggers']) {
       const ctx3 = ctx;
       const [k_block23, v_block23, l_block23, c_block23] = prepareList(ctx['triggers']);;

--- a/packages/owl-runtime/tests/compiler/__snapshots__/t_ref.test.ts.snap
+++ b/packages/owl-runtime/tests/compiler/__snapshots__/t_ref.test.ts.snap
@@ -9,7 +9,7 @@ exports[`t-ref > can get a ref on a node 1`] = `
   let block1 = createBlock(\`<div><span block-ref="0"/></div>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['myspan']);
+    let ref1 = createRef(ctx['myspan'], node);
     return block1([ref1]);
   }
 }"
@@ -39,7 +39,7 @@ exports[`t-ref > ref in a t-call 2`] = `
   let block1 = createBlock(\`<div>1<span block-ref="0"/>2</div>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['name']);
+    let ref1 = createRef(ctx['name'], node);
     return block1([ref1]);
   }
 }"
@@ -57,7 +57,7 @@ exports[`t-ref > ref in a t-if 1`] = `
   return function template(ctx, node, key = "") {
     let b2;
     if (ctx['condition']) {
-      let ref1 = createRef(ctx['name']);
+      let ref1 = createRef(ctx['name'], node);
       b2 = block2([ref1]);
     }
     return block1([], [b2]);
@@ -82,7 +82,7 @@ exports[`t-ref > refs in a loop 1`] = `
       ctx[\`item\`] = k_block2[i1];
       const key1 = ctx['item'].id;
       const tKey_1 = ctx['item'].id;
-      let ref1 = createRef(ctx['item'].ref);
+      let ref1 = createRef(ctx['item'].ref, node);
       const b4 = toggler(tKey_1, safeOutput(ctx['item'].id));
       c_block2[i1] = withKey(block3([ref1], [b4]), tKey_1 + key1);
     }
@@ -104,10 +104,10 @@ exports[`t-ref > two refs, one in a t-if 1`] = `
   return function template(ctx, node, key = "") {
     let b2;
     if (ctx['condition']) {
-      let ref1 = createRef(ctx['refs'].name);
+      let ref1 = createRef(ctx['refs'].name, node);
       b2 = block2([ref1]);
     }
-    let ref2 = createRef(ctx['refs'].p);
+    let ref2 = createRef(ctx['refs'].p, node);
     return block1([ref2], [b2]);
   }
 }"

--- a/packages/owl-runtime/tests/compiler/t_ref.test.ts
+++ b/packages/owl-runtime/tests/compiler/t_ref.test.ts
@@ -105,7 +105,8 @@ describe("t-ref", () => {
     app.addTemplate("sub", sub);
 
     const name = signal<any>(null);
-    const bdom = app.getTemplate("main").call(null, { name }, {});
+    // `node` would be a ComponentNode in real rendering; stub what createRef needs
+    const bdom = app.getTemplate("main").call(null, { name }, { trackRef() {} });
     mount(bdom, document.createElement("div"));
 
     expect(name().tagName).toBe("SPAN");

--- a/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
@@ -12,7 +12,7 @@ exports[`hooks > autofocus hook > input in a t-if 1`] = `
   return function template(ctx, node, key = "") {
     let b2;
     if (ctx['this'].state.flag) {
-      let ref1 = createRef(ctx['this'].input);
+      let ref1 = createRef(ctx['this'].input, node);
       b2 = block2([ref1]);
     }
     return block1([], [b2]);
@@ -29,7 +29,7 @@ exports[`hooks > autofocus hook > simple input 1`] = `
   let block1 = createBlock(\`<div><input/><input block-ref="0"/></div>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].input);
+    let ref1 = createRef(ctx['this'].input, node);
     return block1([ref1]);
   }
 }"
@@ -174,7 +174,7 @@ exports[`hooks > useEffect hook > effect can depend on stuff in dom 1`] = `
   return function template(ctx, node, key = "") {
     let b2;
     if (ctx['this'].state.value) {
-      let ref1 = createRef(ctx['this'].ref);
+      let ref1 = createRef(ctx['this'].ref, node);
       b2 = block2([ref1]);
     }
     return multi([b2]);
@@ -264,7 +264,7 @@ exports[`hooks > useListener work with references 1`] = `
   let block1 = createBlock(\`<span block-ref="0"><block-child-0/></span>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].span);
+    let ref1 = createRef(ctx['this'].span, node);
     const b2 = safeOutput(ctx['this'].value());
     return block1([ref1], [b2]);
   }

--- a/packages/owl-runtime/tests/components/__snapshots__/refs.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/refs.test.ts.snap
@@ -9,7 +9,7 @@ exports[`refs > basic use 1`] = `
   let block1 = createBlock(\`<div block-ref="0"/>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].button);
+    let ref1 = createRef(ctx['this'].button, node);
     return block1([ref1]);
   }
 }"
@@ -24,8 +24,229 @@ exports[`refs > basic use with signal.ref 1`] = `
   let block1 = createBlock(\`<input block-ref="0"/>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].input);
+    let ref1 = createRef(ctx['this'].input, node);
     return block1([ref1]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset across a t-if nested inside the slot content 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Wrapper\`, true, true, false, []);
+  
+  let block3 = createBlock(\`<span block-ref="0">hi</span>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let b3;
+    if (ctx['this'].inner()) {
+      let ref1 = createRef(ctx['this'].myRef, node);
+      b3 = block3([ref1]);
+    }
+    return multi([b3]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    let b4;
+    if (ctx['this'].visible()) {
+      b4 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+    }
+    return multi([b4]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset across a t-if nested inside the slot content 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block1 = createBlock(\`<section><block-child-0/></section>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when an intermediate host is removed in place 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Inner\`, true, true, false, []);
+  
+  let block2 = createBlock(\`<div><block-child-0/></div>\`);
+  let block3 = createBlock(\`<span block-ref="0">x</span>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let ref1 = createRef(ctx['this'].myRef, node);
+    return block3([ref1]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    let b2;
+    if (ctx['this'].show()) {
+      const b4 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+      b2 = block2([], [b4]);
+    }
+    return multi([b2]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when an intermediate host is removed in place 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block1 = createBlock(\`<i><block-child-0/></i>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when forwarded through a nested component 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Wrapper\`, true, true, false, []);
+  
+  let block2 = createBlock(\`<b block-ref="0">x</b>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let ref1 = createRef(ctx['this'].myRef, node);
+    return block2([ref1]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    let b3;
+    if (ctx['this'].visible()) {
+      b3 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+    }
+    return multi([b3]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when forwarded through a nested component 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Inner\`, true, true, false, []);
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  function slot1(ctx, node, key = "") {
+    return callSlot(ctx, node, key, 'default', false, {});
+  }
+  
+  return function template(ctx, node, key = "") {
+    const b3 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+    return block1([], [b3]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when forwarded through a nested component 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block1 = createBlock(\`<i><block-child-0/></i>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when the host removes it in place (host survives) 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Wrapper\`, true, true, false, []);
+  
+  let block1 = createBlock(\`<span class="slotted" block-ref="0">hi</span>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let ref1 = createRef(ctx['this'].myRef, node);
+    return block1([ref1]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    return comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when the host removes it in place (host survives) 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block2 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    let b2;
+    if (ctx['this'].show()) {
+      const b3 = callSlot(ctx, node, key, 'default', false, {});
+      b2 = block2([], [b3]);
+    }
+    return multi([b2]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when the slot host is removed 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Wrapper\`, true, true, false, []);
+  
+  let block2 = createBlock(\`<div class="slotted" block-ref="0">Coucou</div>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let ref1 = createRef(ctx['this'].myRef, node);
+    return block2([ref1]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    let b3;
+    if (ctx['this'].visible()) {
+      b3 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+    }
+    return multi([b3]);
+  }
+}"
+`;
+
+exports[`refs > ref in slot is unset when the slot host is removed 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
   }
 }"
 `;
@@ -52,8 +273,60 @@ exports[`refs > ref is set by child component 2`] = `
   let block1 = createBlock(\`<div id="ref" block-ref="0"/>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].props.ref);
+    let ref1 = createRef(ctx['this'].props.ref, node);
     return block1([ref1]);
+  }
+}"
+`;
+
+exports[`refs > ref is unset even when a sub-root is destroyed re-entrantly mid-removal 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<p>sub</p>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`refs > ref is unset even when a sub-root is destroyed re-entrantly mid-removal 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef, markRaw, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Wrapper\`, true, true, false, []);
+  
+  let block2 = createBlock(\`<span block-ref="0">hi</span>\`);
+  
+  function slot1(ctx, node, key = "") {
+    let ref1 = createRef(ctx['this'].myRef, node);
+    return block2([ref1]);
+  }
+  
+  return function template(ctx, node, key = "") {
+    let b3;
+    if (ctx['this'].show()) {
+      b3 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
+    }
+    return multi([b3]);
+  }
+}"
+`;
+
+exports[`refs > ref is unset even when a sub-root is destroyed re-entrantly mid-removal 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { callSlot } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
   }
 }"
 `;
@@ -70,7 +343,7 @@ exports[`refs > ref is unset when t-if goes to false after unrelated render 1`] 
     let b2;
     if (ctx['this'].state.show) {
       let attr1 = ctx['this'].state.class;
-      let ref1 = createRef(ctx['this'].ref);
+      let ref1 = createRef(ctx['this'].ref, node);
       b2 = block2([attr1, ref1]);
     }
     return multi([b2]);
@@ -90,10 +363,10 @@ exports[`refs > ref shared between t-if and t-else, plain 1`] = `
   return function template(ctx, node, key = "") {
     let b2, b3;
     if (ctx['this'].cond()) {
-      let ref1 = createRef(ctx['this'].ref);
+      let ref1 = createRef(ctx['this'].ref, node);
       b2 = block2([ref1]);
     } else {
-      let ref2 = createRef(ctx['this'].ref);
+      let ref2 = createRef(ctx['this'].ref, node);
       b3 = block3([ref2]);
     }
     return multi([b2, b3]);
@@ -112,14 +385,14 @@ exports[`refs > ref shared between t-if and t-else, t-else has a slotted compone
   let block3 = createBlock(\`<div class="elsebranch" block-ref="0"/>\`);
   
   function slot1(ctx, node, key = "") {
-    let ref2 = createRef(ctx['this'].ref);
+    let ref2 = createRef(ctx['this'].ref, node);
     return block3([ref2]);
   }
   
   return function template(ctx, node, key = "") {
     let b2, b4;
     if (ctx['this'].cond()) {
-      let ref1 = createRef(ctx['this'].ref);
+      let ref1 = createRef(ctx['this'].ref, node);
       b2 = block2([ref1]);
     } else {
       b4 = comp1({slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
@@ -152,7 +425,7 @@ exports[`refs > refs and recursive templates 1`] = `
   
   return function template(ctx, node, key = "") {
     let b2, b3;
-    let ref1 = createRef(ctx['this'].root);
+    let ref1 = createRef(ctx['this'].root, node);
     b2 = safeOutput(ctx['this'].props.tree.value);
     if (ctx['this'].props.tree.child) {
       b3 = comp1({tree: ctx['this'].props.tree.child}, key + \`__1\`, node, this, null);
@@ -176,7 +449,7 @@ exports[`refs > refs and t-key 1`] = `
     let hdlr1 = [hdlr_fn1, ctx];
     const b2 = block2([hdlr1]);
     const tKey_1 = ctx['this'].state.renderId;
-    let ref1 = createRef(ctx['this'].root);
+    let ref1 = createRef(ctx['this'].root, node);
     const b3 = toggler(tKey_1, block3([ref1]));
     return multi([b2, b3]);
   }
@@ -196,7 +469,7 @@ exports[`refs > refs are properly bound in slots 1`] = `
   
   function slot1(ctx, node, key = "") {
     let hdlr1 = [hdlr_fn1, ctx];
-    let ref1 = createRef(ctx['this'].button);
+    let ref1 = createRef(ctx['this'].button, node);
     return block3([hdlr1, ref1]);
   }
   
@@ -239,7 +512,7 @@ exports[`refs > resource can be used for multi ref 1`] = `
       ctx[\`item\`] = k_block1[i1];
       const key1 = ctx['item'];
       let attr1 = \`item-\${ctx['item']}\`;
-      let ref1 = createRef(ctx['this'].refs);
+      let ref1 = createRef(ctx['this'].refs, node);
       c_block1[i1] = withKey(block2([attr1, ref1]), key1);
     }
     return list(c_block1);
@@ -259,10 +532,10 @@ exports[`refs > use 2 refs in a t-if/t-else situation 1`] = `
   return function template(ctx, node, key = "") {
     let b2, b3;
     if (ctx['this'].state.value) {
-      let ref1 = createRef(ctx['this'].ref1);
+      let ref1 = createRef(ctx['this'].ref1, node);
       b2 = block2([ref1]);
     } else {
-      let ref2 = createRef(ctx['this'].ref2);
+      let ref2 = createRef(ctx['this'].ref2, node);
       b3 = block3([ref2]);
     }
     return multi([b2, b3]);

--- a/packages/owl-runtime/tests/components/__snapshots__/slots.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/slots.test.ts.snap
@@ -188,7 +188,7 @@ exports[`slots > can render node with t-ref and Component in same slot 1`] = `
   let block2 = createBlock(\`<div block-ref="0"/>\`);
   
   function slot1(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].ref);
+    let ref1 = createRef(ctx['this'].ref, node);
     const b2 = block2([ref1]);
     const b3 = comp1({}, key + \`__1\`, node, this, null);
     return multi([b2, b3]);

--- a/packages/owl-runtime/tests/components/__snapshots__/t_call.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/t_call.test.ts.snap
@@ -643,7 +643,7 @@ exports[`t-call > t-call-context: ComponentNode is not looked up in the context 
   
   function slot1(ctx, node, key = "") {
     ctx = Object.create(ctx);
-    let ref2 = createRef(ctx['this'].myRef2);
+    let ref2 = createRef(ctx['this'].myRef2, node);
     const b4 = block4([ref2]);
     ctx["test"] = 3;
     const b6 = safeOutput(ctx['test']);
@@ -652,7 +652,7 @@ exports[`t-call > t-call-context: ComponentNode is not looked up in the context 
   }
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].myRef);
+    let ref1 = createRef(ctx['this'].myRef, node);
     const b2 = block2([ref1]);
     const b7 = comp1({prop: (ctx['this'].method).bind(this),slots: markRaw({'default': {__render: slot1.bind(this), __ctx: ctx}})}, key + \`__1\`, node, this, null);
     return multi([b2, b7]);

--- a/packages/owl-runtime/tests/components/refs.test.ts
+++ b/packages/owl-runtime/tests/components/refs.test.ts
@@ -4,6 +4,7 @@ import {
   mount,
   onMounted,
   onPatched,
+  onWillDestroy,
   proxy,
   xml,
   props,
@@ -295,5 +296,168 @@ describe("refs", () => {
     root.cond.set(false);
     await nextTick();
     expect(root.ref()).toBe(fixture.querySelector(".elsebranch"));
+  });
+
+  test("ref in slot is unset when the slot host is removed", async () => {
+    class Wrapper extends Component {
+      static template = xml`<div><t t-call-slot="default"/></div>`;
+    }
+    class Root extends Component {
+      static components = { Wrapper };
+      static template = xml`
+        <t t-if="this.visible()">
+          <Wrapper>
+            <div class="slotted" t-ref="this.myRef">Coucou</div>
+          </Wrapper>
+        </t>`;
+      visible = signal(false);
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).toBeNull();
+
+    root.visible.set(true);
+    await nextTick();
+    expect(root.myRef()).toBe(fixture.querySelector(".slotted"));
+
+    // Removing the wrapper removes the slotted element from the DOM; the ref
+    // signal (owned by the surviving Root) must be cleared too.
+    root.visible.set(false);
+    await nextTick();
+    expect(fixture.innerHTML).not.toContain("Coucou");
+    expect(root.myRef()).toBeNull();
+  });
+
+  test("ref in slot is unset across a t-if nested inside the slot content", async () => {
+    class Wrapper extends Component {
+      static template = xml`<section><t t-call-slot="default"/></section>`;
+    }
+    class Root extends Component {
+      static components = { Wrapper };
+      static template = xml`
+        <t t-if="this.visible()">
+          <Wrapper>
+            <t t-if="this.inner()"><span t-ref="this.myRef">hi</span></t>
+          </Wrapper>
+        </t>`;
+      visible = signal(true);
+      inner = signal(true);
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).not.toBeNull();
+
+    // tearing down the host (and the slot content with it) clears the ref
+    root.visible.set(false);
+    await nextTick();
+    expect(root.myRef()).toBeNull();
+  });
+
+  test("ref in slot is unset when forwarded through a nested component", async () => {
+    class Inner extends Component {
+      static template = xml`<i><t t-call-slot="default"/></i>`;
+    }
+    class Wrapper extends Component {
+      static components = { Inner };
+      static template = xml`<div><Inner><t t-call-slot="default"/></Inner></div>`;
+    }
+    class Root extends Component {
+      static components = { Wrapper };
+      static template = xml`
+        <t t-if="this.visible()">
+          <Wrapper><b t-ref="this.myRef">x</b></Wrapper>
+        </t>`;
+      visible = signal(true);
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).not.toBeNull();
+
+    root.visible.set(false);
+    await nextTick();
+    expect(root.myRef()).toBeNull();
+  });
+
+  test("ref in slot is unset when the host removes it in place (host survives)", async () => {
+    class Wrapper extends Component {
+      static template = xml`<div t-if="this.show()"><t t-call-slot="default"/></div>`;
+      show = signal(true);
+    }
+    class Root extends Component {
+      static components = { Wrapper };
+      static template = xml`<Wrapper><span class="slotted" t-ref="this.myRef">hi</span></Wrapper>`;
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).toBe(fixture.querySelector(".slotted"));
+
+    // Wrapper is NOT unmounted; toggling its own t-if removes the slot element
+    // in place, so the ref is cleared by Wrapper's post-patch sweep.
+    const wrapper = Object.values((root as any).__owl__.children)[0] as any;
+    wrapper.component.show.set(false);
+    await nextTick();
+    expect(fixture.querySelector(".slotted")).toBeNull();
+    expect(root.myRef()).toBeNull();
+  });
+
+  test("ref in slot is unset when an intermediate host is removed in place", async () => {
+    class Inner extends Component {
+      static template = xml`<i><t t-call-slot="default"/></i>`;
+    }
+    class Root extends Component {
+      static components = { Inner };
+      // The ref is hosted by Inner (it owns the slotted span's dom), but Inner
+      // is a block-child of a t-if that Root removes in place: Root survives, so
+      // its own post-patch sweep doesn't cover Inner, and Inner.remove() never
+      // fires (the block bulk-removes it). The removal must still clear the ref.
+      static template = xml`<div t-if="this.show()"><Inner><span t-ref="this.myRef">x</span></Inner></div>`;
+      show = signal(true);
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).not.toBeNull();
+
+    root.show.set(false);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("");
+    expect(root.myRef()).toBeNull();
+  });
+
+  test("ref is unset even when a sub-root is destroyed re-entrantly mid-removal", async () => {
+    const subApp = new App({ test: true });
+    class Sub extends Component {
+      static template = xml`<p>sub</p>`;
+    }
+    const subFixture = document.createElement("div");
+    document.body.appendChild(subFixture);
+    await subApp.createRoot(Sub).mount(subFixture);
+
+    class Wrapper extends Component {
+      static template = xml`<div><t t-call-slot="default"/></div>`;
+      setup() {
+        // Like Portal/Suspense: tear down a sub-root from this component's own
+        // teardown — a removal that re-enters while the parent patch that hosts
+        // our ref is still collecting. Only the outermost removal must sweep.
+        onWillDestroy(() => subApp.destroy());
+      }
+    }
+    class Root extends Component {
+      static components = { Wrapper };
+      static template = xml`<t t-if="this.show()"><Wrapper><span t-ref="this.myRef">hi</span></Wrapper></t>`;
+      show = signal(true);
+      myRef = signal.ref();
+    }
+
+    const root = await mount(Root, fixture);
+    expect(root.myRef()).not.toBeNull();
+
+    root.show.set(false);
+    await nextTick();
+    expect(root.myRef()).toBeNull();
   });
 });

--- a/packages/owl-runtime/tests/helpers.ts
+++ b/packages/owl-runtime/tests/helpers.ts
@@ -95,6 +95,9 @@ export function renderToBdom(template: string, context: any = {}, node?: any): B
     } else {
       context.__owl__.component = context;
     }
+    // Compiled templates always run with a ComponentNode as `node`; at this
+    // blockdom level there is none, so stub the bits createRef needs.
+    node = { trackRef() {} };
   }
   const fn = compile(template);
   if (shouldSnapshot && !snapshottedTemplates.has(template)) {

--- a/packages/owl-runtime/tests/shadow_dom/__snapshots__/shadow_dom.test.ts.snap
+++ b/packages/owl-runtime/tests/shadow_dom/__snapshots__/shadow_dom.test.ts.snap
@@ -90,7 +90,7 @@ exports[`shadow_dom > ref 1`] = `
   let block1 = createBlock(\`<div class="my-div" block-ref="0"/>\`);
   
   return function template(ctx, node, key = "") {
-    let ref1 = createRef(ctx['this'].div);
+    let ref1 = createRef(ctx['this'].div, node);
     return block1([ref1]);
   }
 }"


### PR DESCRIPTION
A t-ref bound to a signal was not reset when its element left the dom as part
of a *bulk* removal — i.e. when the element's own block.remove() never runs
because an enclosing block is detached in one piece. This affects slot content
(`<Wrapper><div t-ref="this.r"/></Wrapper>`), a ref nested in a removed t-if
branch, and a ref forwarded through a child component: the signal kept pointing
at a now-detached element (e.g. `ref() !== null` stayed true after the element
was gone).

The block-ref callback that clears the signal only fires from the owning
block's remove(), and blockdom does not recurse into child vnodes when it
removes a subtree in bulk, so the callback is skipped. Rather than recurse on
removal (quadratic, and it re-walks the whole tree), refs are now tracked on
their host component and swept once the dom has settled:

- createRef receives the host node (for slot content the innermost host,
  threaded through callSlot) and registers signal refs on it (trackedRefs).
- sweepRefs() unsets every tracked ref whose element is no longer isConnected,
  and drops it. isConnected also keeps the t-if/t-else shared-ref case correct:
  a sibling that just took the signal points at a connected element and is left
  alone.
- It runs at the tail of _patch (before user onPatched) for in-place removals,
  and on the ref-bearing nodes collected during the single willUnmount/_destroy
  walk for removed subtrees — swept once by the outermost removal, with a depth
  counter so re-entrant teardown stays correct (e.g. Portal/Suspense destroying
  a sub-root mid-patch).