### PR TITLE
[FIX] owl: incorrect 'any' validator types

### DIFF
--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -293,11 +293,11 @@ function customValidator<T>(
 }
 
 function functionType(): Type<(...parameters: any[]) => any>;
-function functionType<const P extends any[]>(
+function functionType<const P extends unknown[]>(
   parameters: P
 ): Type<(...parameters: StripBrandsAll<P>) => void>;
-function functionType<const P extends any[], R>(): Type<(...parameters: P) => R>;
-function functionType<const P extends any[], R>(
+function functionType<const P extends unknown[], R>(): Type<(...parameters: P) => R>;
+function functionType<const P extends unknown[], R>(
   parameters: P,
   result: R
 ): Type<(...parameters: StripBrandsAll<P>) => StripBrands<R>>;
@@ -459,7 +459,7 @@ function recordType(valueType?: any): any {
   });
 }
 
-function tuple<const T extends any[]>(types: T): Type<StripBrandsAll<T>> {
+function tuple<const T extends unknown[]>(types: T): Type<StripBrandsAll<T>> {
   const validate = makeType(function validateTuple(context: ValidationContext) {
     if (!Array.isArray(context.value)) {
       context.addIssue({ message: "value is not an array" });
@@ -477,7 +477,7 @@ function tuple<const T extends any[]>(types: T): Type<StripBrandsAll<T>> {
   return validate;
 }
 
-function union<T extends any[]>(types: T): Type<StripBrands<T[number]>> {
+function union<T extends unknown[]>(types: T): Type<StripBrands<T[number]>> {
   return makeType(function validateUnion(context: ValidationContext) {
     let firstIssueIndex = 0;
     const subIssues: ValidationIssue[] = [];

--- a/packages/owl/tests/types_lists.ts
+++ b/packages/owl/tests/types_lists.ts
@@ -1,0 +1,31 @@
+// Compile-time checks for prop type lists e.g. t.or([...]). This file is
+// only typechecked (npm run test:types); it is not executed.
+import { props, t } from "../src";
+
+type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+declare function assertNotAny<T>(...args: IsAny<T> extends true ? [never] : []): void;
+
+type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+declare function assertEq<A, B>(...args: Eq<A, B> extends true ? [] : [never]): void;
+
+class Comp {
+  props = props({
+    union: t.or([t.string(), t.number()]),
+    tuple: t.tuple([t.string(), t.number()]),
+    function: t.function([t.string(), t.number()]),
+  });
+}
+declare const comp: Comp;
+void comp;
+
+assertNotAny<typeof comp.props.union>();
+assertNotAny<typeof comp.props.tuple>();
+assertNotAny<(typeof comp.props.tuple)[0]>();
+assertNotAny<(typeof comp.props.tuple)[1]>();
+assertNotAny<typeof comp.props.function>();
+assertNotAny<Parameters<typeof comp.props.function>[0]>();
+assertNotAny<Parameters<typeof comp.props.function>[1]>();
+
+assertEq<typeof comp.props.union, string | number>();
+assertEq<typeof comp.props.tuple, [string, number]>();
+assertEq<typeof comp.props.function, (a: string, b: number) => void>();


### PR DESCRIPTION
Before this commit, the `t.function`, `t.or` and `t.tuple` type validators would incorrectly return `any` types instead of the specific types provided to the validator. For example, given the following type:

```javascript
t.or([t.string(), t.number()])
```

We expect it to return the type `string | number` but instead it returns `any`.

After this commit, the types are corrected by replacing instances of `T extends any[]` with `T extends unknown[]`. In addition, a type-check only test is added to ensure the same issue cannot occur in the future.