### PR TITLE
[FIX] playground: register theme through shiki

### DIFF
--- a/tools/playground/src/components.js
+++ b/tools/playground/src/components.js
@@ -95,7 +95,7 @@ class CodeEditor extends Component {
           };
         },
       };
-      monaco.editor.defineTheme("slate-dark", { base: "vs-dark" });
+      await setupShiki(monaco);
       monaco.typescript.javascriptDefaults.setCompilerOptions({
         allowJs: true,
         allowNonTsExtensions: true,
@@ -120,7 +120,6 @@ class CodeEditor extends Component {
       registerOwlSnippets(monaco);
       registerXmlTagRename(monaco);
       await registerCustomTsWorker(monaco);
-      await setupShiki(monaco);
     });
 
     useEffect(() => {


### PR DESCRIPTION
The colors object was missing over here - `monaco.editor.defineTheme("slate-dark", { base: "vs-dark" });` due to which we get a blank screen and a console error occurs - `TypeError: Cannot read properties of undefined (reading 'editor.foreground')`

Steps to reproduce -
Open `Playground` >> double click on the `Projects`

Removed the unsafe, minimal `defineTheme` and ensured `setupShiki(monaco)` is awaited early in `onWillStart()` so the Shiki-registered `slate-dark` theme (which includes a full `colors` map) is installed before any editor/theme usage.
