### PR TITLE
[FIX] devtools: stop resolving empty components to parent DOM

### DIFF
--- a/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
+++ b/tools/devtools/src/page_scripts/owl_devtools_global_hook.js
@@ -1724,7 +1724,9 @@
       }
       return getter;
     }
-    // Gives the DOM elements which correspond to the given component node
+    // Gives the DOM elements which are rendered by the given component node.
+    // A component which currently renders nothing (root t-if being false, root t-foreach
+    // on an empty collection, ...) yields an empty array.
     getDOMElementsRecursive(node) {
       if (node.hasOwnProperty("bdom")) {
         return this.getDOMElementsRecursive(node.bdom);
@@ -1747,14 +1749,7 @@
             elements = elements.concat(this.getDOMElementsRecursive(child));
           }
         }
-        if (elements.length > 0) {
-          return elements;
-        }
-      }
-      if (node.hasOwnProperty("parentEl")) {
-        if (node.parentEl instanceof Element) {
-          return [node.parentEl];
-        }
+        return elements;
       }
       return [];
     }
@@ -2056,6 +2051,9 @@
     inspectComponentDOM(path) {
       const componentNode = this.getComponentNode(path);
       const elements = this.getDOMElementsRecursive(componentNode);
+      if (!elements.length) {
+        return;
+      }
       if (IS_FIREFOX) {
         window.$temp = elements[0];
       } else {


### PR DESCRIPTION
Fixes an issue where `getDOMElementsRecursive` fell back to a node's `parentEl` if a component rendered no DOM elements of its own. This broke the HTML selector because empty components (like a hidden `Transition` component) would claim ownership of everything inside their shared parent container, hijacking selector focus from dialog content.

This commit removes the fallback entirely. Empty components now correctly result in no highlight when hovered and act as a no-op during DOM inspection, ensuring strict accuracy in element ownership mapping.