### PR TITLE
[IMP] playground: initialize Monaco only once

### DIFF
--- a/tools/playground/src/components.js
+++ b/tools/playground/src/components.js
@@ -17,10 +17,6 @@ import {
 import { parseMarkdown } from "./code_utils.js";
 import { getFileType, makeFileEntry, parseFilePaths, TAB_SIZES } from "./file_utils.js";
 import * as monaco from "@libs/monaco";
-import { playgroundAssetUrl } from "./asset_url.js";
-import { setupShiki } from "./monaco/shiki.js";
-import { registerCustomTsWorker } from "./monaco/auto_import.js";
-import { registerOwlSnippets } from "./monaco/snippets.js";
 import {
   CodePlugin,
   DialogPlugin,
@@ -33,7 +29,7 @@ import {
 } from "./plugins.js";
 import { HELLO_WORLD_JS } from "./samples.js";
 import { debounce } from "./utils.js";
-import { registerXmlTagRename } from "./monaco/xml_tag_rename.js";
+import { initiateMonaco } from "./monaco/initialize_monaco.js";
 
 class CodeEditor extends Component {
   static template = "CodeEditor";
@@ -69,57 +65,7 @@ class CodeEditor extends Component {
     let owlTypesDisposable = null;
 
     onWillStart(async () => {
-      window.MonacoEnvironment = {
-        getWorker(_, label) {
-          switch (label) {
-            case "typescript":
-            case "javascript":
-              return new Worker(
-                playgroundAssetUrl("./libs/workers/ts.worker.js")
-              );
-
-            case "css":
-              return new Worker(
-                playgroundAssetUrl("./libs/workers/css.worker.js")
-              );
-
-            case "html":
-              return new Worker(
-                playgroundAssetUrl("./libs/workers/html.worker.js")
-              );
-
-            default:
-              return new Worker(
-                playgroundAssetUrl("./libs/workers/editor.worker.js")
-              );
-          };
-        },
-      };
-      await setupShiki(monaco);
-      monaco.typescript.javascriptDefaults.setCompilerOptions({
-        allowJs: true,
-        allowNonTsExtensions: true,
-        checkJs: true,
-        noImplicitAny: false,
-        moduleResolution:
-          monaco.typescript.ModuleResolutionKind.NodeJs,
-        module:
-          monaco.typescript.ModuleKind.ESNext,
-        target:
-          monaco.typescript.ScriptTarget.ESNext,
-        baseUrl: "file:///",
-      });
-      monaco.typescript.javascriptDefaults.setDiagnosticsOptions({
-        noSemanticValidation: false,
-        noSyntaxValidation: false,
-      });
-      monaco.typescript.javascriptDefaults.addExtraLib(
-        `declare const TEMPLATES: Record<string, string>;`,
-        "file:///globals.d.ts"
-      );
-      registerOwlSnippets(monaco);
-      registerXmlTagRename(monaco);
-      await registerCustomTsWorker(monaco);
+      await initiateMonaco(monaco);
     });
 
     useEffect(() => {

--- a/tools/playground/src/monaco/initialize_monaco.js
+++ b/tools/playground/src/monaco/initialize_monaco.js
@@ -1,0 +1,65 @@
+import { registerXmlTagRename } from "./xml_tag_rename.js";
+import { registerOwlSnippets } from "./snippets.js";
+import { setupShiki } from "./shiki.js";
+import { registerCustomTsWorker } from "./auto_import.js";
+import { playgroundAssetUrl } from "../asset_url.js";
+
+let monacoInitialized = false;
+
+export async function initiateMonaco(monaco) {
+    if (monacoInitialized) {
+        return;
+    }
+    monacoInitialized = true;
+    window.MonacoEnvironment = {
+        getWorker(_, label) {
+            switch (label) {
+                case "typescript":
+                case "javascript":
+                    return new Worker(
+                        playgroundAssetUrl("./libs/workers/ts.worker.js")
+                    );
+
+                case "css":
+                    return new Worker(
+                        playgroundAssetUrl("./libs/workers/css.worker.js")
+                    );
+
+                case "html":
+                    return new Worker(
+                        playgroundAssetUrl("./libs/workers/html.worker.js")
+                    );
+
+                default:
+                    return new Worker(
+                        playgroundAssetUrl("./libs/workers/editor.worker.js")
+                    );
+            };
+        },
+    };
+    monaco.typescript.javascriptDefaults.setCompilerOptions({
+        allowJs: true,
+        allowNonTsExtensions: true,
+        checkJs: true,
+        noImplicitAny: false,
+        moduleResolution:
+            monaco.typescript.ModuleResolutionKind.NodeJs,
+        module:
+            monaco.typescript.ModuleKind.ESNext,
+        target:
+            monaco.typescript.ScriptTarget.ESNext,
+        baseUrl: "file:///",
+    });
+    monaco.typescript.javascriptDefaults.setDiagnosticsOptions({
+        noSemanticValidation: false,
+        noSyntaxValidation: false,
+    });
+    monaco.typescript.javascriptDefaults.addExtraLib(
+        `declare const TEMPLATES: Record<string, string>;`,
+        "file:///globals.d.ts"
+    );
+    registerOwlSnippets(monaco);
+    registerXmlTagRename(monaco);
+    await registerCustomTsWorker(monaco);
+    await setupShiki(monaco);
+}


### PR DESCRIPTION
Switching between the editor and project manager remounts the CodeEditor, causing `onWillStart` to re-register Monaco workers, snippets, themes, and language configuration on every mount.

Move Monaco initialization into a singleton helper so the global setup runs only once per page.

This avoids duplicate Monaco initialization when reopening the editor.