### PR TITLE
[FIX] owl-core: notify signal atom once per proxy write

### DIFF
--- a/packages/owl-core/src/proxy.ts
+++ b/packages/owl-core/src/proxy.ts
@@ -105,18 +105,15 @@ function onReadTargetKey(target: Target, key: PropertyKey, atom: Atom | null): v
  * @param key the key that changed (or Symbol `KEYCHANGES` if a key was created
  *   or deleted)
  */
-function onWriteTargetKey(target: Target, key: PropertyKey, atom: Atom | null): void {
-  if (!atom) {
-    const keyToAtomItem = targetToKeysToAtomItem.get(target)!;
-    if (!keyToAtomItem) {
-      return;
-    }
-    if (!keyToAtomItem.has(key)) {
-      return;
-    }
-    atom = keyToAtomItem.get(key)!;
+function onWriteTargetKey(target: Target, key: PropertyKey): void {
+  const keyToAtomItem = targetToKeysToAtomItem.get(target)!;
+  if (!keyToAtomItem) {
+    return;
   }
-  onWriteAtom(atom);
+  if (!keyToAtomItem.has(key)) {
+    return;
+  }
+  onWriteAtom(keyToAtomItem.get(key)!);
 }
 
 // Maps proxy objects to the underlying target
@@ -210,25 +207,39 @@ function basicProxyHandler<T extends Target>(atom: Atom | null): ProxyHandler<T>
       const hadKey = objectHasOwnProperty.call(target, key);
       const originalValue = Reflect.get(target, key, receiver);
       const ret = Reflect.set(target, key, toRaw(value), receiver);
-      if (!hadKey && objectHasOwnProperty.call(target, key)) {
-        onWriteTargetKey(target, KEYCHANGES, atom);
-      }
-      // While Array length may trigger the set trap, it's not actually set by this
-      // method but is updated behind the scenes, and the trap is not called with the
-      // new value. We disable the "same-value-optimization" for it because of that.
-      if (
-        originalValue !== Reflect.get(target, key, receiver) ||
-        (key === "length" && Array.isArray(target))
-      ) {
-        onWriteTargetKey(target, key, atom);
+      const keyCreated = !hadKey && objectHasOwnProperty.call(target, key);
+      const valueChanged = originalValue !== Reflect.get(target, key, receiver);
+      if (atom) {
+        // Signal-based proxies observe a single atom: notify it at most once
+        // per write, even when the write both creates a key and changes a
+        // value. Array "length" writes triggered by array methods (push, ...)
+        // don't need the special case below: the index write that caused them
+        // already notified the atom.
+        if (keyCreated || valueChanged) {
+          onWriteAtom(atom);
+        }
+      } else {
+        if (keyCreated) {
+          onWriteTargetKey(target, KEYCHANGES);
+        }
+        // While Array length may trigger the set trap, it's not actually set by this
+        // method but is updated behind the scenes, and the trap is not called with the
+        // new value. We disable the "same-value-optimization" for it because of that.
+        if (valueChanged || (key === "length" && Array.isArray(target))) {
+          onWriteTargetKey(target, key);
+        }
       }
       return ret;
     },
     deleteProperty(target, key) {
       const ret = Reflect.deleteProperty(target, key);
       // TODO: only notify when something was actually deleted
-      onWriteTargetKey(target, KEYCHANGES, atom);
-      onWriteTargetKey(target, key, atom);
+      if (atom) {
+        onWriteAtom(atom);
+      } else {
+        onWriteTargetKey(target, KEYCHANGES);
+        onWriteTargetKey(target, key);
+      }
       return ret;
     },
     ownKeys(target) {
@@ -326,10 +337,10 @@ function delegateAndNotify(
     const ret = target[setterName](key, value);
     const hasKey = target.has(key);
     if (hadKey !== hasKey) {
-      onWriteTargetKey(target, KEYCHANGES, null);
+      onWriteTargetKey(target, KEYCHANGES);
     }
     if (originalValue !== target[getterName](key)) {
-      onWriteTargetKey(target, key, null);
+      onWriteTargetKey(target, key);
     }
     return ret;
   };
@@ -344,9 +355,9 @@ function makeClearNotifier(target: Map<any, any> | Set<any>) {
   return () => {
     const allKeys = [...target.keys()];
     target.clear();
-    onWriteTargetKey(target, KEYCHANGES, null);
+    onWriteTargetKey(target, KEYCHANGES);
     for (const key of allKeys) {
-      onWriteTargetKey(target, key, null);
+      onWriteTargetKey(target, key);
     }
   };
 }

--- a/packages/owl-core/tests/signals.test.ts
+++ b/packages/owl-core/tests/signals.test.ts
@@ -1,4 +1,4 @@
-import { signal } from "../src";
+import { atomSymbol, signal } from "../src";
 import { expectSpy, spyEffect, waitScheduler } from "./helpers";
 
 test("signal can be created and read", () => {
@@ -470,5 +470,71 @@ describe("signal.Set", () => {
 
     await waitScheduler();
     expectSpy(e.spy, 4, { result: [2] });
+  });
+});
+
+describe("signal write notifications", () => {
+  // Counts how many times onWriteAtom is called on the signal's atom by
+  // counting iterations of its observers set (onWriteAtom iterates it once
+  // per call).
+  function countAtomNotifications(sig: any): () => number {
+    const atom = sig[atomSymbol];
+    let count = 0;
+    atom.observers = new (class extends Set<any> {
+      [Symbol.iterator]() {
+        count++;
+        return super[Symbol.iterator]();
+      }
+    })(atom.observers);
+    return () => count;
+  }
+
+  test("adding an element to a signal.Array notifies its atom only once", () => {
+    const reactiveArray = signal.Array<number>([0, 1]);
+    const notified = countAtomNotifications(reactiveArray);
+
+    reactiveArray()[2] = 2;
+    expect(notified()).toBe(1);
+  });
+
+  test("push on a signal.Array notifies its atom only once", () => {
+    const reactiveArray = signal.Array<number>([0]);
+    const notified = countAtomNotifications(reactiveArray);
+
+    reactiveArray().push(1);
+    expect(notified()).toBe(1);
+  });
+
+  test("writing the same value to a signal.Array does not notify", () => {
+    const reactiveArray = signal.Array<number>([0]);
+    const notified = countAtomNotifications(reactiveArray);
+
+    reactiveArray()[0] = 0;
+    expect(notified()).toBe(0);
+  });
+
+  test("truncating a signal.Array through length notifies its atom only once", () => {
+    const reactiveArray = signal.Array<number>([0, 1, 2]);
+    const notified = countAtomNotifications(reactiveArray);
+
+    reactiveArray().length = 1;
+    expect(notified()).toBe(1);
+    expect(reactiveArray()).toEqual([0]);
+  });
+
+  test("adding a key to a signal.Object notifies its atom only once", () => {
+    const reactiveObject = signal.Object<Record<string, number>>({ a: 1 });
+    const notified = countAtomNotifications(reactiveObject);
+
+    reactiveObject().b = 2;
+    expect(notified()).toBe(1);
+  });
+
+  test("deleting a key from a signal.Object notifies its atom only once", () => {
+    const reactiveObject = signal.Object<Record<string, number>>({ a: 1 });
+    const notified = countAtomNotifications(reactiveObject);
+
+    delete reactiveObject().a;
+    expect(notified()).toBe(1);
   });
 });


### PR DESCRIPTION
Writing to a signal.Array or signal.Object called onWriteAtom twice on the signal's atom: once for the KEYCHANGES notification and once for the written key (and a third time for push, via the length set trap). Since signal-based proxies observe a single atom, every call funnels into the same onWriteAtom, redundantly iterating observers and re-scheduling the effect batch. #1903 fixed this for Map/Set/WeakMap helpers but not for the basic handler.

The set and deleteProperty traps now coalesce to at most one onWriteAtom(atom) per write when an atom is present. The array length special case is skipped on the atom path: length writes triggered by array methods are preceded by an index write that already notified the atom, and direct length assignments are caught by the value comparison. The deep proxy() path keeps its per-key notifications, which makes the atom parameter of onWriteTargetKey dead, so it is dropped.

Closes odoo/owl#1972