### PR TITLE
[IMP] owl: let plugins register onError handlers

### DIFF
--- a/doc/v3/owl/reference/error_handling.md
+++ b/doc/v3/owl/reference/error_handling.md
@@ -37,6 +37,11 @@ There are important things to know:
   an error, and Owl will try looking for another error handler up the component
   tree.
 
+- `onError` also works inside a plugin's `setup()`: the handler then catches
+  errors coming from the subtree the plugin is provided in (the whole
+  application for app-level plugins). See
+  [Plugins](plugins.md#error-handling).
+
 ## Example
 
 For example, here is how we could implement a generic component `ErrorBoundary`

--- a/doc/v3/owl/reference/plugins.md
+++ b/doc/v3/owl/reference/plugins.md
@@ -389,3 +389,33 @@ class KeyboardPlugin extends Plugin {
   }
 }
 ```
+
+## Error Handling
+
+Plugins can use the [`onError`](error_handling.md) hook, just like components.
+A handler registered in a plugin's `setup()` catches rendering and lifecycle
+errors coming from the subtree the plugin is provided in: the providing
+component's subtree for `providePlugins()`, or the whole application for
+app-level plugins.
+
+```js
+class ErrorService extends Plugin {
+  lastError = signal(null);
+
+  setup() {
+    onError((error) => {
+      this.lastError.set(error);
+    });
+  }
+}
+```
+
+Handlers closest to the error run first: an error bubbles up the component
+tree, and at each level the component's own handlers run before those of the
+plugins it provides. A handler can rethrow to pass the error further up —
+app-level plugin handlers are the last stop before Owl destroys the
+application.
+
+Note that during the initial mount, an error that reaches the root component
+unhandled rejects the `mount()` promise instead of reaching the app-level
+plugin handlers.

--- a/packages/owl-core/src/plugin_manager.ts
+++ b/packages/owl-core/src/plugin_manager.ts
@@ -70,6 +70,10 @@ interface PluginManagerOptions {
 export class PluginManager extends Scope {
   config: Record<string, any>;
   plugins: Record<string, Plugin>;
+  // The manager this one shadows: set for `providePlugins` managers, null for
+  // the app-level manager. Error handling walks this chain to give plugin
+  // `onError` handlers a chance at each providing level.
+  parent: PluginManager | null;
 
   // Resolves once all batches of plugins have started and their willStart
   // callbacks have settled. The scope transitions to MOUNTED as the last step
@@ -86,9 +90,11 @@ export class PluginManager extends Scope {
 
     if (options.parent) {
       const parent = options.parent;
+      this.parent = parent;
       parent.onDestroy(() => this.destroy());
       this.plugins = Object.create(parent.plugins);
     } else {
+      this.parent = null;
       this.plugins = {};
     }
   }

--- a/packages/owl-runtime/src/lifecycle_hooks.ts
+++ b/packages/owl-runtime/src/lifecycle_hooks.ts
@@ -1,3 +1,4 @@
+import { useScope, type PluginManager } from "@odoo/owl-core";
 import { ComponentNode, getComponentScope } from "./component_node";
 import { nodeErrorHandlers } from "./rendering/error_handling";
 
@@ -41,11 +42,16 @@ export function onWillUnmount(fn: (scope: ComponentNode) => void | any) {
 
 type OnErrorCallback = (error: any) => void | any;
 export function onError(callback: OnErrorCallback) {
-  const scope = getComponentScope();
+  // the only concrete scopes are ComponentNode and PluginManager
+  const scope = useScope() as ComponentNode | PluginManager;
+  if (scope instanceof ComponentNode) {
+    // matching the other lifecycle hooks, bind the handler to the component
+    callback = callback.bind(scope.component);
+  }
   let handlers = nodeErrorHandlers.get(scope);
   if (!handlers) {
     handlers = [];
     nodeErrorHandlers.set(scope, handlers);
   }
-  handlers.push(callback.bind(scope.component));
+  handlers.push(callback);
 }

--- a/packages/owl-runtime/src/rendering/error_handling.ts
+++ b/packages/owl-runtime/src/rendering/error_handling.ts
@@ -1,19 +1,45 @@
+import type { PluginManager } from "@odoo/owl-core";
 import type { ComponentNode } from "../component_node";
 import type { Fiber } from "./fibers";
 
 // Maps fibers to thrown errors
 export const fibersInError: WeakMap<Fiber, any> = new WeakMap();
 export const nodeErrorHandlers: WeakMap<
-  ComponentNode,
+  ComponentNode | PluginManager,
   ((error: any, finalize: Function) => void)[]
 > = new WeakMap();
 
+// Invokes a single scope's error handlers, latest registered first. Returns
+// whether one of them caught, along with the final (possibly rethrown) error.
+function invokeScopeHandlers(
+  scope: ComponentNode | PluginManager,
+  error: any,
+  finalize: Function
+): { handled: boolean; error: any } {
+  const handlers = nodeErrorHandlers.get(scope);
+  if (handlers) {
+    for (let i = handlers.length - 1; i >= 0; i--) {
+      try {
+        handlers[i](error, finalize);
+        return { handled: true, error };
+      } catch (e) {
+        error = e;
+      }
+    }
+  }
+  return { handled: false, error };
+}
+
 // Walks up from `node` (inclusive), invoking the latest error handler at each
-// level. Returns whether a handler caught and the final (possibly rethrown)
-// error. When `markFibers` is true, each visited fiber is recorded in
-// `fibersInError` so re-renders can detect and clear in-error state — this is
-// what `handleError` wants, but sub-root forwarders (Suspense, Portal) want
-// to leave the outer tree's fibers alone.
+// level. Plugin managers sit between the node they are provided at and its
+// parent: after a node's own handlers, the managers introduced at that node
+// (from `node.pluginManager` up to, but excluding, the parent's manager) get
+// a chance, so plugin `onError` handlers guard the subtree the plugins are
+// visible in — the whole app for app-level plugins. Returns whether a handler
+// caught and the final (possibly rethrown) error. When `markFibers` is true,
+// each visited fiber is recorded in `fibersInError` so re-renders can detect
+// and clear in-error state — this is what `handleError` wants, but sub-root
+// forwarders (Suspense, Portal) want to leave the outer tree's fibers alone.
 function invokeErrorHandlers(
   node: ComponentNode | null,
   error: any,
@@ -24,16 +50,19 @@ function invokeErrorHandlers(
     if (markFibers && node.fiber) {
       fibersInError.set(node.fiber, error);
     }
-    const handlers = nodeErrorHandlers.get(node);
-    if (handlers) {
-      for (let i = handlers.length - 1; i >= 0; i--) {
-        try {
-          handlers[i](error, finalize);
-          return { handled: true, error };
-        } catch (e) {
-          error = e;
-        }
+    let result = invokeScopeHandlers(node, error, finalize);
+    if (result.handled) {
+      return result;
+    }
+    error = result.error;
+    const stop = node.parent ? node.parent.pluginManager : null;
+    let manager: PluginManager | null = node.pluginManager;
+    for (; manager && manager !== stop; manager = manager.parent) {
+      result = invokeScopeHandlers(manager, error, finalize);
+      if (result.handled) {
+        return result;
       }
+      error = result.error;
     }
     node = node.parent;
   }

--- a/packages/owl-runtime/tests/components/__snapshots__/plugins.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/plugins.test.ts.snap
@@ -11,6 +11,71 @@ exports[`a global plugin can import the current app 1`] = `
 }"
 `;
 
+exports[`a plugin can handle errors coming from the subtree it is provided in 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Parent\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`a plugin can handle errors coming from the subtree it is provided in 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Boom\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    if (ctx['this'].errors.error()) {
+      b2 = text(\`Error\`);
+    } else {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`a plugin can handle errors coming from the subtree it is provided in 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].a.b.c);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`app-level plugins can handle errors escaping the root component 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    if (ctx['this'].flag()) {
+      b2 = safeOutput(ctx['this'].a.b.c);
+    } else {
+      b3 = text(\`ok\`);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
 exports[`basic use (setup) 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
