### PR TITLE
[IMP] owl-core: add useOnChange hook

### DIFF
--- a/doc/v3/owl/reference/hooks.md
+++ b/doc/v3/owl/reference/hooks.md
@@ -130,8 +130,9 @@ useOnChange(dependencies, callback, options);
 ```
 
 - `dependencies` is a function returning an array of values. It is the tracked
-  part of the hook: the callback runs again whenever a reactive value read here
-  changes.
+  part of the hook: it runs again whenever a reactive value read here changes.
+  The resulting array is compared with the previous one (element by element),
+  and the callback only runs if it actually changed.
 - `callback` receives the dependencies as its arguments. Like an effect
   callback, it may return a cleanup function, which is then called before the
   next run and when the component is destroyed.
@@ -158,8 +159,24 @@ class RecordViewer extends Component {
 }
 ```
 
-This is mostly useful when the callback also needs to read reactive values that
-should _not_ trigger it. Otherwise, a plain `useEffect` is simpler:
+Because the dependency array is compared by value, a dependency computed from
+reactive values only triggers the callback when its own result changes:
+
+```js
+useOnChange(
+  () => [this.count() > 10],
+  (isBig) => console.log("isBig", isBig)
+);
+```
+
+Here `this.count()` going from 2 to 3 does not run the callback: the dependency
+is still `false`. A `useEffect` reading `this.count() > 10` would re-run on
+every change of `count`.
+
+So `useOnChange` is useful when the callback needs to read reactive values that
+should _not_ trigger it, and when the dependencies are derived values. When the
+dependencies are read directly and the callback needs nothing else, a plain
+`useEffect` is simpler:
 
 ```js
 // these are equivalent

--- a/doc/v3/owl/reference/hooks.md
+++ b/doc/v3/owl/reference/hooks.md
@@ -118,6 +118,58 @@ class SomeComponent extends Component {
 }
 ```
 
