### PR TITLE
[FIX] doc: align sidebar below navbar

### DIFF
--- a/doc/.vitepress/theme/custom.css
+++ b/doc/.vitepress/theme/custom.css
@@ -108,6 +108,8 @@
 /* Hide VitePress's navbar entirely — our static navbar replaces it */
 :root {
   --vp-nav-height: 44px;
+  /* Keep the sidebar aligned below the injected static navbar. */
+  --vp-layout-top-height: 44px;
 }
 
 .VPNav {


### PR DESCRIPTION
Previously, the sidebar started underneath the injected static navbar, causing the sidebar & scrollbar to overlap with it. In this commit set the layout top offset to match the navbar height so the sidebar is positioned correctly.

Fixes: https://github.com/odoo/owl/issues/1951