### PR TITLE
[FIX] owl: export prop/type brand symbols for .d.ts generation

### DIFF
--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -83,6 +83,12 @@ export {
   type Type,
   type UnionToIntersection,
   type WithDefault,
+  // Phantom brand symbols carried by the public `Type`/`Optional`/`WithDefault`
+  // types. Exported (type-only) so downstream projects can name them when
+  // emitting declaration files, mirroring `isProps` (see owl#1958).
+  type hasDefault,
+  type isOptional,
+  type typeBrand,
 } from "./types";
 
 // Registry / Resource

--- a/packages/owl-runtime/src/index.ts
+++ b/packages/owl-runtime/src/index.ts
@@ -41,7 +41,12 @@ export { ErrorBoundary } from "./error_boundary";
 export { Portal } from "./portal";
 export { Suspense } from "./suspense";
 export { props } from "./props";
-export type { GetProps } from "./props";
+// `isProps` is a phantom (declare const) brand symbol referenced by the public
+// `Props`/`PropsWithDefaults`/`GetProps` types. It must be exported from the
+// package's type surface so downstream projects can name it when emitting their
+// own declaration files (see owl#1958). Type-only export: it has no runtime
+// value, so this adds nothing to the JS bundle.
+export type { GetProps, isProps } from "./props";
 export { status } from "./status";
 export {
   asyncComputed,
@@ -75,7 +80,15 @@ export { applyDefaults, assertType, getDefault, validateType } from "@odoo/owl-c
 // runtime namespace (which extends the core one with `component`), so do not
 // re-export them from @odoo/owl-core.
 export { types, types as t } from "./types";
-export type { Optional, StripBrands, Type, WithDefault } from "@odoo/owl-core";
+export type {
+  hasDefault,
+  isOptional,
+  Optional,
+  StripBrands,
+  Type,
+  typeBrand,
+  WithDefault,
+} from "@odoo/owl-core";
 export { OwlError } from "@odoo/owl-core";
 export { config, plugin, providePlugins } from "./plugin_hooks";
 export type { PluginInstance } from "./plugin_hooks";

--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -11,7 +11,7 @@ import { getComponentScope } from "./component_node";
 import { staticProp } from "./prop";
 import { types } from "./types";
 
-declare const isProps: unique symbol;
+export declare const isProps: unique symbol;
 
 // The brand stores the defaulted key names: those keys are required for the
 // component reading the props (the default fills them), but may be omitted by


### PR DESCRIPTION
The `isProps` unique symbol brands the public `Props`/`PropsWithDefaults`/ `GetProps` types. When a downstream project (e.g. o-spreadsheet) emits its own declaration files for an implicitly-typed value derived from these types, TypeScript inlines a `typeof isProps` reference (via `GetPropsWithOptionals`'s `Omit<T, typeof isProps>`, which TS keeps lazy in declaration emit). Since the symbol was not exported, this failed with:

  TS2527: The inferred type of 'X' references an inaccessible 'unique
  symbol' type. A type annotation is necessary.

Export the symbol so it can be named across module boundaries. A source `export declare const` alone is not enough: dts-bundle-generator only marks a declaration `export` in the bundled owl.d.ts when it is reachable from the package entry, so the symbol is also re-exported (type-only) from the index. The export is type-only — the symbol is phantom (declare const), so this adds nothing to the JS bundle.

Also export the sibling phantom brands `hasDefault`/`isOptional`/`typeBrand` (carried by `Type`/`Optional`/`WithDefault`) for consistency, so downstream projects can name them too. Unlike `isProps`, no owl helper uses `Omit`/ `Pick` with these (the `Strip*`/`Has*`/`Is*` helpers resolve eagerly via conditional `extends`), so they do not currently leak through any owl type; this is future-proofing and does not fix a reproduced failure.

closes #1958