### PR TITLE
[FIX] owl-runtime: return the anchor as firstNode of an empty list

### DIFF
--- a/packages/owl-runtime/src/blockdom/list.ts
+++ b/packages/owl-runtime/src/blockdom/list.ts
@@ -231,7 +231,12 @@ class VList {
 
   firstNode(): Node | undefined {
     const child = this.children[0];
-    return child ? child.firstNode() : undefined;
+    // An empty list still occupies a position in the DOM: its anchor. Callers
+    // use firstNode to locate a block (toggler key swaps, sibling mounts,
+    // moves), so hiding the anchor would lose the position — e.g. a t-key
+    // change on a component rendering an empty t-foreach used to crash here.
+    // VMulti does the same with its slot anchors.
+    return child ? child.firstNode() : this.anchor;
   }
 
   toString(): string {

--- a/packages/owl-runtime/tests/components/__snapshots__/t_key.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/t_key.test.ts.snap
@@ -40,6 +40,47 @@ exports[`t-key > t-foreach with t-key switch component position 2`] = `
 }"
 `;
 
+exports[`t-key > t-key change on a component rendering an empty list 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`List\`, true, false, false, ["items"]);
+  
+  let block2 = createBlock(\`<button>b</button>\`);
+  let block4 = createBlock(\`<span>end</span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = block2();
+    const tKey_1 = ctx['this'].key;
+    const b3 = toggler(tKey_1, comp1({items: ctx['this'].items}, tKey_1 + key + \`__1\`, node, this, null));
+    const b4 = block4();
+    return multi([b2, b3, b4]);
+  }
+}"
+`;
+
+exports[`t-key > t-key change on a component rendering an empty list 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { prepareList, safeOutput, withKey } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    const ctx1 = ctx;
+    const [k_block1, v_block1, l_block1, c_block1] = prepareList(ctx['this'].props.items);;
+    for (let i1 = 0; i1 < l_block1; i1++) {
+      let ctx = Object.create(ctx1);
+      ctx[\`item\`] = k_block1[i1];
+      ctx[\`item_index\`] = i1;
+      const key1 = ctx['item_index'];
+      c_block1[i1] = withKey(safeOutput(ctx['item']), key1);
+    }
+    return list(c_block1);
+  }
+}"
+`;
+
 exports[`t-key > t-key on Component 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/t_key.test.ts
+++ b/packages/owl-runtime/tests/components/t_key.test.ts
@@ -39,6 +39,47 @@ describe("t-key", () => {
     expect(oldChild === childInstance).toBeFalsy();
   });
 
+  test("t-key change on a component rendering an empty list", async () => {
+    class List extends Component {
+      static template = xml`
+        <t t-foreach="this.props.items" t-as="item" t-key="item_index">
+          <t t-out="item"/>
+        </t>`;
+      props = props();
+    }
+
+    class Parent extends Component {
+      static components = { List };
+      static template = xml`<button>b</button><List t-key="this.key" items="this.items"/><span>end</span>`;
+
+      key = "a";
+      get items() {
+        return this.key === "a" ? [] : [1, 2];
+      }
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<button>b</button><span>end</span>");
+
+    // key change while the outgoing component rendered an empty list
+    parent.key = "b";
+    render(parent);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<button>b</button>12<span>end</span>");
+
+    // key change back: outgoing component has content, incoming one is empty
+    parent.key = "a";
+    render(parent);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<button>b</button><span>end</span>");
+
+    // and once more from an empty one, to check the anchor bookkeeping survives
+    parent.key = "b";
+    render(parent);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<button>b</button>12<span>end</span>");
+  });
+
   test("t-key on Component as a function", async () => {
     let childInstance = null;
     class Child extends Component {


### PR DESCRIPTION
## Problem

Changing the `t-key` of a component whose template rendered an empty list (e.g. a `t-foreach` over an empty array) crashes with:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'parentElement')
```

`VToggler.patch` locates the outgoing child with `child1.firstNode()` to insert a position marker before removing it and mounting the replacement there. `VList.firstNode()` returned `undefined` when the list had no children, so the toggler dereferenced `undefined`.

## Fix

An empty list block is not position-less: `VList.mount` always inserts an anchor text node into the DOM precisely so the block keeps a position — `firstNode()` just hid it. `VMulti` already returns its slot anchor for an empty slot (which is why the same scenario with an empty `t-if` root works), and `VList.moveBeforeVNode` already falls back to `other.anchor`; the list's `firstNode` was the one outlier. It now returns the anchor when the list is empty.

All `firstNode` call sites were audited (toggler, multi, list diffing, event_catcher, suspense, component_node). Beyond the crash, the change repairs latent *mispositions* that had `|| null` / "empty child" fallbacks instead of crashes: `list.patch` and `multi.patch` mounted new content at the end of the parent element instead of at an empty sibling block's position, and the toggler/multi `moveBeforeVNode` fallbacks did the same. `suspense` would have crashed like the toggler if its fallback rendered an empty list.

## Tests

New regression test in `t_key.test.ts` mirroring the reported playground snippet, with position checks: key change while the outgoing list is empty (reproduced the exact `TypeError` before the fix), then non-empty → empty, then empty → non-empty, asserting the content lands between its siblings each time. Full owl-runtime suite passes (1401 tests).