### PR TITLE
[FIX] owl-runtime: make sub-root renders yield to ancestor renders

### DIFF
--- a/packages/owl-runtime/src/app.ts
+++ b/packages/owl-runtime/src/app.ts
@@ -37,6 +37,9 @@ interface SubRootConfig<P> extends RootConfig<P> {
   // error handler seeded on the root node so descendant errors route back into
   // the host's parent chain instead of tearing down the whole app.
   onError?: (error: any, finalize: Function) => void;
+  // the component node hosting the sub-root, so the scheduler can delay
+  // renders inside the sub-root while an ancestor of the host is rendering.
+  host?: ComponentNode;
 }
 
 export interface AppConfig extends TemplateSetConfig {
@@ -139,6 +142,9 @@ export class App extends TemplateSet {
       }
       if (subConfig.onError) {
         nodeErrorHandlers.set(node, [subConfig.onError]);
+      }
+      if (subConfig.host) {
+        node.host = subConfig.host;
       }
     } catch (e) {
       error = e;

--- a/packages/owl-runtime/src/app.ts
+++ b/packages/owl-runtime/src/app.ts
@@ -12,7 +12,7 @@ import {
   toRaw,
 } from "@odoo/owl-core";
 import { nodeErrorHandlers } from "./rendering/error_handling";
-import { Fiber, MountFiber, MountOptions, RootFiber } from "./rendering/fibers";
+import { Fiber, MountFiber, MountOptions, RootFiber, subRootHosts } from "./rendering/fibers";
 import { Scheduler } from "./rendering/scheduler";
 import { TemplateSet, TemplateSetConfig } from "./template_set";
 import { validateTarget } from "./utils";
@@ -144,7 +144,7 @@ export class App extends TemplateSet {
         nodeErrorHandlers.set(node, [subConfig.onError]);
       }
       if (subConfig.host) {
-        node.host = subConfig.host;
+        subRootHosts.set(node, subConfig.host);
       }
     } catch (e) {
       error = e;

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -26,6 +26,12 @@ type LifecycleHook = Function;
 
 export class ComponentNode extends Scope implements VNode<ComponentNode> {
   fiber: Fiber | null = null;
+  // For sub-root nodes (Portal/Suspense content): the component node hosting
+  // the sub-root. Null for regular nodes and the app root. This is not a
+  // parent link (the sub-root renders independently); it lets the scheduler
+  // see through the boundary, so a render inside the sub-root still yields to
+  // an in-flight ancestor render that may be about to remove the host.
+  host: ComponentNode | null = null;
   component!: Component;
   bdom: BDom | null = null;
   componentName: string;

--- a/packages/owl-runtime/src/component_node.ts
+++ b/packages/owl-runtime/src/component_node.ts
@@ -26,12 +26,6 @@ type LifecycleHook = Function;
 
 export class ComponentNode extends Scope implements VNode<ComponentNode> {
   fiber: Fiber | null = null;
-  // For sub-root nodes (Portal/Suspense content): the component node hosting
-  // the sub-root. Null for regular nodes and the app root. This is not a
-  // parent link (the sub-root renders independently); it lets the scheduler
-  // see through the boundary, so a render inside the sub-root still yields to
-  // an in-flight ancestor render that may be about to remove the host.
-  host: ComponentNode | null = null;
   component!: Component;
   bdom: BDom | null = null;
   componentName: string;

--- a/packages/owl-runtime/src/portal.ts
+++ b/packages/owl-runtime/src/portal.ts
@@ -53,6 +53,10 @@ export class Portal extends Component {
         // sub-root errors would propagate to app._handleError and tear down
         // the whole app.
         onError: forwardErrorToParent(portalNode),
+        // Let the scheduler see through the sub-root boundary, so renders of
+        // the portaled content yield to in-flight ancestor renders (e.g. a
+        // t-if about to remove this Portal).
+        host: portalNode,
       } as any);
 
       root.mount(target);

--- a/packages/owl-runtime/src/rendering/fibers.ts
+++ b/packages/owl-runtime/src/rendering/fibers.ts
@@ -76,6 +76,12 @@ function throwOnRender() {
   throw new OwlError("Attempted to render cancelled fiber");
 }
 
+// Host component node of each sub-root node (Portal/Suspense content), seeded
+// by createRoot. Sparse metadata kept out of ComponentNode itself (same
+// pattern as nodeErrorHandlers): only sub-roots have entries, and they are
+// GC'd with their node.
+export const subRootHosts = new WeakMap<ComponentNode, ComponentNode>();
+
 /**
  * The node whose in-flight render this node's own render must yield to.
  * Usually the parent; for a mounted sub-root node (Portal/Suspense content),
@@ -86,7 +92,7 @@ function throwOnRender() {
  * rendering).
  */
 function above(node: ComponentNode): ComponentNode | null {
-  return node.parent || (node.status === STATUS.MOUNTED ? node.host : null);
+  return node.parent || (node.status === STATUS.MOUNTED ? subRootHosts.get(node) || null : null);
 }
 
 /**

--- a/packages/owl-runtime/src/rendering/fibers.ts
+++ b/packages/owl-runtime/src/rendering/fibers.ts
@@ -77,6 +77,19 @@ function throwOnRender() {
 }
 
 /**
+ * The node whose in-flight render this node's own render must yield to.
+ * Usually the parent; for a mounted sub-root node (Portal/Suspense content),
+ * its host, so renders inside the sub-root still yield to an ancestor render
+ * that may be about to remove the host. An unmounted sub-root deliberately
+ * stays unlinked: its initial render must proceed in parallel with the host's
+ * own mount (Suspense renders its default slot while the outer tree is still
+ * rendering).
+ */
+function above(node: ComponentNode): ComponentNode | null {
+  return node.parent || (node.status === STATUS.MOUNTED ? node.host : null);
+}
+
+/**
  * @returns number of not-yet rendered fibers cancelled
  */
 function cancelFibers(fibers: Fiber[]): number {
@@ -150,11 +163,18 @@ export class Fiber {
     // walk.
     if (scheduler.tasks.size > 1) {
       let prev = this.root!.node;
-      let current = prev.parent;
+      let current = above(prev);
       while (current) {
         if (current.fiber) {
           let root = current.fiber.root!;
-          if (root.counter === 0 && prev.parentKey! in current.fiber.childrenMap) {
+          // `!prev.parent` means we crossed a sub-root boundary: the content
+          // never appears in the host's childrenMap, but it is retained as
+          // long as the host node survives — and a node holding a fiber of a
+          // finished (counter 0) render pass survives that pass.
+          if (
+            root.counter === 0 &&
+            (!prev.parent || prev.parentKey! in current.fiber.childrenMap)
+          ) {
             current = root.node;
           } else {
             scheduler.delayedRenders.push(this);
@@ -162,7 +182,7 @@ export class Fiber {
           }
         }
         prev = current;
-        current = current.parent;
+        current = above(current);
       }
     }
 

--- a/packages/owl-runtime/src/suspense.ts
+++ b/packages/owl-runtime/src/suspense.ts
@@ -53,6 +53,10 @@ export class Suspense extends Component {
       // Route errors from the sub-root back into Suspense's parent chain so
       // consumer `onError` handlers still catch descendant failures.
       onError: forwardErrorToParent(suspenseNode),
+      // Let the scheduler see through the sub-root boundary, so renders of
+      // the default slot yield to in-flight ancestor renders (e.g. a t-if
+      // about to remove this Suspense).
+      host: suspenseNode,
     } as any);
 
     // Kick off the render phase now — descendants' onWillStart fires in

--- a/packages/owl-runtime/tests/components/portal.test.ts
+++ b/packages/owl-runtime/tests/components/portal.test.ts
@@ -54,6 +54,52 @@ test("renders nothing in place; mounts content into target Element", async () =>
   app.destroy();
 });
 
+test("slot content is not re-rendered when the guard removing it flips", async () => {
+  const target = makeOutside("portal-target-guard");
+  target.dataset.testPortal = "1";
+
+  const seen: boolean[] = [];
+
+  class Popover extends Component {
+    static components = { Portal };
+    static template = xml`
+      <Portal target="this.target">
+        <t t-call-slot="default"/>
+      </Portal>`;
+    target = target;
+  }
+
+  class Root extends Component {
+    static components = { Popover };
+    static template = xml`
+      <button>toggle</button>
+      <Popover t-if="this.open()">open<t t-out="this.probe()"/></Popover>`;
+    open = signal(false);
+    probe() {
+      seen.push(this.open());
+      return "";
+    }
+  }
+
+  const app = new App();
+  const root = (await app.createRoot(Root).mount(fixture)) as InstanceType<typeof Root>;
+  await nextTick();
+  expect(seen).toEqual([]);
+
+  root.open.set(true);
+  await nextTick();
+  expect(target.textContent).toBe("open");
+  expect(seen).toEqual([true]);
+
+  root.open.set(false);
+  await nextTick();
+  expect(target.textContent).toBe("");
+  // The slot must never have been evaluated with the guard value that
+  // removed it: the sub-root render has to yield to the ancestor's.
+  expect(seen).toEqual([true]);
+  app.destroy();
+});
+
 test("accepts a CSS selector string as target", async () => {
   const target = makeOutside("portal-target-2");
   target.dataset.testPortal = "1";


### PR DESCRIPTION
## Problem

With a Portal whose slot both reads a signal and is guarded by it in the owner:

```xml
<Popover t-if="this.isPopoverOpen()">
  Coucou <t t-if="console.log(this.isPopoverOpen())"/>
</Popover>
```

closing the popover logs `false` — the slot is evaluated with the very value that is removing it (a "zombie render"), even though it sits behind a `t-if` guarding against that value.

Slot content rendered through a Portal subscribes the portal **sub-root**'s computation, not the slot owner's. Flipping the signal schedules two re-renders: the owner's (whose `t-if` will remove the Portal) and the sub-root's. The sub-root rendered first.

Owl already prevents this for in-tree components: `Fiber.render` walks up `node.parent` looking for an in-flight ancestor render, and delays the child's render if the ancestor's pass dropped it (`delayedRenders`), so the pending render dies with the node at commit. But `createRoot` builds sub-root nodes with `parent = null`, so Portal (and Suspense) content escaped the walk entirely.

## Fix

Sub-roots now carry a `host` link (internal `SubRootConfig.host`, stored on `ComponentNode`, passed by Portal and Suspense) — not a parent link, just visibility for the scheduler. The ancestor walk climbs parent-or-host, with two boundary rules:

- The childrenMap retention test cannot apply at the boundary (sub-root content never appears in the host's childrenMap): crossing counts as retained when the host itself holds a fiber of a finished (counter 0) pass — a node holding a fiber of a finished pass survives it — and otherwise the walk continues into the host's ancestors, where the normal logic decides.
- The crossing only applies once the sub-root is **mounted** (`above()` helper). Suspense deliberately renders its default slot in parallel with the outer tree's still-in-flight mount, so the initial render must not be delayed; the zombie scenario is by definition a re-render of mounted content. (A first version without this gate broke three Suspense tests — fallback-flash and parallel-willStart behavior.)

## Tests

New regression test in `portal.test.ts` probing every evaluation of a portaled slot guarded by a `t-if`: it recorded `[true, false]` before the fix, `[true]` after — the slot is never evaluated with the guard value that removed it, and the portal target is emptied correctly. Full owl-runtime suite passes (1402 tests, Suspense suite included) plus the umbrella package.