### PR TITLE
[FIX] owl-runtime: count render loop iterations per fiber

### DIFF
--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -15,7 +15,7 @@ import type { App } from "./app";
 import { BDom, VNode } from "./blockdom";
 import { Component, ComponentConstructor } from "./component";
 import { fibersInError, handleError } from "./rendering/error_handling";
-import { Fiber, makeRootFiber, MountFiber } from "./rendering/fibers";
+import { APPLIED_TO_DOM, Fiber, makeRootFiber, MountFiber } from "./rendering/fibers";
 import { STATUS } from "./status";
 
 // -----------------------------------------------------------------------------
@@ -275,7 +275,7 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
       }
       this.sweepRefs();
       sweepRemovedRefs();
-      this.fiber!.appliedToDom = true;
+      this.fiber!.renderState |= APPLIED_TO_DOM;
       this.fiber = null;
     }
   }
@@ -294,7 +294,7 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
     this.bdom = bdom;
     bdom.mount(parent, anchor);
     this.status = STATUS.MOUNTED;
-    this.fiber!.appliedToDom = true;
+    this.fiber!.renderState |= APPLIED_TO_DOM;
     this.children = this.fiber!.childrenMap;
     this.fiber = null;
   }
@@ -341,7 +341,7 @@ export class ComponentNode extends Scope implements VNode<ComponentNode> {
     }
     this.sweepRefs();
     sweepRemovedRefs();
-    fiber.appliedToDom = true;
+    fiber.renderState |= APPLIED_TO_DOM;
     this.fiber = null;
   }
 

--- a/packages/owl-runtime/src/rendering/fibers.ts
+++ b/packages/owl-runtime/src/rendering/fibers.ts
@@ -10,10 +10,14 @@ import type { ComponentNode } from "../component_node";
 import { STATUS } from "../status";
 import { fibersInError, handleError } from "./error_handling";
 
-// Max times a root fiber may be re-rendered before being committed to the DOM
+// Max times a given fiber may be recycled before being committed to the DOM
 // before we treat it as an infinite render loop. A healthy render commits after
 // ~1 pass; only a self-retriggering loop ever approaches this. See issue #1968.
 const MAX_RENDER_ITERATIONS = 1000;
