### PR TITLE
[FIX] package: Fix commonJs filename to avoid ambiguity

### DIFF
--- a/packages/owl/build.mjs
+++ b/packages/owl/build.mjs
@@ -5,7 +5,7 @@ import { readFileSync, mkdirSync } from "fs";
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 const IIFE_FILENAME = "dist/owl.iife.js";
-const CJS_FILENAME = "dist/owl.cjs.js";
+const CJS_FILENAME = "dist/owl.cjs";
 const ES_FILENAME = "dist/owl.es.js";
 
 if (pkg.module !== ES_FILENAME || pkg.main !== CJS_FILENAME) {

--- a/packages/owl/package.json
+++ b/packages/owl/package.json
@@ -2,14 +2,14 @@
   "name": "@odoo/owl",
   "version": "3.0.0-alpha.38",
   "description": "Odoo Web Library (OWL)",
-  "main": "dist/owl.cjs.js",
+  "main": "dist/owl.cjs",
   "module": "dist/owl.es.js",
   "types": "dist/types/owl.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/owl.d.ts",
       "import": "./dist/owl.es.js",
-      "require": "./dist/owl.cjs.js",
+      "require": "./dist/owl.cjs",
       "default": "./dist/owl.es.js"
     },
     "./dist/*": "./dist/*",


### PR DESCRIPTION
Since [1], the package has a default type of 'module' which directs nodeJs on how to handle files with and extension `.js` [2]. Historically, if this parameter was not provided, `.js` files would be interpreted as common js so the extension did not matter too much.

Now, however, trying to load the `cjs` bundle in nodeJs will fail as node, seeing the `.js` extension, will rely on package.json to know how to interprete the file and will consider it as a module, therefore raising the error

```
module.exports = __toCommonJS(index_exports);
^

ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/home/rar/rar-workspace/o-spreadsheet/node_modules/@odoo/owl/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

This revision changes the extension of the common js file so that it is properly treated as such by nodeJs.

[1]: edff831c64d5add5edc47fd695f422dffaa9223a
[2]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#type