### PR TITLE
[IMP] owl-core: add asyncComputed().currentPromise()

### DIFF
--- a/doc/v3/owl/reference/computed_values.md
+++ b/doc/v3/owl/reference/computed_values.md
@@ -71,6 +71,7 @@ user.loading(); // reactive boolean: true while a run is in flight
 user.error(); // reactive Error | null
 user.refresh(); // re-run the fetcher even if nothing changed
 user.dispose(); // tear down (auto-called when the surrounding scope dies)
+user.currentPromise(); // promise that resolves once no run is in flight
 ```
 
 The `abortSignal` argument follows the same convention as
@@ -85,6 +86,34 @@ While a fetch is in flight, the previous resolved value remains visible via
 When created inside a component or a plugin's `setup`, `asyncComputed` cleans
 up automatically on destroy. Outside any scope, you must call `.dispose()`
 yourself.
+
+### Awaiting the current run
+
+`currentPromise()` returns a promise that resolves as soon as no run is in
+flight: if a run is currently running it resolves once that run — or any run
+that supersedes it — settles, otherwise it resolves immediately. It never
+rejects; a fetcher error is reported through `error()`, not by rejecting.
+
+This pairs naturally with [`onWillStart`](scope.md) to hold the first render
+until the initial data is available:
+
+```js
+class UserCard extends Component {
+  static template = xml`<div t-out="this.user()?.name"/>`;
+  user = asyncComputed(async ({ abortSignal }) => {
+    const res = await fetch(`/api/users/${userId()}`, { signal: abortSignal });
+    return res.json();
+  });
+  setup() {
+    onWillStart(() => this.user.currentPromise());
+  }
+}
+```
+
+The component mounts only once the first fetch settles, so `this.user()` is
+already populated on the initial render. Later re-runs (a dependency changed,
+or `refresh()`) update the value reactively without blocking, and you can
+branch on `loading()` to show a spinner for those.
 
 ### Tracking only happens before the first `await`
 

--- a/packages/owl-core/src/async_computed.ts
+++ b/packages/owl-core/src/async_computed.ts
@@ -16,6 +16,14 @@ export interface AsyncComputed<T> {
   error(): Error | null;
   refresh(): void;
   dispose(): void;
+  /**
+   * Returns a promise that resolves as soon as no run is in flight: if a run
+   * is currently running it resolves once that run (or any run that supersedes
+   * it) settles, otherwise it resolves immediately. It never rejects — fetcher
+   * errors are surfaced through `error()`. Handy to await the value in
+   * `onWillStart`: `onWillStart(() => data.currentPromise())`.
+   */
+  currentPromise(): Promise<void>;
 }
 
 /**
@@ -35,6 +43,33 @@ export function asyncComputed<T>(
   let runId = 0;
   let runController: AbortController | null = null;
 
+  // Whether a run is currently in flight. Mirrors `loading`, but as a plain
+  // (non-reactive) flag: `currentPromise()` can read it without registering a
+  // dependency, and `dispose()` can mark the run abandoned without writing to
+  // the reactive `loading` signal.
+  let inFlight = false;
+  // Deferred handed out by `currentPromise()`, created lazily — only when a
+  // caller actually asks for it while a run is in flight. Resolved when the run
+  // settles; a re-run that supersedes an in-flight run keeps the same deferred,
+  // so it resolves only once the latest run is no longer in flight. It never
+  // rejects: errors are surfaced through `error()`.
+  let pending: { promise: Promise<void>; resolve: () => void } | null = null;
+
+  function beginRun() {
+    loading.set(true);
+    inFlight = true;
+  }
+
+  // Settles the current run. Must not read a signal — it also runs on the
+  // synchronous path of the effect (the fetcher throwing), where a read would
+  // register as a spurious dependency.
+  function endRun() {
+    loading.set(false);
+    inFlight = false;
+    pending?.resolve();
+    pending = null;
+  }
+
   const stopEffect = effect(() => {
     refreshTick();
     const myRunId = ++runId;
@@ -50,7 +85,7 @@ export function asyncComputed<T>(
       abortSignals.push(scope.abortSignal);
     }
 
-    loading.set(true);
+    beginRun();
     error.set(null);
 
     let promise: Promise<T>;
@@ -59,11 +94,11 @@ export function asyncComputed<T>(
     } catch (e) {
       if (myRunId !== runId) return;
       if (isAbortError(e)) {
-        loading.set(false);
+        endRun();
         return;
       }
       error.set(e as Error);
-      loading.set(false);
+      endRun();
       return;
     }
 
@@ -71,16 +106,16 @@ export function asyncComputed<T>(
       (result) => {
         if (myRunId !== runId) return;
         value.set(result);
-        loading.set(false);
+        endRun();
       },
       (e) => {
         if (myRunId !== runId) return;
         if (isAbortError(e)) {
-          loading.set(false);
+          endRun();
           return;
         }
         error.set(e);
-        loading.set(false);
+        endRun();
       }
     );
   });
@@ -89,6 +124,10 @@ export function asyncComputed<T>(
     stopEffect();
     runController?.abort();
     runController = null;
+    // Mark the abandoned run as no longer in flight and release any awaiter.
+    inFlight = false;
+    pending?.resolve();
+    pending = null;
   }
 
   scope?.onDestroy(dispose);
@@ -98,5 +137,15 @@ export function asyncComputed<T>(
   read.error = () => error();
   read.refresh = () => refreshTick.set(refreshTick() + 1);
   read.dispose = dispose;
+  read.currentPromise = () => {
+    if (!inFlight) {
+      return Promise.resolve();
+    }
+    if (!pending) {
+      let resolve!: () => void;
+      pending = { promise: new Promise<void>((res) => (resolve = res)), resolve };
+    }
+    return pending.promise;
+  };
   return read;
 }

--- a/packages/owl-runtime/tests/reactivity/async_computed.test.ts
+++ b/packages/owl-runtime/tests/reactivity/async_computed.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, asyncComputed, computed, effect, signal, xml } from "../../src";
+import { App, Component, asyncComputed, computed, effect, onWillStart, signal, xml } from "../../src";
 import { makeDeferred, makeTestFixture } from "../helpers";
 
 let fixture: HTMLElement;
@@ -315,4 +315,155 @@ test("composes with computed: downstream computed re-runs when value resolves", 
 
   stop();
   list.dispose();
+});
+
+test("currentPromise() resolves once the in-flight run settles", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def);
+
+  let resolved = false;
+  a.currentPromise().then(() => (resolved = true));
+
+  await flush();
+  expect(resolved).toBe(false);
+  expect(a.loading()).toBe(true);
+
+  def.resolve(42);
+  await flush();
+  expect(resolved).toBe(true);
+  expect(a()).toBe(42);
+
+  a.dispose();
+});
+
+test("currentPromise() resolves immediately when no run is in flight", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def);
+  def.resolve(1);
+  await flush();
+  expect(a.loading()).toBe(false);
+
+  // Awaiting it and reaching the next line proves it already resolved.
+  let resolved = false;
+  await a.currentPromise().then(() => (resolved = true));
+  expect(resolved).toBe(true);
+
+  a.dispose();
+});
+
+test("currentPromise() reuses one deferred per in-flight run, lazily", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def);
+
+  // Repeated calls within a single in-flight run hand out the same promise
+  // (the deferred is created once, on the first call, and reused).
+  const p1 = a.currentPromise();
+  const p2 = a.currentPromise();
+  expect(p1).toBe(p2);
+
+  def.resolve(1);
+  await flush();
+  expect(a.loading()).toBe(false);
+
+  // Once idle, a fresh already-resolved promise is returned instead.
+  const p3 = a.currentPromise();
+  expect(p3).not.toBe(p1);
+  await p3;
+
+  a.dispose();
+});
+
+test("currentPromise() resolves only after the latest run when superseded", async () => {
+  const id = signal(1);
+  const def1 = makeDeferred<number>();
+  const def2 = makeDeferred<number>();
+  const defs = [def1, def2];
+  const a = asyncComputed(async () => defs[id() - 1]);
+
+  let resolved = false;
+  a.currentPromise().then(() => (resolved = true));
+
+  await Promise.resolve();
+  id.set(2); // supersede run 1 with run 2
+  await flush();
+  expect(resolved).toBe(false);
+
+  // Resolving the superseded run 1 must NOT resolve currentPromise.
+  def1.resolve(100);
+  await flush();
+  expect(resolved).toBe(false);
+  expect(a.loading()).toBe(true);
+
+  // Resolving the latest run 2 does.
+  def2.resolve(200);
+  await flush();
+  expect(resolved).toBe(true);
+  expect(a()).toBe(200);
+
+  a.dispose();
+});
+
+test("currentPromise() resolves (does not reject) when the run errors", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def);
+
+  let outcome = "";
+  a.currentPromise().then(
+    () => (outcome = "resolved"),
+    () => (outcome = "rejected")
+  );
+
+  def.reject(new Error("boom"));
+  await flush();
+  expect(outcome).toBe("resolved");
+  expect(a.error()).toMatchObject({ message: "boom" });
+
+  a.dispose();
+});
+
+test("currentPromise() resolves on dispose so awaiters do not hang", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def);
+
+  let resolved = false;
+  a.currentPromise().then(() => (resolved = true));
+
+  await flush();
+  expect(resolved).toBe(false);
+
+  a.dispose();
+  await flush();
+  expect(resolved).toBe(true);
+});
+
+test("onWillStart can await currentPromise() before mounting", async () => {
+  const def = makeDeferred<string>();
+
+  class Root extends Component {
+    static template = xml`<div t-out="this.data() || 'pending'"/>`;
+    data = asyncComputed(() => def);
+    setup() {
+      onWillStart(() => this.data.currentPromise());
+    }
+  }
+
+  const app = new App();
+  let mounted = false;
+  const mountProm = app
+    .createRoot(Root)
+    .mount(fixture)
+    .then(() => (mounted = true));
+
+  await flush();
+  // onWillStart is still awaiting the in-flight fetch: not mounted yet.
+  expect(mounted).toBe(false);
+  expect(fixture.innerHTML).toBe("");
+
+  def.resolve("hello");
+  await mountProm;
+  // The value is ready by the time the component renders.
+  expect(mounted).toBe(true);
+  expect(fixture.innerHTML).toBe("<div>hello</div>");
+
+  app.destroy();
 });


### PR DESCRIPTION
`currentPromise()` returns a promise that resolves as soon as no run is in flight: if a run is running it resolves once that run (or any run that supersedes it) settles, otherwise it resolves immediately. It never rejects — fetcher errors are surfaced through `error()`.

This makes asyncComputed awaitable from onWillStart, to hold the first render until the initial data is ready:

  onWillStart(() => this.data.currentPromise())

The in-flight run is tracked as a deferred that moves in lockstep with `loading`: created when a run begins, resolved when it settles. A re-run keeps the same deferred, so it resolves only once the latest run is no longer in flight. The deferred is resolved (never read) so it is safe to settle on the effect's synchronous path without registering a spurious dependency, and it is also resolved on dispose so awaiters never hang.

Documents the method on the Async Computed Values reference page.