### PR TITLE
[FIX] owl-runtime: don't access document at module load

### DIFF
--- a/packages/owl-runtime/src/blockdom/toggler.ts
+++ b/packages/owl-runtime/src/blockdom/toggler.ts
@@ -4,7 +4,12 @@ import type { VNode } from "./index";
 // Toggler node
 // -----------------------------------------------------------------------------
 
-const txt = document.createTextNode("");
+// Shared anchor text node, reused across togglers. Accessed through
+// `globalThis` and optional-chained so that merely importing owl does not
+// crash without a `document`: this lets the non-rendering APIs (reactivity,
+// type system, ...) run in environments such as Node.js. It is only ever read
+// in `patch`, which runs while rendering into a real DOM, so the `!` holds.
+const txt = globalThis.document?.createTextNode("")!;
 
 class VToggler {
   key: string;

--- a/packages/owl-runtime/tests/no_dom.test.ts
+++ b/packages/owl-runtime/tests/no_dom.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+
+// This suite runs in a Node environment (no `document`/`window`). It guards
+// the contract that owl can be imported and its non-rendering APIs used
+// without a DOM, so the base reactivity and type-validation primitives work
+// server-side. See https://github.com/odoo/owl/issues/1952.
+
+import { describe, expect, test } from "vitest";
+import { App, computed, effect, proxy, signal, types as t, validateType } from "../src/index";
+
+describe("owl without a DOM", () => {
+  test("the environment really has no document/window", () => {
+    expect(typeof document).toBe("undefined");
+    expect(typeof window).toBe("undefined");
+  });
+
+  test("reactivity primitives work", async () => {
+    const count = signal(1);
+    const double = computed(() => count() * 2);
+    expect(double()).toBe(2);
+
+    const seen: number[] = [];
+    effect(() => seen.push(count()));
+    count.set(5);
+    await Promise.resolve();
+    expect(double()).toBe(10);
+    expect(seen).toEqual([1, 5]);
+
+    const state = proxy({ a: 1 });
+    const sum = computed(() => state.a + 1);
+    expect(sum()).toBe(2);
+    state.a = 10;
+    expect(sum()).toBe(11);
+  });
+
+  test("the type system works", () => {
+    expect(validateType("hello", t.string())).toEqual([]);
+    expect(validateType(42, t.string())).not.toEqual([]);
+  });
+
+  test("an App can be constructed", () => {
+    const app = new App();
+    expect(app).toBeInstanceOf(App);
+    app.destroy();
+  });
+});


### PR DESCRIPTION
The toggler module created its shared anchor text node at the top level with `document.createTextNode("")`. Since the umbrella owl package eagerly loads the blockdom modules, this made merely importing owl throw `ReferenceError: document is not defined` in environments without a DOM, such as Node.js — even when only the non-rendering APIs (reactivity, type system, ...) are needed.

Access document through `globalThis` and optional-chain it, so the guard runs once at module load without crashing when there is no document (note that a bare `document?.` would still throw, as optional chaining does not guard an undeclared identifier). The node is only ever read in `patch`, which runs while rendering into a real DOM, so the `!` holds.

A regression test runs the base APIs in a Node (no-DOM) environment.

closes #1952