### PR TITLE
[FIX] owl-core: apply defaults through intersection (and) types

### DIFF
--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -16,6 +16,9 @@ const elementTypeSymbol = Symbol("elementType");
 // Attached to validators created by `.optional()`: an object key with an
 // optional type may be omitted.
 const optionalSymbol = Symbol("optional");
+// Attached to intersection validators (`and`), so that `applyDefaults` can
+// fold defaults from every member type into the value.
+const intersectionSymbol = Symbol("intersection");
 
 // Type-level brand carried by `.optional(value)`. It is phantom (declare):
 // nothing exists at runtime under this key. The brand stores the wrapped type
@@ -183,6 +186,14 @@ function applyDefaultsRec(value: any, type: any): any {
   if (typeof inner !== "function" || !value || typeof value !== "object") {
     return value;
   }
+  const members = inner[intersectionSymbol];
+  if (members) {
+    let result = value;
+    for (const member of members) {
+      result = applyDefaultsRec(result, member);
+    }
+    return result;
+  }
   const elementType = inner[elementTypeSymbol];
   if (elementType && Array.isArray(value)) {
     let result = value;
@@ -320,11 +331,13 @@ function instanceType<T extends Constructor>(constructor: T): Type<InstanceType<
 }
 
 function intersection<T extends any[]>(types: T): Type<UnionToIntersection<StripBrands<T[number]>>> {
-  return makeType(function validateIntersection(context: ValidationContext) {
+  const validate = makeType(function validateIntersection(context: ValidationContext) {
     for (const type of types) {
       context.validate(type);
     }
   });
+  validate[intersectionSymbol] = types;
+  return validate;
 }
 
 export type LiteralTypes = number | string | boolean | null | undefined;

--- a/packages/owl-core/tests/validation.test.ts
+++ b/packages/owl-core/tests/validation.test.ts
@@ -1080,4 +1080,35 @@ describe("applyDefaults", () => {
     expect(applyDefaults({ config: {} }, type)).toEqual({ config: { depth: 3 } });
     expect(applyDefaults({}, type)).toEqual({});
   });
+
+  test("fills in defaults from every member of an intersection", () => {
+    const type = t.and([
+      t.object({ label: t.string().optional() }),
+      t.object({ title: t.string().optional("Default title") }),
+    ]);
+    const value = { label: "Apples" };
+    const result = applyDefaults(value, type);
+    expect(result).toEqual({ label: "Apples", title: "Default title" });
+    expect(value).toEqual({ label: "Apples" });
+    expect(result).not.toBe(value);
+  });
+
+  test("returns the input as is when an intersection has nothing to fill in", () => {
+    const type = t.and([
+      t.object({ label: t.string().optional() }),
+      t.object({ title: t.string().optional("Default title") }),
+    ]);
+    const value = { label: "Apples", title: "Pears" };
+    expect(applyDefaults(value, type)).toBe(value);
+  });
+
+  test("fills in defaults through an optional intersection wrapper", () => {
+    const type = t.object({
+      props: t
+        .and([t.object({ a: t.number().optional(1) }), t.object({ b: t.number().optional(2) })])
+        .optional(),
+    });
+    expect(applyDefaults({ props: { a: 5 } }, type)).toEqual({ props: { a: 5, b: 2 } });
+    expect(applyDefaults({}, type)).toEqual({});
+  });
 });


### PR DESCRIPTION
`applyDefaults` walked object shapes, tuples and arrays, but not intersection (`t.and`) validators: they carried no metadata for the recursion to follow, so a `t.and([...])` schema fell through and the value was returned unchanged. Defaults declared inside any member of the intersection were never filled in.

Tag intersection validators with their member types and fold `applyDefaults` over each member, threading the value through. Copy-on-write is preserved, so the input is never mutated and an untouched value is returned as is.

closes #1947