+### `useOnChange`
+
+The `useOnChange` hook runs a callback whenever one of the values returned by a
+dependency function changes. Contrary to [`useEffect`](#useeffect), only the
+dependency function is tracked: reactive values read (or written) inside the
+callback do not become dependencies, so the callback cannot retrigger itself.
+
+```js
+useOnChange(dependencies, callback, options);
+```
+
+- `dependencies` is a function returning an array of values. It is the tracked
+  part of the hook: the callback runs again whenever a reactive value read here
+  changes.
+- `callback` receives the dependencies as its arguments. Like an effect
+  callback, it may return a cleanup function, which is then called before the
+  next run and when the component is destroyed.
+- `options.initialRun` (default: `true`): if `false`, the callback does not run
+  on the initial execution, only on subsequent changes.
+
+```js
+class RecordViewer extends Component {
+  static template = xml`<div t-out="this.record().name"/>`;
+
+  props = props({ recordId: t.number() });
+  record = signal(null);
+
+  setup() {
+    useOnChange(
+      () => [this.props.recordId],
+      (recordId) => {
+        // reading/writing this.record here does not make it a dependency
+        this.record.set(null);
+        loadRecord(recordId).then((record) => this.record.set(record));
+      }
+    );
+  }
+}
+```
+
+This is mostly useful when the callback also needs to read reactive values that
+should _not_ trigger it. Otherwise, a plain `useEffect` is simpler:
+
+```js
+// these are equivalent
+useOnChange(
+  () => [this.value()],
+  (value) => console.log(value)
+);
+useEffect(() => console.log(this.value()));
+```
+
 ### `useListener`
 
 The `useListener` hook adds an event listener to a target and automatically

--- a/doc/v3/owl/reference/overview.md
+++ b/doc/v3/owl/reference/overview.md
@@ -39,6 +39,7 @@ Here is a list of everything exported by the Owl library.
 ## Other Hooks
 
 - [`useEffect`](hooks.md#useeffect): create a reactive effect, cleaned up on destroy
+- [`useOnChange`](hooks.md#useonchange): run a callback when some dependencies change
 - [`useListener`](hooks.md#uselistener): add a listener to a target, removed on destroy
 - [`useApp`](hooks.md#useapp): get the current App instance
 - [`useScope`](scope.md): get the current scope (for async cancellation, captured execution)

--- a/doc/v3/owl/reference/plugins.md
+++ b/doc/v3/owl/reference/plugins.md
@@ -375,8 +375,8 @@ class WebSocketPlugin extends Plugin {
 }
 ```
 
-The `useListener()` and `useEffect()` hooks also work inside plugins, with
-automatic cleanup on destroy:
+The `useListener()`, `useEffect()` and `useOnChange()` hooks also work inside
+plugins, with automatic cleanup on destroy:
 
 ```js
 class KeyboardPlugin extends Plugin {

--- a/packages/owl-core/src/hooks.ts
+++ b/packages/owl-core/src/hooks.ts
@@ -1,3 +1,4 @@
+import { untrack } from "./computations";
 import { effect } from "./effect";
 import { onWillDestroy } from "./lifecycle_hooks";
 import { useScope } from "./scope";
@@ -17,6 +18,62 @@ import { Signal } from "./signal";
  */
 export function useEffect(fn: Parameters<typeof effect>[0]): void {
   onWillDestroy(effect(fn));
+}
+
+// -----------------------------------------------------------------------------
+// useOnChange
+// -----------------------------------------------------------------------------
+
+type Cleanup = (() => void) | void;
+
+/**
+ * Identity mapped type over a tuple. It keeps the type of each position when
+ * `callback` is contextually typed, while preventing typescript from inferring
+ * the dependency tuple from `callback`'s own (possibly shorter) parameter list.
+ */
+type Args<T extends unknown[]> = { [K in keyof T]: T[K] };
+
+/**
+ * Runs `callback` whenever one of the reactive values read by `dependencies`
+ * changes. Contrary to `useEffect`, only the `dependencies` function is
+ * tracked: reactive values read inside `callback` do not become dependencies,
+ * so the callback cannot retrigger itself.
+ *
+ * `dependencies` must return an array of values, which are spread as the
+ * arguments of `callback`. As with `useEffect`, if `callback` returns a
+ * function, that function is called as cleanup before the next run and when
+ * the owning scope is destroyed.
+ *
+ * By default the callback also runs on the initial execution. Pass
+ * `{ initialRun: false }` to only react to subsequent changes.
+ *
+ * Example — refetch a record whenever its id changes, without subscribing to
+ * everything `loadRecord` happens to read:
+ *   useOnChange(
+ *     () => [this.props.recordId],
+ *     (recordId) => {
+ *       this.loadRecord(recordId);
+ *     }
+ *   );
+ */
+export function useOnChange<T extends unknown[]>(
+  // the variadic tuple `[...T]` (instead of a plain `T`) makes typescript infer
+  // a tuple from the returned array literal, so each argument of `callback`
+  // keeps its own type
+  dependencies: () => [...T],
+  callback: (...args: Args<T>) => Cleanup,
+  { initialRun = true }: { initialRun?: boolean } = {}
+): void {
+  let skipRun = !initialRun;
+  useEffect(() => {
+    // Reading the dependencies is the only tracked part of this effect.
+    const deps = dependencies();
+    if (skipRun) {
+      skipRun = false;
+      return;
+    }
+    return untrack(() => callback(...deps));
+  });
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/owl-core/src/hooks.ts
+++ b/packages/owl-core/src/hooks.ts
@@ -1,8 +1,10 @@
+import { computed } from "./computed";
 import { untrack } from "./computations";
 import { effect } from "./effect";
 import { onWillDestroy } from "./lifecycle_hooks";
 import { useScope } from "./scope";
 import { Signal } from "./signal";
+import { shallowEqual } from "./utils";
 
 // -----------------------------------------------------------------------------
 // useEffect
@@ -34,10 +36,14 @@ type Cleanup = (() => void) | void;
 type Args<T extends unknown[]> = { [K in keyof T]: T[K] };
 
 /**
- * Runs `callback` whenever one of the reactive values read by `dependencies`
- * changes. Contrary to `useEffect`, only the `dependencies` function is
- * tracked: reactive values read inside `callback` do not become dependencies,
- * so the callback cannot retrigger itself.
+ * Runs `callback` whenever the array returned by `dependencies` changes.
+ * Contrary to `useEffect`, only the `dependencies` function is tracked:
+ * reactive values read inside `callback` do not become dependencies, so the
+ * callback cannot retrigger itself.
+ *
+ * The dependency array is compared with `shallowEqual`, so `callback` only
+ * runs when one of the values it receives actually changed: with
+ * `() => [count() > 10]`, `count` going from 2 to 3 does not run it.
  *
  * `dependencies` must return an array of values, which are spread as the
  * arguments of `callback`. As with `useEffect`, if `callback` returns a
@@ -64,15 +70,19 @@ export function useOnChange<T extends unknown[]>(
   callback: (...args: Args<T>) => Cleanup,
   { initialRun = true }: { initialRun?: boolean } = {}
 ): void {
+  // `dependencies` re-runs whenever any reactive value it reads changes, but
+  // the structural equality discards a result equal to the previous one, so the
+  // effect below is not notified when the dependency values are unchanged.
+  const deps = computed(dependencies, { equals: shallowEqual });
   let skipRun = !initialRun;
   useEffect(() => {
     // Reading the dependencies is the only tracked part of this effect.
-    const deps = dependencies();
+    const args = deps();
     if (skipRun) {
       skipRun = false;
       return;
     }
-    return untrack(() => callback(...deps));
+    return untrack(() => callback(...args));
   });
 }
 

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -110,6 +110,7 @@ export {
   useApp,
   useEffect,
   useListener,
+  useOnChange,
 } from "./hooks";
 
 export {

--- a/packages/owl-runtime/src/hooks.ts
+++ b/packages/owl-runtime/src/hooks.ts
@@ -1,6 +1,6 @@
 import { App } from "./app";
 import { useApp as useCoreApp } from "@odoo/owl-core";
 
-export { useEffect, useListener } from "@odoo/owl-core";
+export { useEffect, useListener, useOnChange } from "@odoo/owl-core";
 
 export const useApp: () => App = useCoreApp;

--- a/packages/owl-runtime/src/index.ts
+++ b/packages/owl-runtime/src/index.ts
@@ -64,7 +64,7 @@ export {
   type ReactiveValue,
   type Signal,
 } from "@odoo/owl-core";
-export { useEffect, useListener, useApp } from "./hooks";
+export { useEffect, useListener, useOnChange, useApp } from "./hooks";
 export { batched, EventBus, htmlEscape, shallowEqual, whenReady, markup } from "./utils";
 export {
   onWillStart,

--- a/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
@@ -271,6 +271,19 @@ exports[`hooks > useListener work with references 1`] = `
 }"
 `;
 
+exports[`hooks > useOnChange hook > callback does not run if the dependency values are unchanged 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
 exports[`hooks > useOnChange hook > callback receives each dependency as an argument 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
@@ -270,3 +270,55 @@ exports[`hooks > useListener work with references 1`] = `
   }
 }"
 `;
+
+exports[`hooks > useOnChange hook > callback receives each dependency as an argument 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useOnChange hook > callback runs on mount, on dependency change and is cleaned up 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useOnChange hook > does not run the callback on mount with initialRun=false 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useOnChange hook > reactive values read in the callback are not dependencies 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;

--- a/packages/owl-runtime/tests/components/hooks.test.ts
+++ b/packages/owl-runtime/tests/components/hooks.test.ts
@@ -14,6 +14,7 @@ import {
   signal,
   useEffect,
   useListener,
+  useOnChange,
   xml,
 } from "../../src";
 import {
@@ -536,6 +537,115 @@ describe("hooks", () => {
       }
       expect(error!.message).toBe("Intentional error");
       expect(getConsoleOutput()).toEqual([]);
+    });
+  });
+
+  describe("useOnChange hook", () => {
+    test("callback runs on mount, on dependency change and is cleaned up", async () => {
+      class MyComponent extends Component {
+        static template = xml`<div/>`;
+        state = proxy({ value: 0 });
+        setup() {
+          useOnChange(
+            () => [this.state.value],
+            (value) => {
+              logStep(`value is ${value}`);
+              return () => logStep(`cleaning up for ${value}`);
+            }
+          );
+        }
+      }
+
+      const component = await mount(MyComponent, fixture);
+      expect(["value is 0"]).toBeLogged();
+
+      component.state.value++;
+      await nextTick();
+      expect(["cleaning up for 0", "value is 1"]).toBeLogged();
+
+      await component.__owl__.destroy();
+      expect(["cleaning up for 1"]).toBeLogged();
+    });
+
+    test("does not run the callback on mount with initialRun=false", async () => {
+      class MyComponent extends Component {
+        static template = xml`<div/>`;
+        value = signal(0);
+        setup() {
+          useOnChange(
+            () => [this.value()],
+            (value) => {
+              logStep(`value is ${value}`);
+              return () => logStep(`cleaning up for ${value}`);
+            },
+            { initialRun: false }
+          );
+        }
+      }
+
+      const component = await mount(MyComponent, fixture);
+      expect([]).toBeLogged();
+
+      component.value.set(1);
+      await nextTick();
+      expect(["value is 1"]).toBeLogged();
+
+      component.value.set(2);
+      await nextTick();
+      expect(["cleaning up for 1", "value is 2"]).toBeLogged();
+
+      await component.__owl__.destroy();
+      expect(["cleaning up for 2"]).toBeLogged();
+    });
+
+    test("reactive values read in the callback are not dependencies", async () => {
+      class MyComponent extends Component {
+        static template = xml`<div/>`;
+        a = signal(0);
+        b = signal(0);
+        setup() {
+          useOnChange(
+            () => [this.a()],
+            (a) => {
+              // reading b here should not subscribe the callback to it
+              logStep(`a=${a}, b=${this.b()}`);
+              // ... and writing to b should not retrigger it either
+              this.b.set(this.b() + 1);
+            }
+          );
+        }
+      }
+
+      const component = await mount(MyComponent, fixture);
+      expect(["a=0, b=0"]).toBeLogged();
+
+      component.b.set(10);
+      await nextTick();
+      expect([]).toBeLogged();
+
+      component.a.set(1);
+      await nextTick();
+      expect(["a=1, b=10"]).toBeLogged();
+    });
+
+    test("callback receives each dependency as an argument", async () => {
+      class MyComponent extends Component {
+        static template = xml`<div/>`;
+        state = proxy({ a: 1, b: "x" });
+        setup() {
+          useOnChange(
+            () => [this.state.a, this.state.b],
+            (a, b) => logStep(`${a.toFixed(1)}/${b.toUpperCase()}`)
+          );
+        }
+      }
+
+      const component = await mount(MyComponent, fixture);
+      expect(["1.0/X"]).toBeLogged();
+
+      component.state.b = "y";
+      await nextTick();
+      expect(["1.0/Y"]).toBeLogged();
     });
   });
 });

--- a/packages/owl-runtime/tests/components/hooks.test.ts
+++ b/packages/owl-runtime/tests/components/hooks.test.ts
@@ -628,6 +628,43 @@ describe("hooks", () => {
       expect(["a=1, b=10"]).toBeLogged();
     });
 
+    test("callback does not run if the dependency values are unchanged", async () => {
+      class MyComponent extends Component {
+        static template = xml`<div/>`;
+        count = signal(0);
+        setup() {
+          useOnChange(
+            () => [this.count() > 10],
+            (isBig) => {
+              logStep(`isBig=${isBig}`);
+              return () => logStep(`cleaning up for isBig=${isBig}`);
+            }
+          );
+        }
+      }
+
+      const component = await mount(MyComponent, fixture);
+      expect(["isBig=false"]).toBeLogged();
+
+      // count changed, but the dependency value did not
+      component.count.set(2);
+      await nextTick();
+      expect([]).toBeLogged();
+
+      component.count.set(3);
+      await nextTick();
+      expect([]).toBeLogged();
+
+      // the dependency value now changes
+      component.count.set(11);
+      await nextTick();
+      expect(["cleaning up for isBig=false", "isBig=true"]).toBeLogged();
+
+      component.count.set(12);
+      await nextTick();
+      expect([]).toBeLogged();
+    });
+
     test("callback receives each dependency as an argument", async () => {
       class MyComponent extends Component {
         static template = xml`<div/>`;

--- a/packages/owl/tests/types_hooks.ts
+++ b/packages/owl/tests/types_hooks.ts
@@ -1,0 +1,72 @@
+// Compile-time checks for hook signatures. This file is only typechecked
+// (npm run test:types); it is not executed.
+import { signal, useOnChange } from "../src";
+
+type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+declare function assertEq<A, B>(...args: Eq<A, B> extends true ? [] : [never]): void;
+
+declare const count: ReturnType<typeof signal<number>>;
+declare const label: ReturnType<typeof signal<string>>;
+
+// each dependency keeps its own type, without needing `as const`
+useOnChange(
+  () => [count(), label()],
+  (c, l) => {
+    assertEq<typeof c, number>();
+    assertEq<typeof l, string>();
+  }
+);
+
+// the callback may declare fewer parameters than there are dependencies...
+useOnChange(
+  () => [count(), label()],
+  (c) => {
+    assertEq<typeof c, number>();
+  }
+);
+
+// ... or none at all
+useOnChange(
+  () => [count()],
+  () => {}
+);
+
+// the callback may return a cleanup function
+useOnChange(
+  () => [count()],
+  (c) => () => {
+    assertEq<typeof c, number>();
+  }
+);
+
+useOnChange(
+  () => [count()],
+  () => {},
+  { initialRun: false }
+);
+
+useOnChange(
+  () => [count()],
+  // @ts-expect-error the callback cannot declare more parameters than there are
+  // dependencies
+  (_c: number, _extra: string) => {}
+);
+
+useOnChange(
+  () => [count()],
+  // @ts-expect-error wrong dependency type
+  (_c: string) => {}
+);
+
+useOnChange(
+  // @ts-expect-error dependencies must return an array
+  () => count(),
+  () => {}
+);
+
+useOnChange(
+  () => [count()],
+  () => {},
+  // @ts-expect-error unknown option
+  { initial: false }
+);


### PR DESCRIPTION
`useEffect` tracks every reactive value read while it runs, which is inconvenient when the callback also needs to read (or write) reactive values that should not retrigger it.

This PR adds a `useOnChange(dependencies, callback, options)` hook: only `dependencies` is tracked, and its returned array is spread as the arguments of `callback`, which runs untracked.

```js
useOnChange(
  () => [this.props.recordId],
  (recordId) => {
    this.loadRecord(recordId);
  }
);
```

- as with `useEffect`, a function returned by the callback is used as cleanup (before the next run and on destroy)
- `options.initialRun` (default `true`) can be set to `false` to react only to subsequent changes
- works in components and in plugins, like the other hooks built on `useEffect`

### Notes on typing

Getting per-dependency argument types required some care. `dependencies: () => [...T]` (variadic tuple) is what makes TypeScript infer a tuple from the returned array literal, so mixed arrays don't collapse to a union and `as const` isn't needed. But typing the callback as `(...args: T)` turns it into an inference site as well, so a zero-parameter callback infers `T = []` and fails to compile; `NoInfer<T>` fixes that case but breaks callbacks declaring only a prefix of the dependencies, and an overload pair loses contextual typing entirely.

The identity mapped type `Args<T> = { [K in keyof T]: T[K] }` handles every arity: it still expands per position for contextual typing, but does not let the callback's parameter list drive inference. Both tricks are commented in the source, and `packages/owl/tests/types_hooks.ts` locks the behaviour in with compile-time checks (full arity, partial arity, no arity, and the cases that must fail).

### Tests

Behavioural tests in `hooks.test.ts` cover the run-on-mount/change/cleanup sequence, `initialRun: false`, and the fact that reads *and* writes performed inside the callback do not retrigger it.

Docs: new `useOnChange` section in the hooks reference, plus entries in the reference overview and the plugins page.