### PR TITLE
[IMP] devtools: enable horizontal scroll in profiler

### DIFF
--- a/tools/devtools/manifest-chrome.json
+++ b/tools/devtools/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "manifest_version": 3,
   "description": "Chromium devtools extension for Odoo Owl framework",
   "icons": {

--- a/tools/devtools/manifest-firefox.json
+++ b/tools/devtools/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Owl devtools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Firefox devtools extension for Odoo Owl framework",
   "manifest_version": 2,
   "browser_specific_settings": {

--- a/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
+++ b/tools/devtools/src/devtools_app/devtools_window/profiler_tab/profiler_tab.xml
@@ -31,16 +31,18 @@
           </div>
         </t>
         <t t-else="">
-          <t t-if="this.profiler.eventsTreeView()">
-            <t t-foreach="this.profiler.eventsTree()" t-as="event" t-key="event.id">
-              <EventNode event="event"/>
+          <div class="events-wrapper">
+            <t t-if="this.profiler.eventsTreeView()">
+              <t t-foreach="this.profiler.eventsTree()" t-as="event" t-key="event.id">
+                <EventNode event="event"/>
+              </t>
             </t>
-          </t>
-          <t t-else="">
-            <t t-foreach="this.profiler.events()" t-as="event" t-key="event_index">
-              <Event event="event"/>
+            <t t-else="">
+              <t t-foreach="this.profiler.events()" t-as="event" t-key="event_index">
+                <Event event="event"/>
+              </t>
             </t>
-          </t>
+          </div>
         </t>
       </div>
     </div>

--- a/tools/devtools/src/main.css
+++ b/tools/devtools/src/main.css
@@ -240,8 +240,11 @@
 }
 
 .events-container {
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: auto;
+}
+
+.events-wrapper {
+  min-width: max-content;
 }
 
 .split-screen-right {


### PR DESCRIPTION
Enables horizontal scrolling within the profiler tab container. This ensures that the interface remains fully usable and legible even when a combination of deep hierarchy depth, long component names, and component keys overflows the view. This is the second and last feature in the v2.0.3 release.