### PR TITLE
[IMP] typing: export `isProps`

### DIFF
--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -11,7 +11,7 @@ import { getComponentScope } from "./component_node";
 import { staticProp } from "./prop";
 import { types } from "./types";
 
-declare const isProps: unique symbol;
+export declare const isProps: unique symbol;
 
 // The brand stores the defaulted key names: those keys are required for the
 // component reading the props (the default fills them), but may be omitted by


### PR DESCRIPTION
Some symbols used to declare the type `GetPropsWithOptionals` are not
exported and it creates issues when we try to generate a type
declaration file in o-spreadsheet.

If we do not explicitly type a variable/ the output of a getter which
contains elements typed after `GetPropsWithOptionals`, typescript will
try to resolve the full type by itself and will fail when trying to
access the symbol `isProps'.