### PR TITLE
[IMP] owl-runtime: detect render loops instead of freezing

### DIFF
--- a/packages/owl-runtime/src/rendering/fibers.ts
+++ b/packages/owl-runtime/src/rendering/fibers.ts
@@ -10,6 +10,11 @@ import type { ComponentNode } from "../component_node";
 import { STATUS } from "../status";
 import { fibersInError, handleError } from "./error_handling";
 
+// Max times a root fiber may be re-rendered before being committed to the DOM
+// before we treat it as an infinite render loop. A healthy render commits after
+// ~1 pass; only a self-retriggering loop ever approaches this. See issue #1968.
+const MAX_RENDER_ITERATIONS = 1000;
+
 export function makeChildFiber(node: ComponentNode, parent: Fiber): Fiber {
   let current = node.fiber;
   if (current) {
@@ -23,6 +28,10 @@ export function makeRootFiber(node: ComponentNode): Fiber {
   let current = node.fiber;
   if (current) {
     let root = current.root!;
+    // This fiber is being re-rendered before it was ever committed to the DOM.
+    // In a healthy app a fiber is committed (and node.fiber nulled) before the
+    // next render, so this only climbs without bound in a render loop (#1968).
+    root.renderCount++;
     // lock root fiber because canceling children fibers may destroy components,
     // which means any arbitrary code can be run in onWillDestroy, which may
     // trigger new renderings
@@ -149,6 +158,24 @@ export class Fiber {
     const node = this.node;
     const root = this.root;
     if (root) {
+      // Bail before touching the computation tracking pointer (below) so a
+      // detected loop never leaves currentComputation pinned to a signalComputation
+      // that app.destroy is about to dispose. The root's own render runs right
+      // after makeRootFiber bumped renderCount and before any child render, so
+      // the reported component is always the looping root.
+      if (root.renderCount > MAX_RENDER_ITERATIONS) {
+        handleError({
+          node,
+          error: new OwlError(
+            `Maximum render iterations (${MAX_RENDER_ITERATIONS}) exceeded. ` +
+              `Component "${node.componentName}" is stuck in a render loop: rendering it ` +
+              `keeps triggering another render before the DOM is updated. A common cause is ` +
+              `updating reactive state during render or setup() — e.g. calling a parent's ` +
+              `state setter from a child's setup().`
+          ),
+        });
+        return;
+      }
       const c = getCurrentComputation();
       removeSources(node.signalComputation);
       setComputation(node.signalComputation);
@@ -172,6 +199,9 @@ export class Fiber {
 
 export class RootFiber extends Fiber {
   counter: number = 1;
+  // Number of times this (uncommitted) fiber has been recycled by makeRootFiber.
+  // Climbs without bound only in a render loop; see issue #1968.
+  renderCount = 0;
 
   // only add stuff in this if they have registered some hooks
   willPatch: Fiber[] = [];

--- a/packages/owl-runtime/tests/components/__snapshots__/rendering.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/rendering.test.ts.snap
@@ -65,6 +65,32 @@ exports[`force render in case of existing render 3`] = `
 }"
 `;
 
+exports[`render loop detection > throws a clear error instead of freezing on a render loop (#1968) 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["value","inc"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {value: ctx['this'].value(),inc: ctx['this'].inc};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`render loop detection > throws a clear error instead of freezing on a render loop (#1968) 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.value);
+  }
+}"
+`;
+
 exports[`rendering semantics > can force a render to update sub tree 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/rendering.test.ts
+++ b/packages/owl-runtime/tests/components/rendering.test.ts
@@ -1,4 +1,14 @@
-import { Component, mount, onWillUpdateProps, props, proxy, xml } from "../../src";
+import {
+  Component,
+  mount,
+  onWillUpdateProps,
+  OwlError,
+  props,
+  proxy,
+  signal,
+  t,
+  xml,
+} from "../../src";
 import {
   makeTestFixture,
   snapshotEverything,
@@ -8,6 +18,7 @@ import {
   nextMicroTick,
   render,
   steps,
+  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -488,4 +499,34 @@ test("children, default props and renderings", async () => {
       "Parent:patched",
     ]
   `);
+});
+
+describe("render loop detection", () => {
+  test("throws a clear error instead of freezing on a render loop (#1968)", async () => {
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.value"/>`;
+      props = props({ value: t.number(), inc: t.function() });
+      setup() {
+        // Updating parent state during setup retriggers the parent render, which
+        // recreates this child, whose setup runs again: an infinite render loop.
+        this.props.inc();
+      }
+    }
+    class Root extends Component {
+      static components = { Child };
+      static template = xml`<Child value="this.value()" inc="this.inc"/>`;
+      value = signal(1);
+      // arrow so it stays bound to the Root instance when called from the child
+      inc = () => this.value.set(this.value() + 1);
+    }
+
+    let error: any;
+    // Before the fix this never resolves (the tab freezes); now it rejects.
+    await mount(Root, fixture, { test: true }).catch((e) => (error = e));
+
+    expect(error).toBeInstanceOf(OwlError);
+    expect(error.message).toMatch(/render loop/);
+    expect(error.message).toContain("Root");
+    expect(getConsoleOutput()).toEqual([]);
+  });
 });


### PR DESCRIPTION
When a component updates reactive state that an ancestor reads during render (e.g. a child whose setup() calls a parent state setter), the parent re-renders, recreates the child, runs setup() again, and so on. The cycle is driven entirely by microtasks, so the rAF-based DOM commit never runs and the tab freezes silently with no error, which is very hard to debug.

Track how many times a root fiber is re-rendered before being committed to the DOM (renderCount, bumped in makeRootFiber when an uncommitted fiber is recycled). A healthy render commits and discards its fiber, so a fresh one always starts at 0; only a self-retriggering loop ever makes the count climb without bound. Once it exceeds MAX_RENDER_ITERATIONS, Fiber.render() bails through handleError with a clear OwlError naming the looping component, halting the loop and tearing the app down. Same idea as React's "Maximum update depth exceeded" / Vue's "Maximum recursive updates", adapted to Owl's async fiber model.

closes #1968