+
+// Bit 0 of Fiber.renderState: whether the fiber's result was applied to the
+// DOM (the other bits hold the recycle count, see the renderState declaration).
+export const APPLIED_TO_DOM = 1;
 
 export function makeChildFiber(node: ComponentNode, parent: Fiber): Fiber {
   let current = node.fiber;
@@ -31,7 +35,10 @@ export function makeRootFiber(node: ComponentNode): Fiber {
     // This fiber is being re-rendered before it was ever committed to the DOM.
     // In a healthy app a fiber is committed (and node.fiber nulled) before the
     // next render, so this only climbs without bound in a render loop (#1968).
-    root.renderCount++;
+    // The count is per fiber, NOT on the root: under a long-lived uncommitted
+    // root, many sibling subtrees may legitimately re-render once each, and a
+    // shared counter would add those up and flag a loop where there is none.
+    current.renderState += 2; // bump the recycle count held in bits 1+
     // lock root fiber because canceling children fibers may destroy components,
     // which means any arbitrary code can be run in onWillDestroy, which may
     // trigger new renderings
@@ -44,7 +51,7 @@ export function makeRootFiber(node: ComponentNode): Fiber {
     if (fibersInError.has(current)) {
       fibersInError.delete(current);
       fibersInError.delete(root);
-      current.appliedToDom = false;
+      current.renderState &= ~APPLIED_TO_DOM;
       if (current instanceof RootFiber) {
         // it is possible that this fiber is a fiber that crashed while being
         // mounted, so the mounted list is possibly corrupted. We restore it to
@@ -112,7 +119,12 @@ export class Fiber {
   root: RootFiber | null; // A Fiber that has been replaced by another has no root
   parent: Fiber | null;
   children: Fiber[] = [];
-  appliedToDom = false;
+  // Packs the "applied to DOM" flag (bit 0, see APPLIED_TO_DOM) together with
+  // the number of times this uncommitted fiber has been recycled by
+  // makeRootFiber (bits 1 and up). The recycle count climbs without bound only
+  // in a render loop (#1968); it shares a slot with the flag so the many
+  // fibers that are never recycled don't pay for a dedicated field.
+  renderState = 0;
   deep: boolean = false;
   childrenMap: ComponentNode["children"] = {};
 
@@ -160,10 +172,10 @@ export class Fiber {
     if (root) {
       // Bail before touching the computation tracking pointer (below) so a
       // detected loop never leaves currentComputation pinned to a signalComputation
-      // that app.destroy is about to dispose. The root's own render runs right
-      // after makeRootFiber bumped renderCount and before any child render, so
-      // the reported component is always the looping root.
-      if (root.renderCount > MAX_RENDER_ITERATIONS) {
+      // that app.destroy is about to dispose. The looping node's own fiber is
+      // the one makeRootFiber keeps recycling, so the reported component is
+      // the one actually stuck in the loop.
+      if (this.renderState >> 1 > MAX_RENDER_ITERATIONS) {
         handleError({
           node,
           error: new OwlError(
@@ -199,9 +211,6 @@ export class Fiber {
 
 export class RootFiber extends Fiber {
   counter: number = 1;
-  // Number of times this (uncommitted) fiber has been recycled by makeRootFiber.
-  // Climbs without bound only in a render loop; see issue #1968.
-  renderCount = 0;
 
   // only add stuff in this if they have registered some hooks
   willPatch: Fiber[] = [];
@@ -239,7 +248,7 @@ export class RootFiber extends Fiber {
       // Step 4: calling all mounted lifecycle hooks
       while ((current = mountedFibers.pop())) {
         current = current;
-        if (current.appliedToDom) {
+        if (current.renderState & APPLIED_TO_DOM) {
           for (let cb of current.node.mounted) {
             cb();
           }
@@ -250,7 +259,7 @@ export class RootFiber extends Fiber {
       let patchedFibers = this.patched;
       while ((current = patchedFibers.pop())) {
         current = current;
-        if (current.appliedToDom) {
+        if (current.renderState & APPLIED_TO_DOM) {
           for (let cb of current.node.patched) {
             cb();
           }
@@ -314,7 +323,7 @@ export class MountFiber extends RootFiber {
       // Prepare-only: the render phase is done, but no target has been
       // supplied yet. Signal readiness and let the scheduler drop this
       // fiber from its tasks — commit() will run _mount() when called.
-      this.appliedToDom = true;
+      this.renderState |= APPLIED_TO_DOM;
       this.onPrepared?.();
     }
   }
@@ -359,10 +368,10 @@ export class MountFiber extends RootFiber {
       node.fiber = null;
 
       node.status = STATUS.MOUNTED;
-      this.appliedToDom = true;
+      this.renderState |= APPLIED_TO_DOM;
       let mountedFibers = this.mounted;
       while ((current = mountedFibers.pop())) {
-        if (current.appliedToDom) {
+        if (current.renderState & APPLIED_TO_DOM) {
           for (let cb of current.node.mounted) {
             cb();
           }

--- a/packages/owl-runtime/src/rendering/scheduler.ts
+++ b/packages/owl-runtime/src/rendering/scheduler.ts
@@ -1,5 +1,5 @@
 import { fibersInError } from "./error_handling";
-import { Fiber, RootFiber } from "./fibers";
+import { APPLIED_TO_DOM, Fiber, RootFiber } from "./fibers";
 import { STATUS } from "../status";
 
 // -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ export class Scheduler {
         // was an error and an error handler triggered a new rendering that recycled
         // the fiber, so in that case, we actually want to keep the fiber around,
         // otherwise it will just be ignored.
-        if (fiber.appliedToDom) {
+        if (fiber.renderState & APPLIED_TO_DOM) {
           this.tasks.delete(fiber);
         }
       }

--- a/packages/owl-runtime/tests/components/__snapshots__/rendering.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/rendering.test.ts.snap
@@ -91,6 +91,58 @@ exports[`render loop detection > throws a clear error instead of freezing on a r
 }"
 `;
 
+exports[`render loop detection > wide re-render under an uncommitted root is not a render loop 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { prepareList, OwlError, createComponent, withKey } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  const comp2 = createComponent(app, \`AsyncChild\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const ctx1 = ctx;
+    const [k_block2, v_block2, l_block2, c_block2] = prepareList(ctx['this'].ids);;
+    const keys2 = new Set();
+    for (let i1 = 0; i1 < l_block2; i1++) {
+      let ctx = Object.create(ctx1);
+      ctx[\`i\`] = k_block2[i1];
+      const key1 = ctx['i'];
+      if (keys2.has(String(key1))) { throw new OwlError(\`Got duplicate key in t-foreach: \${key1}\`)}
+      keys2.add(String(key1));
+      const props1 = {};
+      c_block2[i1] = withKey(comp1(props1, key + \`__1__\${key1}\`, node, this, null), key1);
+    }
+    const b2 = list(c_block2);
+    const props2 = {};
+    const b4 = comp2(props2, key + \`__2\`, node, this, null);
+    return multi([b2, b4]);
+  }
+}"
+`;
+
+exports[`render loop detection > wide re-render under an uncommitted root is not a render loop 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].shared());
+  }
+}"
+`;
+
+exports[`render loop detection > wide re-render under an uncommitted root is not a render loop 3`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  return function template(ctx, node, key = "") {
+    return text(\`async\`);
+  }
+}"
+`;
+
 exports[`rendering semantics > can force a render to update sub tree 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/rendering.test.ts
+++ b/packages/owl-runtime/tests/components/rendering.test.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   mount,
+  onWillStart,
   onWillUpdateProps,
   OwlError,
   props,
@@ -527,6 +528,43 @@ describe("render loop detection", () => {
     expect(error).toBeInstanceOf(OwlError);
     expect(error.message).toMatch(/render loop/);
     expect(error.message).toContain("Root");
+    expect(getConsoleOutput()).toEqual([]);
+  });
+
+  test("wide re-render under an uncommitted root is not a render loop", async () => {
+    // 1001 children each re-rendering once while the root fiber is held open
+    // by an async sibling. Each child renders only twice: no loop. A counter
+    // shared at the root level would add up all sibling re-renders and reach
+    // the limit anyway (false positive), so the count must stay per fiber.
+    const shared = signal(0);
+    const def = makeDeferred();
+
+    class Child extends Component {
+      static template = xml`<t t-out="this.shared()"/>`;
+      shared = shared;
+    }
+    class AsyncChild extends Component {
+      static template = xml`async`;
+      setup() {
+        onWillStart(() => def);
+      }
+    }
+    class Root extends Component {
+      static components = { Child, AsyncChild };
+      static template = xml`
+        <t t-foreach="this.ids" t-as="i" t-key="i"><Child/></t>
+        <AsyncChild/>`;
+      ids = [...Array(1001).keys()];
+    }
+
+    const promise = mount(Root, fixture, { test: true });
+    await nextTick(); // all Child fibers rendered; root fiber waits on AsyncChild
+    shared.set(1); // every Child re-renders exactly once
+    await nextTick();
+
+    def.resolve();
+    await promise;
+    expect(fixture.textContent).toContain("async");
     expect(getConsoleOutput()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

The render-loop detection from 8f791a43 (#1968) stores its `renderCount` on the **root fiber**, shared by the whole render tree. When a component re-renders while an ancestor's render is still uncommitted, its recycled fiber's `root` is the ancestor's root fiber — so *all* sibling re-renders under one uncommitted root accumulate in a single counter.

This produces false positives on wide trees: with 1000+ children that each legitimately re-render once (e.g. a signal they all read changes while an async sibling's `willStart` keeps the root fiber open, or any state write landing between the render pass and the rAF commit), the shared counter crosses the limit and the app crashes with `Maximum render iterations (1000) exceeded` — even though every component rendered at most twice. The error also named an arbitrary innocent child rather than a looping component. This matches user reports of the error firing with no loop but >1000 components involved.

## Fix

Count recycles **per fiber**: `makeRootFiber` returns the same fiber object each time it recycles one, so a genuine loop still climbs without bound on the looping node's own fiber (ping-pong loops between two components are still caught too, at ~2× the iteration count), while a wide fan-out only ever brings each fiber's count to 1. The reported component is now the one actually stuck in the loop.

To avoid adding a slot to every fiber for this niche counter, the count is packed into the existing `appliedToDom` slot, renamed `renderState`: bit 0 is the applied-to-DOM flag (`APPLIED_TO_DOM`), bits 1+ are the recycle count. The field is a small integer from construction on, so fibers keep a single hidden class and all operations stay cheap Smi bit ops. The field was renamed (rather than keeping the name with a new meaning) so the compiler flags any remaining boolean-style use.

## Tests

- New regression test: 1001 children re-rendering once under a root held open by an async sibling must mount without error.
- The original #1968 test still passes and still reports the looping root.
- Full owl-runtime suite: 1399 passed.