### PR TITLE
[FIX] runtime: don't lose coalesced renders

### DIFF
--- a/src/runtime/fibers.ts
+++ b/src/runtime/fibers.ts
@@ -76,6 +76,15 @@ function cancelFibers(fibers: Fiber[]): number {
       node.forceNextRender = true;
     } else {
       result++;
+      if (node.bdom) {
+        // a mounted node whose pending fiber is cancelled before it could
+        // render may have renders coalesced into that fiber (requested by
+        // reactive changes, whose subscriptions were cleared when they were
+        // notified), so dropping the fiber would silently lose them: force
+        // the cancelling render to re-render the node even if its props are
+        // unchanged.
+        node.forceNextRender = true;
+      }
     }
     result += cancelFibers(fiber.children);
   }

--- a/tests/components/__snapshots__/concurrency.test.ts.snap
+++ b/tests/components/__snapshots__/concurrency.test.ts.snap
@@ -152,6 +152,31 @@ exports[`calling render in destroy 3`] = `
 }"
 `;
 
+exports[`cancelled fiber does not swallow a render coalesced into it 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  const comp1 = app.createComponent(\`Child\`, true, false, false, [\\"p\\"]);
+  
+  return function template(ctx, node, key = \\"\\") {
+    return comp1({p: ctx['state'].p}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`cancelled fiber does not swallow a render coalesced into it 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler, comment } = bdom;
+  
+  return function template(ctx, node, key = \\"\\") {
+    const b2 = text(ctx['props'].p);
+    const b3 = text(ctx['shared'].value);
+    return multi([b2, b3]);
+  }
+}"
+`;
+
 exports[`change state and call manually render: no unnecessary rendering 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/tests/components/concurrency.test.ts
+++ b/tests/components/concurrency.test.ts
@@ -9,6 +9,7 @@ import {
   onWillStart,
   onWillUnmount,
   onWillUpdateProps,
+  reactive,
   useState,
   xml,
 } from "../../src";
@@ -5004,3 +5005,54 @@ test("component destroyed just after render", async () => {
 //     );
 //   });
 // });
+
+test("cancelled fiber does not swallow a render coalesced into it", async () => {
+  // A reactive change notifying a component whose parent holds a pending,
+  // not-yet-rendered child fiber for it is coalesced into that fiber (the
+  // component's reactive subscriptions are cleared at notification time). A
+  // second parent render cancelling that fiber used to drop the coalesced
+  // render whenever the child's props compared equal to its committed props,
+  // leaving the child stale and unsubscribed from the reactive state (hence
+  // deaf to all its further changes).
+  const shared = reactive({ value: "a" });
+  let def: ReturnType<typeof makeDeferred> | null = null;
+  class Child extends Component {
+    static template = xml`<t t-esc="props.p"/><t t-esc="shared.value"/>`;
+    shared: any;
+    setup() {
+      this.shared = useState(shared);
+      onWillUpdateProps(() => def);
+    }
+  }
+  let parent: any;
+  class Parent extends Component {
+    static template = xml`<Child p="state.p"/>`;
+    static components = { Child };
+    state = useState({ p: 1 });
+    setup() {
+      parent = this;
+    }
+  }
+  await mount(Parent, fixture);
+  expect(fixture.textContent).toBe("1a");
+  // parent render pass 1: Child's props differ, so the parent creates a child
+  // fiber for it, held pending by the gate on willUpdateProps
+  def = makeDeferred();
+  parent.state.p = 2;
+  await nextMicroTick();
+  await nextMicroTick();
+  // reactive change: Child's re-render is coalesced into the pending fiber
+  shared.value = "b";
+  await nextMicroTick();
+  // parent render pass 2: the prop reverts; the pending child fiber is
+  // cancelled and Child's props compare equal to its committed props
+  parent.state.p = 1;
+  def.resolve();
+  def = null;
+  await nextTick();
+  expect(fixture.textContent).toBe("1b");
+  // the child must also still react to later changes
+  shared.value = "c";
+  await nextTick();
+  expect(fixture.textContent).toBe("1c");
+});


### PR DESCRIPTION
When a reactive change notifies a component, its reactive subscriptions are cleared before its render callback runs. If the component's parent holds a pending, not yet rendered fiber for it (the parent is mid-render, e.g. awaiting `onWillUpdateProps`), the requested render is coalesced into that pending fiber. If another parent render then cancels that fiber before it could render, `cancelFibers` only set `forceNextRender` for fibers that had already rendered (with a `bdom`): a not yet rendered fiber was dropped without compensation. When the child's props also compare equal to its committed props (a transient prop that changed and reverted compares equal, as committed props are only updated on patch), the cancelling render pass skips the child entirely: the coalesced render is lost, and since the subscriptions were already cleared, the component no longer reacts to any further change of the reactive state it displays. Its DOM is silently stale until an unrelated render of it happens.

Force the next render of a mounted node whose not yet rendered fiber is cancelled, as master already does.

This is the root cause of odoo runbot error 940032 ("thread messages never render"): the render displaying the freshly loaded messages of a discuss channel was coalesced into a pending fiber that a parent double-render cancelled, and the message list stayed empty with no error, surviving two application-side fix attempts.

https://runbot.odoo.com/odoo/error/940032