### PR TITLE
[IMP] ci: update github actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,9 +21,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22.x
     - run: npm ci
@@ -36,9 +36,9 @@ jobs:
     - name: Assemble site
       run: node tools/site/assemble.mjs
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: dist/website
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5


### PR DESCRIPTION
Bump the actions used by the CI and Pages deploy workflows to their latest majors, moving them onto the Node 24 runtime and clearing the Node 20 deprecation warnings now enforced on the runners:

- pages.yml: checkout v4->v7, setup-node v4->v6, upload-pages-artifact v3->v5, deploy-pages v4->v5
- ci.yml: checkout v2->v7, setup-node v1->v6