### PR TITLE
[FIX] reactivity: keep immediate effects immediate

### DIFF
--- a/packages/owl-core/src/computations.ts
+++ b/packages/owl-core/src/computations.ts
@@ -184,6 +184,8 @@ function markDownstream(computation: ComputationAtom) {
       observer.state = ComputationState.PENDING;
       if (observer.isDerived) {
         stack.push(observer);
+      } else if (observer.immediate) {
+        immediateObservers.push(observer);
       } else {
         observers.push(observer);
       }

--- a/packages/owl-core/tests/immediate_effect.test.ts
+++ b/packages/owl-core/tests/immediate_effect.test.ts
@@ -1,4 +1,4 @@
-import { immediateEffect, effect, proxy, signal } from "../src";
+import { computed, immediateEffect, effect, proxy, signal } from "../src";
 import { expectSpy, nextMicroTick } from "./helpers";
 
 async function waitScheduler() {
@@ -46,6 +46,47 @@ describe("immediateEffect", () => {
     expectSpy(spy, 2, { args: [2] });
     s.set(3);
     expectSpy(spy, 3, { args: [3] });
+  });
+
+  test("immediateEffect keeps synchronous timing through a computed", () => {
+    const s = signal(1);
+    const double = computed(() => s() * 2);
+    const spy = vi.fn();
+    immediateEffect(() => spy(double()));
+    expectSpy(spy, 1, { args: [2] });
+    s.set(2);
+    expectSpy(spy, 2, { args: [4] });
+    s.set(3);
+    expectSpy(spy, 3, { args: [6] });
+  });
+
+  test("computed dependency does not degrade a direct dependency to batched", () => {
+    const a = signal(1);
+    const b = signal(10);
+    const isPositive = computed(() => a() > 0);
+    const spy = vi.fn();
+    immediateEffect(() => spy(isPositive(), b()));
+    expectSpy(spy, 1, { args: [true, 10] });
+    // Write reaching the effect through the computed: must not leave the
+    // effect parked in the batched queue...
+    a.set(-1);
+    expectSpy(spy, 2, { args: [false, 10] });
+    // ...nor with a non-EXECUTED state that would make onWriteAtom skip
+    // scheduling this later direct write in the same task.
+    b.set(20);
+    expectSpy(spy, 3, { args: [false, 20] });
+  });
+
+  test("immediateEffect does not rerun when a computed dependency recomputes to an equal value", () => {
+    const a = signal(1);
+    const isPositive = computed(() => a() > 0);
+    const spy = vi.fn();
+    immediateEffect(() => spy(isPositive()));
+    expectSpy(spy, 1, { args: [true] });
+    a.set(2);
+    expectSpy(spy, 1, { args: [true] });
+    a.set(-1);
+    expectSpy(spy, 2, { args: [false] });
   });
 
   test("immediateEffect should unsubscribe previous dependencies", () => {


### PR DESCRIPTION
An immediateEffect observing a computed lost its synchronous timing: markDownstream pushed every non-derived downstream observer into the batched queue without checking `immediate`, so a write reaching the effect through a derived deferred it to a microtask, while the same write on a direct source would have flushed it synchronously.

Worse, the batched scheduling degraded the effect's other direct dependencies too: once its state left EXECUTED, the scheduling check in onWriteAtom skipped any later direct write in the same task, so a single derived dependency silently batched the whole effect.

Schedule immediate observers found by markDownstream into immediateObservers: the ongoing onWriteAtom flushes that queue synchronously right after marking. The pull check in updateComputation is unaffected and still skips the rerun when the derived recomputes to an equal value.