### PR TITLE
[FIX] owl-core: update asyncComputed state after disposal

### DIFF
--- a/packages/owl-core/src/async_computed.ts
+++ b/packages/owl-core/src/async_computed.ts
@@ -128,6 +128,7 @@ export function asyncComputed<T>(
   });
 
   function dispose() {
+    runId++;
     stopEffect();
     runController?.abort();
     runController = null;

--- a/packages/owl-runtime/tests/reactivity/async_computed.test.ts
+++ b/packages/owl-runtime/tests/reactivity/async_computed.test.ts
@@ -468,6 +468,31 @@ test("currentPromise() resolves on dispose so awaiters do not hang", async () =>
   expect(resolved).toBe(true);
 });
 
+test("dispose prevents a late resolution from mutating the asyncComputed state", async () => {
+  const def = makeDeferred<number>();
+  const a = asyncComputed(() => def, { initial: 0 });
+
+  a.dispose();
+  def.resolve(42);
+  await flush();
+
+  expect(a()).toBe(0);
+  expect(a.error()).toBeNull();
+});
+
+test("dispose prevents a late rejection from mutating the asyncComputed state", async () => {
+    const def = makeDeferred<number>();
+    const a = asyncComputed(() => def, { initial: 0 });
+
+    a.dispose();
+
+    def.reject(new Error("boom"));
+    await flush();
+
+    expect(a()).toBe(0);
+    expect(a.error()).toBeNull();
+});
+
 test("onWillStart can await currentPromise() before mounting", async () => {
   const def = makeDeferred<string>();
 


### PR DESCRIPTION
When an `asyncComputed` is created inside a component/scope and the scope is destroyed while the fetch is still pending, a later resolve/reject can still call `value.set(...)`, `error.set(...)`, or otherwise update the reactive state even though the computation is no longer valid.

After this commit, once an `asyncComputed` is disposed, late results from it should be ignored.

fixes https://github.com/odoo/owl/issues/1994