### PR TITLE
[FIX] playground: adapt `.optional()` instead of `?`

### DIFF
--- a/tools/playground/samples/v3/props/product_card.js
+++ b/tools/playground/samples/v3/props/product_card.js
@@ -6,6 +6,6 @@ export class ProductCard extends Component {
     props = props({
         name: t.string(),
         price: t.number(),
-        "image?": t.string(),
+        image: t.string().optional(),
     });
 }

--- a/tools/playground/samples/v3/slots/dialog.js
+++ b/tools/playground/samples/v3/slots/dialog.js
@@ -2,7 +2,7 @@ import { Component, props, t } from "@odoo/owl";
 
 export class Dialog extends Component {
     static template = "example.Dialog";
-    props = props({ title: t.string(), "onClose?": t.function()})
+    props = props({ title: t.string(), onClose: t.function().optional() })
 
     close() {
         if (this.props.onClose) {

--- a/tools/playground/samples/v3/tutorials/getting_started/3/product_card.js
+++ b/tools/playground/samples/v3/tutorials/getting_started/3/product_card.js
@@ -15,8 +15,6 @@ export class ProductCard extends Component {
         name: t.string(),
         description: t.string(),
         price: t.number(),
-        "image?": t.string(),
-    }, {
-        image: "📦",
+        image: t.string().optional("📦"),
     });
 }

--- a/tools/playground/samples/v3/tutorials/hibou_os/10/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/10/window.js
@@ -5,11 +5,11 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.signal(),
-        "y?": t.signal(),
-        "zIndex?": t.signal(),
-        "component?": t.function(),
+        onClose: t.function().optional(),
+        x: t.signal().optional(),
+        y: t.signal().optional(),
+        zIndex: t.signal().optional(),
+        component: t.function().optional(),
     });
 
     startDrag(ev) {

--- a/tools/playground/samples/v3/tutorials/hibou_os/11/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/11/window.js
@@ -6,11 +6,11 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.signal(),
-        "y?": t.signal(),
-        "zIndex?": t.signal(),
-        "component?": t.function(),
+        onClose: t.function().optional(),
+        x: t.signal().optional(),
+        y: t.signal().optional(),
+        zIndex: t.signal().optional(),
+        component: t.function().optional(),
     });
 
     dnd = useDragAndDrop(this.props.x, this.props.y);

--- a/tools/playground/samples/v3/tutorials/hibou_os/12/hibou_solution.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/12/hibou_solution.js
@@ -7,8 +7,8 @@ const APP_SCHEMA = t.object({
     name: t.string(),
     icon: t.string(),
     window: t.constructor(Component),
-    "systrayItems?": t.array(t.constructor(Component)),
-    "plugins?": t.array(t.constructor(Plugin)),
+    systrayItems: t.array(t.constructor(Component)).optional(),
+    plugins: t.array(t.constructor(Plugin)).optional(),
 });
 
 export class Hibou extends Component {

--- a/tools/playground/samples/v3/tutorials/hibou_os/14/registries.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/14/registries.js
@@ -6,8 +6,8 @@ export const menuItemRegistry = new Registry({
         name: t.string(),
         icon: t.string(),
         window: t.constructor(Component),
-        "width?": t.number(),
-        "height?": t.number(),
+        width: t.number().optional(),
+        height: t.number().optional(),
     }),
 });
 

--- a/tools/playground/samples/v3/tutorials/hibou_os/14/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/14/window.js
@@ -6,13 +6,13 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.signal(),
-        "y?": t.signal(),
-        "zIndex?": t.signal(),
-        "component?": t.function(),
-        "width?": t.number(),
-        "height?": t.number(),
+        onClose: t.function().optional(),
+        x: t.signal().optional(),
+        y: t.signal().optional(),
+        zIndex: t.signal().optional(),
+        component: t.function().optional(),
+        width: t.number().optional(),
+        height: t.number().optional(),
     });
 
     dnd = useDragAndDrop(this.props.x, this.props.y);

--- a/tools/playground/samples/v3/tutorials/hibou_os/3/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/3/window.js
@@ -5,6 +5,6 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
+        onClose: t.function().optional(),
     });
 }

--- a/tools/playground/samples/v3/tutorials/hibou_os/4/taskbar_solution.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/4/taskbar_solution.js
@@ -6,6 +6,6 @@ export class Taskbar extends Component {
     static components = { Clock };
 
     props = props({
-        "onClockClick?": t.function(),
+        onClockClick: t.function().optional(),
     });
 }

--- a/tools/playground/samples/v3/tutorials/hibou_os/4/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/4/window.js
@@ -5,8 +5,8 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.number(),
-        "y?": t.number(),
+        onClose: t.function().optional(),
+        x: t.number().optional(),
+        y: t.number().optional(),
     });
 }

--- a/tools/playground/samples/v3/tutorials/hibou_os/8/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/8/window.js
@@ -5,9 +5,9 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.number(),
-        "y?": t.number(),
-        "zIndex?": t.signal(),
+        onClose: t.function().optional(),
+        x: t.number().optional(),
+        y: t.number().optional(),
+        zIndex: t.signal().optional(),
     });
 }

--- a/tools/playground/samples/v3/tutorials/hibou_os/9/window.js
+++ b/tools/playground/samples/v3/tutorials/hibou_os/9/window.js
@@ -5,10 +5,10 @@ export class Window extends Component {
 
     props = props({
         title: t.string(),
-        "onClose?": t.function(),
-        "x?": t.number(),
-        "y?": t.number(),
-        "zIndex?": t.signal(),
-        "component?": t.function(),
+        onClose: t.function().optional(),
+        x: t.number().optional(),
+        y: t.number().optional(),
+        zIndex: t.signal().optional(),
+        component: t.function().optional(),
     });
 }

--- a/tools/playground/samples/v3/tutorials/todo_list/7/todo_item_solution.js
+++ b/tools/playground/samples/v3/tutorials/todo_list/7/todo_item_solution.js
@@ -5,6 +5,6 @@ export class TodoItem extends Component {
 
     props = props({
         todo: t.object({ id: t.number(), text: t.string(), completed: t.signal() }),
-        "onDelete?": t.function(),
+        onDelete: t.function().optional(),
     });
 }


### PR DESCRIPTION
In this commit:
===============
- Adapt new optional props and types validation `.optional()` instead of deprecated `?`