### PR TITLE
[REF] owl: remove the CANCELLED scope status

### DIFF
--- a/doc/v3/owl/reference/component.md
+++ b/doc/v3/owl/reference/component.md
@@ -398,6 +398,5 @@ console.log(status(component));
 // logs either:
 // - 'new', if the component is new and has not been mounted yet
 // - 'mounted', if the component is currently mounted
-// - 'cancelled', if the component has not been mounted yet but will be destroyed soon
 // - 'destroyed' if the component is currently destroyed
 ```

--- a/doc/v3/owl/reference/scope.md
+++ b/doc/v3/owl/reference/scope.md
@@ -12,8 +12,8 @@ Scopes serve three purposes:
   `usePlugin()`, etc., they find their owner by looking at the currently active
   scope on the scope stack.
 - **Single source of truth for liveness.** `scope.status` is the authoritative
-  answer to "is this component/plugin still alive?" (`NEW`, `MOUNTED`,
-  `CANCELLED`, or `DESTROYED`).
+  answer to "is this component/plugin still alive?" (`NEW`, `MOUNTED`, or
+  `DESTROYED`).
 - **Async cancellation.** Every scope exposes an `AbortSignal` that is
   automatically aborted when the scope dies. Async work keyed to that signal
   stops naturally when the component is destroyed.
@@ -55,25 +55,22 @@ if you need to tolerate that case — it returns `Scope | null`.
 
 ## Lifetime and Status
 
-A scope's `status` transitions through four values, defined by the `STATUS`
+A scope's `status` transitions through three values, defined by the `STATUS`
 enum:
 
-| Status      | Meaning                                                             |
-| ----------- | ------------------------------------------------------------------- |
-| `NEW`       | just created, not yet mounted                                       |
-| `MOUNTED`   | fully alive (for a component: attached to the DOM)                  |
-| `CANCELLED` | abandoned before being mounted (e.g. replaced by a newer rendering) |
-| `DESTROYED` | fully destroyed, all cleanup has run                                |
+| Status      | Meaning                                            |
+| ----------- | -------------------------------------------------- |
+| `NEW`       | just created, not yet mounted                      |
+| `MOUNTED`   | fully alive (for a component: attached to the DOM) |
+| `DESTROYED` | fully destroyed, all cleanup has run               |
 
-The transitions `NEW → CANCELLED` and any transition into `DESTROYED` will
-abort the scope's abort signal (see below). Code that looks at `scope.status`
-should usually ask "is it greater than `MOUNTED`?" to mean "this is dead."
+A component that is abandoned before being mounted (e.g. replaced by a newer
+rendering) transitions directly from `NEW` to `DESTROYED`. Any transition into
+`DESTROYED` aborts the scope's abort signal (see below).
 
-The `scope.isDestroyed()` method answers the stricter question "has this scope
-been fully destroyed?" — it returns `true` only once all cleanup (destroy
-callbacks, computation disposal) has run. A `CANCELLED` scope is dead but not
-yet destroyed, so `isDestroyed()` still returns `false` for it until the
-scheduler finalizes it.
+The `scope.isDestroyed()` method answers the question "is this scope dead?" —
+it returns `true` once all cleanup (destroy callbacks, computation disposal)
+has run.
 
 The `status()` helper function (which takes a `Component` or `Plugin` instance
 directly) is a more convenient frontend for reading a scope's status:
@@ -272,18 +269,15 @@ active. Reach for this only when the absence of a scope is meaningful.
 
 ### `Scope`
 
-- `status: STATUS` — current status (`NEW` / `MOUNTED` / `CANCELLED` / `DESTROYED`).
+- `status: STATUS` — current status (`NEW` / `MOUNTED` / `DESTROYED`).
 - `app: App` — the owning application.
 - `parent: Scope | null` — parent scope in the tree.
 - `abortSignal: AbortSignal` — an `AbortSignal` aborted when the scope dies.
   Lazily allocates an `AbortController` on first access.
-- `isDestroyed(): boolean` — true once the scope is fully destroyed (all
-  cleanup has run). A `CANCELLED` scope is not yet destroyed — to ask "is this
-  scope dead?", check `status > MOUNTED` instead.
+- `isDestroyed(): boolean` — true once the scope is destroyed (all cleanup
+  has run).
 - `onDestroy(cb: () => void): void` — registers a destroy callback. If the
   scope is already destroyed, calls the callback immediately.
-- `cancel(): void` — marks the scope as `CANCELLED` and aborts its abort
-  signal. Used internally when a component is abandoned before mount.
 - `run<Args, T>(fn: (...args: Args) => T, ...args: Args): T` — pushes the
   scope for the duration of `fn`, forwarding any extra arguments to it.
   Throws an `OwlError` up front if the scope is already dead. If `fn` returns

--- a/packages/owl-core/src/scope.ts
+++ b/packages/owl-core/src/scope.ts
@@ -110,11 +110,9 @@ export abstract class Scope {
   }
 
   /**
-   * Returns true once the scope has been fully destroyed, i.e. `finalize` has
-   * run: the abort signal is aborted, onDestroy callbacks have executed and
-   * computations are disposed. Note that a CANCELLED scope (abandoned before
-   * mount, but not yet finalized) is dead but not destroyed — to ask "is this
-   * scope dead?", check `status > STATUS.MOUNTED` instead.
+   * Returns true once the scope has been destroyed, i.e. `finalize` has run:
+   * the abort signal is aborted, onDestroy callbacks have executed and
+   * computations are disposed.
    */
   isDestroyed(): boolean {
     return this.status >= STATUS.DESTROYED;
@@ -130,19 +128,6 @@ export abstract class Scope {
       return;
     }
     (this._destroyCbs ??= []).push(cb);
-  }
-
-  /**
-   * Marks the scope as cancelled and aborts its signal. Used when an entity is
-   * abandoned before it reaches the MOUNTED state. Subclasses may override to
-   * extend the behavior (e.g. ComponentNode recurses to children).
-   */
-  cancel(): void {
-    if (this.status > STATUS.MOUNTED) {
-      return;
-    }
-    this.status = STATUS.CANCELLED;
-    this._controller?.abort();
   }
 
   /**

--- a/packages/owl-core/src/status.ts
+++ b/packages/owl-core/src/status.ts
@@ -5,9 +5,6 @@
 export const STATUS = {
   NEW: 0,
   MOUNTED: 1, // is ready, and in DOM. It has a valid el
-  // component has been created, but has been replaced by a newer component before being mounted
-  // it is cancelled until the next animation frame where it will be destroyed
-  CANCELLED: 2,
-  DESTROYED: 3,
+  DESTROYED: 2,
 } as const;
 export type StatusValue = (typeof STATUS)[keyof typeof STATUS];

--- a/packages/owl-runtime/src/app.ts
+++ b/packages/owl-runtime/src/app.ts
@@ -229,7 +229,6 @@ export class App extends TemplateSet {
       destroy: () => {
         this.roots.delete(root);
         node?.destroy();
-        this.scheduler.processCancelledNodes();
       },
     };
     this.roots.add(root);
@@ -241,7 +240,6 @@ export class App extends TemplateSet {
       root.destroy();
     }
     this.pluginManager.destroy();
-    this.scheduler.processCancelledNodes();
     this.scheduler.tasks.clear();
     this.scheduler.delayedRenders = [];
     apps.delete(this);

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -131,7 +131,7 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
   }
 
   async render(deep: boolean) {
-    if (this.status >= STATUS.CANCELLED) {
+    if (this.status >= STATUS.DESTROYED) {
       return;
     }
     let current = this.fiber;
@@ -160,7 +160,7 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
 
     this.app.scheduler.addFiber(fiber);
     await Promise.resolve();
-    if (this.status >= STATUS.CANCELLED) {
+    if (this.status >= STATUS.DESTROYED) {
       return;
     }
     // We only want to actually render the component if the following two
@@ -180,17 +180,8 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
   }
 
   cancel() {
-    this._cancel();
     delete this.parent!.children[this.parentKey!];
-    this.app.scheduler.scheduleDestroy(this);
-  }
-
-  _cancel() {
-    super.cancel();
-    const children = this.children;
-    for (let childKey in children) {
-      children[childKey]._cancel();
-    }
+    this._destroy();
   }
 
   destroy() {

--- a/packages/owl-runtime/src/rendering/scheduler.ts
+++ b/packages/owl-runtime/src/rendering/scheduler.ts
@@ -1,4 +1,3 @@
-import type { ComponentNode } from "../component_node";
 import { fibersInError } from "./error_handling";
 import { Fiber, RootFiber } from "./fibers";
 import { STATUS } from "../status";
@@ -20,7 +19,6 @@ export class Scheduler {
   requestAnimationFrame: Window["requestAnimationFrame"];
   frame: number = 0;
   delayedRenders: Fiber[] = [];
-  cancelledNodes: Set<ComponentNode> = new Set();
   processing = false;
 
   constructor() {
@@ -30,13 +28,6 @@ export class Scheduler {
 
   addFiber(fiber: Fiber) {
     this.tasks.add(fiber.root!);
-  }
-
-  scheduleDestroy(node: ComponentNode) {
-    this.cancelledNodes.add(node);
-    if (this.frame === 0) {
-      this.frame = this.requestAnimationFrame(this.processTasks);
-    }
   }
 
   /**
@@ -65,7 +56,6 @@ export class Scheduler {
     }
     this.processing = true;
     this.frame = 0;
-    this.processCancelledNodes();
     for (let fiber of this.tasks) {
       if (fiber.root !== fiber) {
         this.tasks.delete(fiber);
@@ -100,17 +90,5 @@ export class Scheduler {
       }
     }
     this.processing = false;
-  }
-
-  processCancelledNodes() {
-    for (let node of this.cancelledNodes) {
-      node._destroy();
-    }
-    this.cancelledNodes.clear();
-    for (let task of this.tasks) {
-      if (task.node.status === STATUS.DESTROYED) {
-        this.tasks.delete(task);
-      }
-    }
   }
 }

--- a/packages/owl-runtime/src/status.ts
+++ b/packages/owl-runtime/src/status.ts
@@ -3,14 +3,12 @@ import { Plugin, STATUS } from "@odoo/owl-core";
 
 export { STATUS } from "@odoo/owl-core";
 
-type STATUS_DESCR = "new" | "started" | "mounted" | "cancelled" | "destroyed";
+type STATUS_DESCR = "new" | "started" | "mounted" | "destroyed";
 
 export function status(entity: Component | Plugin): STATUS_DESCR {
   switch (entity.__owl__.status) {
     case STATUS.NEW:
       return "new";
-    case STATUS.CANCELLED:
-      return "cancelled";
     case STATUS.MOUNTED:
       return entity instanceof Plugin ? "started" : "mounted";
     case STATUS.DESTROYED:

--- a/packages/owl-runtime/tests/app/__snapshots__/app.test.ts.snap
+++ b/packages/owl-runtime/tests/app/__snapshots__/app.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`app > app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 1`] = `
+exports[`app > app: clear scheduler tasks on destroy 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
@@ -18,7 +18,7 @@ exports[`app > app: clear scheduler tasks and destroy cancelled nodes immediatel
 }"
 `;
 
-exports[`app > app: clear scheduler tasks and destroy cancelled nodes immediately on destroy 3`] = `
+exports[`app > app: clear scheduler tasks on destroy 3`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;

--- a/packages/owl-runtime/tests/app/app.test.ts
+++ b/packages/owl-runtime/tests/app/app.test.ts
@@ -66,7 +66,7 @@ describe("app", () => {
     expect(status(comp)).toBe("destroyed");
   });
 
-  test("app: clear scheduler tasks and destroy cancelled nodes immediately on destroy", async () => {
+  test("app: clear scheduler tasks on destroy", async () => {
     let def = makeDeferred();
     class B extends Component {
       static template = xml`B`;
@@ -103,11 +103,12 @@ describe("app", () => {
       ]
     `);
 
-    // rerender to force the instantiation of a new B component (and cancelling the first)
+    // rerender to force the instantiation of a new B component (destroying the first)
     render(comp);
     await nextMicroTick();
     expect(steps.splice(0)).toMatchInlineSnapshot(`
       [
+        "B:willDestroy",
         "B:setup",
         "B:willStart",
       ]
@@ -119,7 +120,6 @@ describe("app", () => {
         "A:willUnmount",
         "B:willDestroy",
         "A:willDestroy",
-        "B:willDestroy",
       ]
     `);
   });

--- a/packages/owl-runtime/tests/components/__snapshots__/concurrency.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/concurrency.test.ts.snap
@@ -164,6 +164,50 @@ exports[`calling render in destroy 3`] = `
 }"
 `;
 
+exports[`cancelled components are destroyed immediately 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`B\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    b2 = text(\`A\`);
+    if (ctx['this'].state.flag) {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`cancelled components are destroyed immediately 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`C\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = text(\`B\`);
+    const b3 = comp1({}, key + \`__1\`, node, this, null);
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`cancelled components are destroyed immediately 5`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  return function template(ctx, node, key = "") {
+    return text(\`C\`);
+  }
+}"
+`;
+
 exports[`change state and call manually render: no unnecessary rendering 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
@@ -251,50 +295,6 @@ exports[`component destroyed just after render 2`] = `
     const b2 = text(\`B\`);
     const b3 = safeOutput(ctx['this'].state.value);
     return multi([b2, b3]);
-  }
-}"
-`;
-
-exports[`components are not destroyed between animation frame 1`] = `
-"function anonymous(app, bdom, helpers
-) {
-  let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { createComponent } = helpers;
-  const comp1 = createComponent(app, \`B\`, true, false, false, []);
-  
-  return function template(ctx, node, key = "") {
-    let b2, b3;
-    b2 = text(\`A\`);
-    if (ctx['this'].state.flag) {
-      b3 = comp1({}, key + \`__1\`, node, this, null);
-    }
-    return multi([b2, b3]);
-  }
-}"
-`;
-
-exports[`components are not destroyed between animation frame 3`] = `
-"function anonymous(app, bdom, helpers
-) {
-  let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { createComponent } = helpers;
-  const comp1 = createComponent(app, \`C\`, true, false, false, []);
-  
-  return function template(ctx, node, key = "") {
-    const b2 = text(\`B\`);
-    const b3 = comp1({}, key + \`__1\`, node, this, null);
-    return multi([b2, b3]);
-  }
-}"
-`;
-
-exports[`components are not destroyed between animation frame 5`] = `
-"function anonymous(app, bdom, helpers
-) {
-  let { text, createBlock, list, multi, html, toggler } = bdom;
-  
-  return function template(ctx, node, key = "") {
-    return text(\`C\`);
   }
 }"
 `;

--- a/packages/owl-runtime/tests/components/concurrency.test.ts
+++ b/packages/owl-runtime/tests/components/concurrency.test.ts
@@ -137,6 +137,7 @@ test("destroying/recreating a subwidget with different props (if start is not ov
 
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "Child:willDestroy",
       "Child:setup",
       "Child:willStart",
     ]
@@ -148,7 +149,6 @@ test("destroying/recreating a subwidget with different props (if start is not ov
   expect(Object.values(w.__owl__.children).length).toBe(1);
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
-      "Child:willDestroy",
       "W:willPatch",
       "Child:mounted",
       "W:patched",
@@ -197,9 +197,9 @@ test("destroying/recreating a subcomponent, other scenario", async () => {
     [
       "Child:setup",
       "Child:willStart",
+      "Child:willDestroy",
       "Child:setup",
       "Child:willStart",
-      "Child:willDestroy",
       "Parent:willPatch",
       "Child:mounted",
       "Parent:patched",
@@ -273,11 +273,11 @@ test("creating two async components, scenario 1", async () => {
   expect(fixture.innerHTML).toBe("");
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "ChildA:willDestroy",
       "ChildA:setup",
       "ChildA:willStart",
       "ChildB:setup",
       "ChildB:willStart",
-      "ChildA:willDestroy",
     ]
   `);
 
@@ -745,9 +745,9 @@ test("rendering component again in next microtick", async () => {
     [
       "Child:setup",
       "Child:willStart",
+      "Child:willDestroy",
       "Child:setup",
       "Child:willStart",
-      "Child:willDestroy",
       "Parent:willPatch",
       "Child:mounted",
       "Parent:patched",
@@ -1735,8 +1735,8 @@ test("concurrent renderings scenario 10", async () => {
   expect(fixture.innerHTML).toBe("<div><p></p></div>");
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
-      "ComponentB:willUpdateProps",
       "ComponentC:willDestroy",
+      "ComponentB:willUpdateProps",
     ]
   `);
 
@@ -2268,10 +2268,10 @@ test("concurrent renderings scenario 16", async () => {
     [
       "D:setup",
       "D:willStart",
+      "D:willDestroy",
       "C:willUpdateProps",
       "D:setup",
       "D:willStart",
-      "D:willDestroy",
     ]
   `);
 
@@ -2982,9 +2982,9 @@ test("t-key on dom node having a component", async () => {
   expect(fixture.innerHTML).toBe("<div>3</div>");
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "Child (2):willDestroy",
       "Child (3):setup",
       "Child (3):willStart",
-      "Child (2):willDestroy",
       "Child (1):willUnmount",
       "Child (1):willDestroy",
       "Child (3):mounted",
@@ -3041,9 +3041,9 @@ test("t-key on dynamic async component (toggler is never patched)", async () => 
   expect(fixture.innerHTML).toBe("<div>3</div>");
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "Child (2):willDestroy",
       "Child (3):setup",
       "Child (3):willStart",
-      "Child (2):willDestroy",
       "Child (1):willUnmount",
       "Child (1):willDestroy",
       "Child (3):mounted",
@@ -3101,9 +3101,9 @@ test("t-foreach with dynamic async component", async () => {
   expect(fixture.innerHTML).toBe("<div>3</div>");
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "Child (2):willDestroy",
       "Child (3):setup",
       "Child (3):willStart",
-      "Child (2):willDestroy",
       "Child (1):willUnmount",
       "Child (1):willDestroy",
       "Child (3):mounted",
@@ -3824,12 +3824,12 @@ test("destroyed component causes other soon to be destroyed component to rerende
   await nextTick();
   expect(steps.splice(0)).toMatchInlineSnapshot(`
     [
+      "B:willDestroy",
+      "C:willDestroy",
       "B:setup",
       "B:willStart",
       "C:setup",
       "C:willStart",
-      "B:willDestroy",
-      "C:willDestroy",
       "A:willPatch",
       "C:mounted",
       "B:mounted",
@@ -4175,7 +4175,7 @@ test.skip("delayed render is not cancelled by upcoming render", async () => {
   `);
 });
 
-test("components are not destroyed between animation frame", async () => {
+test("cancelled components are destroyed immediately", async () => {
   const def = makeDeferred();
   class C extends Component {
     static template = xml`C`;
@@ -4224,14 +4224,10 @@ test("components are not destroyed between animation frame", async () => {
 
   // force a render of A
   //  => owl will need to create a new B component
-  //  => initial B component will be cancelled
+  //  => initial B component will be cancelled, and destroyed on the spot
   render(a);
   await nextMicroTick();
-  expect([
-    // note that B is not destroyed here. It is cancelled instead
-    "B:setup",
-    "B:willStart",
-  ]).toBeLogged();
+  expect(["B:willDestroy", "B:setup", "B:willStart"]).toBeLogged();
 
   // resolve def, so B render is unblocked
   def.resolve();
@@ -4240,7 +4236,6 @@ test("components are not destroyed between animation frame", async () => {
     [
       "C:setup",
       "C:willStart",
-      "B:willDestroy",
       "A:willPatch",
       "C:mounted",
       "B:mounted",

--- a/packages/owl-runtime/tests/components/error_handling.test.ts
+++ b/packages/owl-runtime/tests/components/error_handling.test.ts
@@ -1652,12 +1652,6 @@ describe("can catch errors", () => {
     expect(steps.splice(0)).toMatchInlineSnapshot(`
       [
         "Child:willDestroy",
-      ]
-    `);
-    expect(fixture.innerHTML).toBe("1");
-    await nextTick();
-    expect(steps.splice(0)).toMatchInlineSnapshot(`
-      [
         "Parent:willPatch",
         "Parent:patched",
       ]


### PR DESCRIPTION
A component abandoned before mount (replaced by a newer rendering) was marked CANCELLED immediately, but only finalized on the next animation frame through a dedicated scheduler.cancelledNodes set. The intermediate status existed solely to bridge that gap and served no real purpose.

ComponentNode.cancel() now detaches the node from its parent and calls _destroy() on the spot, so scopes go straight from NEW (or MOUNTED) to DESTROYED:

- STATUS.CANCELLED is removed (DESTROYED is now 2) and Scope.cancel is deleted; a scope can no longer be dead but not yet destroyed
- the scheduler loses cancelledNodes/scheduleDestroy/ processCancelledNodes, and App.destroy no longer needs to flush them
- the status() helper no longer reports "cancelled"

Observable consequence: willDestroy of a cancelled component fires at cancellation time, during the parent render that replaces it (before the replacement's setup), instead of one frame later. The re-entrancy guards around cancelFibers (root fiber lock, microtask deferral in render) protect against user code running in those callbacks.