### PR TITLE
[IMP] owl-core: add .type method

### DIFF
--- a/doc/v3/owl/reference/types_validation.md
+++ b/doc/v3/owl/reference/types_validation.md
@@ -379,6 +379,43 @@ t.object({ color: t.string().optional("red") });
 // rejects:   "42"       with the first example ("value is not a number")
 ```
 
+## Deriving a TypeScript type
+
+Every type exposes a `.type` field that carries the TypeScript type of the
+values it validates. This lets a schema — which is a runtime value — double as
+the single source of truth for a static type, so you don't have to declare the
+shape twice and keep them in sync.
+
+```ts
+const userType = t.object({
+  name: t.string(),
+  age: t.number().optional(),
+});
+
+type User = typeof userType.type;
+// => { name: string; age?: number }
+```
+
+Optional keys become optional properties, and a default declared with
+`.optional(value)` is reflected too. The field is purely a type-level handle:
+nothing exists under `.type` at runtime (reading it returns `undefined`), so it
+must only be used in a type position (`typeof ...`).
+
+It also works from plain JavaScript through a JSDoc annotation, which is handy
+for typing a function argument against a schema without writing the type by
+hand:
+
+```js
+const optionsType = t.object({ depth: t.number(), name: t.string() });
+
+/**
+ * @param {typeof optionsType.type} options
+ */
+function run(options) {
+  // options is typed as { depth: number, name: string }
+}
+```
+
 ## `applyDefaults`
 
 ```js

--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -46,6 +46,8 @@ export type Type<T> = T & {
    * a function type must use the factory form.
    */
   optional(value: T extends Function ? () => T : T | (() => T)): WithDefault<T>;
+
+  type: T;
 };
 
 type IsAny<T> = 0 extends 1 & T ? true : false;


### PR DESCRIPTION
When defining a schema in owl, we can do something like this:

const mySchema = t.object({ a: t.string() });

which is very useful. But if we want to use the type, either in typescript or in javascript as a method
argument, we cannot really do it easily,

Now, with this commit, we had a .type empty field, which returns the proper type. So we can do this in typescript:

type Schema = typeof mySchema.type

or in javascript:

/*
 * param { mySchema.type } */ function (thing) {
  ...
}

closes #1953