### PR TITLE
[FIX] owl-core: do not retain destroyed sub plugin managers

### DIFF
--- a/packages/owl-core/src/plugin_manager.ts
+++ b/packages/owl-core/src/plugin_manager.ts
@@ -85,9 +85,13 @@ export class PluginManager extends Scope {
     this.pluginManager = this;
 
     if (options.parent) {
-      const parent = options.parent;
-      parent.onDestroy(() => this.destroy());
-      this.plugins = Object.create(parent.plugins);
+      // The parent deliberately keeps NO reference to this sub manager: an
+      // onDestroy callback on the parent is never removed, so a long-lived
+      // parent would retain every destroyed sub manager (and all its plugin
+      // instances). Whoever creates a sub manager is responsible for
+      // destroying it — providePlugins ties it to its host component's
+      // lifetime, and the app destroys its own manager.
+      this.plugins = Object.create(options.parent.plugins);
     } else {
       this.plugins = {};
     }

--- a/packages/owl-runtime/tests/plugins.test.ts
+++ b/packages/owl-runtime/tests/plugins.test.ts
@@ -466,7 +466,9 @@ describe("sub plugin managers", () => {
     expect(steps.splice(0)).toEqual(["destroy A"]);
   });
 
-  test("destroying parent plugin manager destroys everything", () => {
+  test("destroying parent plugin manager does not destroy sub managers", () => {
+    // The parent keeps no reference to its sub managers (it would retain
+    // destroyed ones forever): whoever creates a sub manager destroys it.
     const steps: string[] = [];
 
     class A extends Plugin {
@@ -490,11 +492,63 @@ describe("sub plugin managers", () => {
     const app = new App();
     const manager = new PluginManager(app);
     manager.startPlugins([A]);
-    new PluginManager(app, { parent: manager }).startPlugins([B]);
+    const subManager = new PluginManager(app, { parent: manager });
+    subManager.startPlugins([B]);
     expect(steps.splice(0)).toEqual(["setup A", "setup B"]);
 
     manager.destroy();
-    expect(steps.splice(0)).toEqual(["destroy B", "destroy A"]);
+    expect(steps.splice(0)).toEqual(["destroy A"]);
+
+    subManager.destroy();
+    expect(steps.splice(0)).toEqual(["destroy B"]);
+  });
+
+  test("destroyed sub plugin manager is not retained by its parent", async () => {
+    const steps: string[] = [];
+
+    class P extends Plugin {
+      setup() {
+        steps.push("setup P");
+        onWillDestroy(() => {
+          steps.push("destroy P");
+        });
+      }
+    }
+
+    class Child extends Component {
+      static template = xml`child`;
+      setup() {
+        providePlugins([P]);
+      }
+    }
+
+    class Root extends Component {
+      static components = { Child };
+      static template = xml`<Child t-if="this.show()"/>`;
+      show = signal(true);
+    }
+
+    const fixture = makeTestFixture();
+    const app = new App();
+    const root = app.createRoot(Root);
+    const component = (await root.mount(fixture)) as Root;
+    expect(steps.splice(0)).toEqual(["setup P"]);
+
+    for (let i = 0; i < 3; i++) {
+      component.show.set(false);
+      await nextTick();
+      expect(steps.splice(0)).toEqual(["destroy P"]);
+
+      component.show.set(true);
+      await nextTick();
+      expect(steps.splice(0)).toEqual(["setup P"]);
+    }
+
+    // The app-level manager must not accumulate references to the destroyed
+    // sub managers (and through them, all their plugin instances).
+    expect((app.pluginManager as any)._destroyCbs ?? []).toHaveLength(0);
+    app.destroy();
+    expect(steps.splice(0)).toEqual(["destroy P"]);
   });
 
   test("can access plugin in parent manager", () => {


### PR DESCRIPTION
## Problem

A sub plugin manager registers `parent.onDestroy(() => this.destroy())` at construction so the parent's destruction cascades to it. But `onDestroy` callbacks are never removed: when the sub manager dies first — the normal case, since `providePlugins` destroys it with its host component — the parent keeps the callback forever, and through its closure the destroyed manager and **all its plugin instances**. With a long-lived parent (typically the app-level manager) and `providePlugins` components mounted/unmounted repeatedly, every destroyed sub manager leaks.

Reproduced in the new regression test: after 1 mount + 3 remount cycles of a `providePlugins` component, the app-level manager held 4 destroy callbacks, 3 of them pinning already-destroyed managers.

## Fix

Drop the back-registration — the cascade is redundant. A manager is only ever created with a parent by `providePlugins`, which ties its destruction to the host component's `onWillDestroy`, and `app.destroy()` tears down the component trees (hence all sub managers) before destroying its own manager. `finalize` being idempotent, the removed call was only ever a no-op second destroy.

## Contract change

For code constructing `new PluginManager(app, { parent })` manually: destroying a parent manager no longer destroys sub managers — whoever creates a sub manager is responsible for destroying it. The `"destroying parent plugin manager destroys everything"` test asserted the old cascade and is rewritten to document the new contract.

## Tests

- New regression test: repeated mount/unmount of a `providePlugins` component leaves no destroy callbacks on the app-level manager, and plugin setup/destroy lifecycle is unchanged (including on `app.destroy()`).
- Full suites pass: owl-core (202), owl-runtime (1399), owl-compiler, owl.