@@ -247,6 +312,53 @@ exports[`plugin config are validated 1`] = `
   
   return function template(ctx, node, key = "") {
     return safeOutput(ctx['this'].a.inputA);
+  }
+}"
+`;
+
+exports[`plugin onError handlers can rethrow, after the host's own handlers 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Provider\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    if (ctx['this'].error()) {
+      b2 = text(\`Error\`);
+    } else {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`plugin onError handlers can rethrow, after the host's own handlers 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Boom\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`plugin onError handlers can rethrow, after the host's own handlers 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].a.b.c);
+    return block1([], [b2]);
   }
 }"
 `;

--- a/packages/owl-runtime/tests/components/plugins.test.ts
+++ b/packages/owl-runtime/tests/components/plugins.test.ts
@@ -4,6 +4,7 @@ import {
   computed,
   config,
   mount,
+  onError,
   onWillDestroy,
   onWillStart,
   plugin,
@@ -17,6 +18,7 @@ import {
   types as t,
   useApp,
   useEffect,
+  usePlugin,
   xml,
 } from "../../src";
 import {
@@ -552,4 +554,109 @@ test("providePlugins respects plugin sequence", async () => {
   expect(steps.splice(0)).toEqual(["feature:setup (data=hello)"]);
   expect(fixture.innerHTML).toBe("<span>child</span>");
   app.destroy();
+});
+
+test("a plugin can handle errors coming from the subtree it is provided in", async () => {
+  class ErrorPlugin extends Plugin {
+    error = signal(null);
+    setup() {
+      onError((e) => this.error.set(e));
+    }
+  }
+
+  class Boom extends Component {
+    static template = xml`<div t-out="this.a.b.c"/>`;
+  }
+
+  class Parent extends Component {
+    static template = xml`<t t-if="this.errors.error()">Error</t><t t-else=""><Boom/></t>`;
+    static components = { Boom };
+    errors: any;
+    setup() {
+      providePlugins([ErrorPlugin]);
+      this.errors = usePlugin(ErrorPlugin);
+    }
+  }
+
+  class Root extends Component {
+    static template = xml`<Parent/>`;
+    static components = { Parent };
+  }
+
+  await mount(Root, fixture);
+  expect(fixture.innerHTML).toBe("Error");
+  expect(getConsoleOutput()).toEqual([]);
+});
+
+test("app-level plugins can handle errors escaping the root component", async () => {
+  const flag = signal(false);
+  let caught: any = null;
+
+  class ErrorPlugin extends Plugin {
+    setup() {
+      onError((e) => {
+        caught = e;
+        flag.set(false);
+      });
+    }
+  }
+
+  class Root extends Component {
+    static template = xml`<t t-if="this.flag()" t-out="this.a.b.c"/><t t-else="">ok</t>`;
+    flag = flag;
+  }
+
+  await mount(Root, fixture, { plugins: [ErrorPlugin] });
+  expect(fixture.innerHTML).toBe("ok");
+
+  flag.set(true);
+  await nextTick();
+  expect(caught).toBeInstanceOf(TypeError);
+  expect(fixture.innerHTML).toBe("ok");
+  expect(getConsoleOutput()).toEqual([]);
+});
+
+test("plugin onError handlers can rethrow, after the host's own handlers", async () => {
+  const steps: string[] = [];
+
+  class ErrorPlugin extends Plugin {
+    setup() {
+      onError((e) => {
+        steps.push("plugin");
+        throw e;
+      });
+    }
+  }
+
+  class Boom extends Component {
+    static template = xml`<div t-out="this.a.b.c"/>`;
+  }
+
+  class Provider extends Component {
+    static template = xml`<Boom/>`;
+    static components = { Boom };
+    setup() {
+      providePlugins([ErrorPlugin]);
+      onError((e) => {
+        steps.push("provider");
+        throw e;
+      });
+    }
+  }
+
+  class Root extends Component {
+    static template = xml`<t t-if="this.error()">Error</t><t t-else=""><Provider/></t>`;
+    static components = { Provider };
+    error = signal(false);
+    setup() {
+      onError(() => {
+        steps.push("root");
+        this.error.set(true);
+      });
+    }
+  }
+
+  await mount(Root, fixture);
+  expect(fixture.innerHTML).toBe("Error");
+  expect(steps).toEqual(["provider", "plugin", "root"]);
 });


### PR DESCRIPTION
The onError hook now works inside a plugin's setup(), like in a component's. A plugin handler guards the subtree its plugins are provided in: error propagation still walks up the component tree, but at each node, after the node's own handlers, it consults the managers introduced at that node (node.pluginManager up to, excluding, the parent's manager, via a new PluginManager.parent link). App-level plugin handlers are thus the last stop before app._handleError destroys the app, which is what an app-wide error service needs.

Note that during the initial mount, an error reaching the root unhandled still rejects the mount() promise instead of reaching app-level plugin handlers.