### PR TITLE
[IMP] owl-core: add clear method on Resource and Registry

### DIFF
--- a/doc/v3/owl/reference/registries.md
+++ b/doc/v3/owl/reference/registries.md
@@ -117,11 +117,22 @@ setup() {
 
 ### `delete(key)`
 
-Removes an entry by key. Returns `void` (not chainable — unlike
-`Resource.delete`).
+Removes an entry by key. Returns the registry for chaining.
 
 ```js
 views.delete("form");
+views.delete("list").delete("kanban");
+```
+
+### `clear()`
+
+Removes every entry. Returns `void` (not chainable, since there is nothing left
+to operate on). Entries added with `use()` are removed as well: their scope
+cleanup becomes a no-op, so nothing comes back when the component or plugin is
+destroyed.
+
+```js
+views.clear();
 ```
 
 ### `has(key)`
@@ -200,7 +211,8 @@ See [Types & Validation](types_validation.md) for the full schema syntax.
 | `use(key, value, { sequence?, force? })` | Add for the lifetime of the current component/plugin. Chainable. Throws outside a context, or on duplicate key unless `force: true`. |
 | `useById(item, { sequence?, force? })`   | Scoped variant of `addById`. Chainable.                                                                                              |
 | `get(key, defaultValue?)`                | Look up by key. Throws `OwlError` if missing and no default.                                                                         |
-| `delete(key)`                            | Remove. Returns `void`.                                                                                                              |
+| `delete(key)`                            | Remove. Chainable.                                                                                                                   |
+| `clear()`                                | Remove every entry. Returns `void`.                                                                                                  |
 | `has(key)`                               | Test key presence.                                                                                                                   |
 | `items()`                                | Reactive computed returning values sorted by sequence.                                                                               |
 | `entries()`                              | Reactive computed returning `[key, value]` tuples sorted by sequence.                                                                |

--- a/doc/v3/owl/reference/resources.md
+++ b/doc/v3/owl/reference/resources.md
@@ -86,6 +86,17 @@ commands.delete(item);
 commands.delete(a).delete(b);
 ```
 
+### `clear()`
+
+Removes every item. Returns `void` (not chainable, since there is nothing left
+to operate on). Items added with `use()` are removed as well: their scope
+cleanup becomes a no-op, so nothing comes back when the component or plugin is
+destroyed.
+
+```js
+commands.clear();
+```
+
 ### `has(item)`
 
 Returns `true` if the resource contains the given item (reference equality).
@@ -155,5 +166,6 @@ See [Types & Validation](types_validation.md) for the full schema syntax.
 | `add(item, { sequence? })`             | Add permanently. Chainable.                                                                |
 | `use(item, { sequence? })`             | Add for the lifetime of the current component/plugin. Chainable. Throws outside a context. |
 | `delete(item)`                         | Remove by reference equality. Chainable.                                                   |
+| `clear()`                              | Remove every item. Returns `void`.                                                         |
 | `has(item)`                            | Test membership by reference equality.                                                     |
 | `items()`                              | Reactive computed returning items sorted by sequence.                                      |

--- a/packages/owl-core/src/registry.ts
+++ b/packages/owl-core/src/registry.ts
@@ -70,8 +70,13 @@ export class Registry<T> {
     return hasKey ? this._map()[key][1] : defaultValue!;
   }
 
-  delete(key: string) {
+  delete(key: string): Registry<T> {
     delete this._map()[key];
+    return this;
+  }
+
+  clear() {
+    this._map.set(Object.create(null));
   }
 
   has(key: string): boolean {

--- a/packages/owl-core/src/resource.ts
+++ b/packages/owl-core/src/resource.ts
@@ -48,6 +48,10 @@ export class Resource<T> {
     return this;
   }
 
+  clear() {
+    this._items.set([]);
+  }
+
   has(item: Item<T>): boolean {
     return this._items().some(([s, value]) => value === item);
   }

--- a/packages/owl-core/tests/registry.test.ts
+++ b/packages/owl-core/tests/registry.test.ts
@@ -25,6 +25,41 @@ describe("registry", () => {
     registry.add("key", "some value");
     expect(registry.get("key")).toBe("some value");
     registry.delete("key");
+    expect(registry.has("key")).toBe(false);
+  });
+
+  test("delete method returns the registry, so it is chainable", () => {
+    const registry = new Registry();
+
+    registry.add("a", 1).add("b", 2).add("c", 3);
+    registry.delete("a").delete("b");
+    expect(registry.items()).toEqual([3]);
+  });
+
+  test("can remove every value", () => {
+    const registry = new Registry();
+
+    registry.add("key", "some value").add("other", "value");
+    registry.clear();
+    expect(registry.has("key")).toBe(false);
+    expect(registry.has("other")).toBe(false);
+    expect(registry.items()).toEqual([]);
+    registry.add("key", "again");
+    expect(registry.get("key")).toBe("again");
+  });
+
+  test("clear notifies effects", async () => {
+    const registry: Registry<string> = new Registry();
+    registry.add("key", "a");
+    const steps: string[][] = [];
+
+    effect(() => {
+      steps.push(registry.items());
+    });
+    expect(steps).toEqual([["a"]]);
+    registry.clear();
+    await waitScheduler();
+    expect(steps).toEqual([["a"], []]);
   });
 
   test("set method returns the registry, so it is chainable", () => {

--- a/packages/owl-core/tests/resource.test.ts
+++ b/packages/owl-core/tests/resource.test.ts
@@ -33,6 +33,30 @@ test("can remove values", () => {
   expect(resource.items()).toEqual(["c"]);
 });
 
+test("can remove every value", () => {
+  const resource = new Resource();
+  resource.add("a").add("b");
+  resource.clear();
+  expect(resource.items()).toEqual([]);
+  expect(resource.has("a")).toBe(false);
+  resource.add("c");
+  expect(resource.items()).toEqual(["c"]);
+});
+
+test("clear notifies effects", async () => {
+  const resource: Resource<string> = new Resource();
+  resource.add("a");
+  const steps: string[][] = [];
+
+  effect(() => {
+    steps.push(resource.items());
+  });
+  expect(steps).toEqual([["a"]]);
+  resource.clear();
+  await waitScheduler();
+  expect(steps).toEqual([["a"], []]);
+});
+
 test("sequence", async () => {
   const resource = new Resource<string>({ name: "r" });
 


### PR DESCRIPTION
`Resource` and `Registry` could only be emptied one entry at a time. This PR adds a `clear` method on both.

```js
resource.add("a").add("b").clear();
resource.items(); // []

registry.add("form", View).clear();
registry.has("form"); // false
```

Each container is backed by a single signal, so `clear` replaces the underlying value: subscribers are notified once and `items()`/`entries()` recompute. Entries added through `use()` are removed as well — their scope cleanup is either guarded or a no-op filter, so nothing reappears when the component or plugin is destroyed.

`Resource.clear` is chainable and `Registry.clear` returns `void`, mirroring `delete` on each class.

Also documented in the Resource / Registry reference pages (new sections + API summary rows).