### PR TITLE
[FIX] site: run build:types before assembling site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,7 @@ jobs:
         node-version: 22.x
     - run: npm ci
     - run: npm run build
+    - run: npm run build:types
     - run: npm run build:playground
     - run: npm run build:monaco -w tools/playground
     - run: npm run build:doc

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:playground": "npm run build -w tools/playground",
     "build:doc": "vitepress build doc",
     "build:doc-v2": "vitepress build doc/v2",
-    "build:site": "npm run build && npm run build:playground && npm run build:monaco -w tools/playground && npm run build:doc && npm run build:doc-v2 && node tools/site/assemble.mjs",
+    "build:site": "npm run build && npm run build:types && npm run build:playground && npm run build:monaco -w tools/playground && npm run build:doc && npm run build:doc-v2 && node tools/site/assemble.mjs",
     "serve:site": "npm run build:site && python3 tools/site/server.py || python tools/site/server.py",
     "playground:serve": "python3 tools/playground/server.py || python tools/playground/server.py",
     "playground": "npm run build && npm run build:types && npm run build:playground && npm run playground:serve",


### PR DESCRIPTION
### Problem

The GitHub Pages deploy is failing on `master` after #1956 was merged:

```
Error: ENOENT: no such file or directory, lstat '.../packages/owl/dist/types/owl.d.ts'
    at cpSync (node:fs:3132:3)
    at file:///.../tools/site/assemble.mjs:27:1
```

(failing run: https://github.com/odoo/owl/actions/runs/28030820171/job/82970680412)

#1956 added a `cpSync` of `packages/owl/dist/types/owl.d.ts` to `tools/site/assemble.mjs` (the playground now fetches `owl.d.ts` for version-aware typings), but `build:types` was never wired into the site pipeline. So the file is absent when `assemble.mjs` runs.

The `build:monaco` half of the pipeline was added correctly; `build:types` was the missing piece. It only worked locally because the `playground` npm script already runs `build:types`.

### Fix

Add `npm run build:types` right after `npm run build` (it depends on the package build) in both:

- the `build:site` script in `package.json`
- the `pages.yml` deploy workflow

### Verification

- Removed `packages/owl/dist/types/` to reproduce the CI state.
- Ran `npm run build:types` → `owl.d.ts` regenerated.
- Ran `node tools/site/assemble.mjs` → exit 0, "Site assembled", with `owl.d.ts` present in `dist/website/`.