### PR TITLE
[FIX] owl-core: track array and object signals per key

### DIFF
--- a/doc/v3/owl/reference/signals.md
+++ b/doc/v3/owl/reference/signals.md
@@ -132,20 +132,28 @@ list.set([10, 20]); // whole-value replacement, detected
 
 ### Tracking granularity
 
-`signal.Array` and `signal.Object` invalidate the **whole signal** on any
-mutation. Reading the proxy — whether `obj()` itself or a single property like
-`obj().a` — subscribes the caller to the entire collection, and _any_ write
-re-runs every observer. This is the right model when the collection is small
-or consumers usually look at all of it.
-
-`signal.Set` and `signal.Map` track **per-key**, just like `proxy`.
-Subscribing to `set().has(1)` only re-runs when key `1` is added or removed;
+The four variants track **per-key**, just like `proxy`. Reading one entry only
+subscribes to that entry: an effect reading `list()[0]` or `obj().a` does not
+re-run when another index or another key is written. Subscribing to
+`set().has(1)` only re-runs when key `1` is added or removed, and
 `set().add(2)` leaves observers of `has(1)` (or `map.get(otherKey)`) alone.
-Iteration (`[...set()]`, `forEach`, `keys`, `values`, `entries`, `size`)
-subscribes to every key, so an effect that iterates still re-runs on any
-add/delete.
+
+Reading the collection as a whole subscribes to all of it: iteration
+(`[...list()]`, `forEach`, `keys`, `values`, `entries`, `size`), a spread, or
+`list().length`. Such an observer re-runs on any add or delete.
+
+Reading the signal without reading anything in it, `list()` alone, subscribes
+to replacement only: `list.set(...)` re-runs the observer, an in-place mutation
+does not.
 
 ```js
+const list = signal.Array([1, 2, 3]);
+
+effect(() => console.log("first =", list()[0]));
+list()[2] = 30; // logged once at setup, NOT re-run (index 2 is unrelated)
+list()[0] = 10; // re-run: index 0 changed
+list.set([1, 2, 3]); // re-run: whole signal was replaced
+
 const set = signal.Set(new Set());
 
 effect(() => console.log("has(1) =", set().has(1)));

--- a/packages/owl-core/src/proxy.ts
+++ b/packages/owl-core/src/proxy.ts
@@ -90,10 +90,9 @@ function getTargetKeyAtom(target: Target, key: PropertyKey): Atom {
  * @param target the target whose key should be observed
  * @param key the key to observe (or Symbol(KEYCHANGES) for key creation
  *  or deletion)
- * @param callback the function to call when the key changes
  */
-function onReadTargetKey(target: Target, key: PropertyKey, atom: Atom | null): void {
-  onReadAtom(atom ?? getTargetKeyAtom(target, key));
+function onReadTargetKey(target: Target, key: PropertyKey): void {
+  onReadAtom(getTargetKeyAtom(target, key));
 }
 
 /**
@@ -187,7 +186,7 @@ export function proxy<T extends Target>(target: T): T {
 function basicProxyHandler<T extends Target>(atom: Atom | null): ProxyHandler<T> {
   return {
     get(target, key, receiver) {
-      onReadTargetKey(target, key, atom);
+      onReadTargetKey(target, key);
       const value = Reflect.get(target, key, receiver);
       // Fast path: signal-based proxies and primitive values don't need wrapping
       if (atom || typeof value !== "object" || value === null) {
@@ -209,48 +208,33 @@ function basicProxyHandler<T extends Target>(atom: Atom | null): ProxyHandler<T>
       const ret = Reflect.set(target, key, toRaw(value), receiver);
       const keyCreated = !hadKey && objectHasOwnProperty.call(target, key);
       const valueChanged = originalValue !== Reflect.get(target, key, receiver);
-      if (atom) {
-        // Signal-based proxies observe a single atom: notify it at most once
-        // per write, even when the write both creates a key and changes a
-        // value. Array "length" writes triggered by array methods (push, ...)
-        // don't need the special case below: the index write that caused them
-        // already notified the atom.
-        if (keyCreated || valueChanged) {
-          onWriteAtom(atom);
-        }
-      } else {
-        if (keyCreated) {
-          onWriteTargetKey(target, KEYCHANGES);
-        }
-        // While Array length may trigger the set trap, it's not actually set by this
-        // method but is updated behind the scenes, and the trap is not called with the
-        // new value. We disable the "same-value-optimization" for it because of that.
-        if (valueChanged || (key === "length" && Array.isArray(target))) {
-          onWriteTargetKey(target, key);
-        }
+      if (keyCreated) {
+        onWriteTargetKey(target, KEYCHANGES);
+      }
+      // While Array length may trigger the set trap, it's not actually set by this
+      // method but is updated behind the scenes, and the trap is not called with the
+      // new value. We disable the "same-value-optimization" for it because of that.
+      if (valueChanged || (key === "length" && Array.isArray(target))) {
+        onWriteTargetKey(target, key);
       }
       return ret;
     },
     deleteProperty(target, key) {
       const ret = Reflect.deleteProperty(target, key);
       // TODO: only notify when something was actually deleted
-      if (atom) {
-        onWriteAtom(atom);
-      } else {
-        onWriteTargetKey(target, KEYCHANGES);
-        onWriteTargetKey(target, key);
-      }
+      onWriteTargetKey(target, KEYCHANGES);
+      onWriteTargetKey(target, key);
       return ret;
     },
     ownKeys(target) {
-      onReadTargetKey(target, KEYCHANGES, atom);
+      onReadTargetKey(target, KEYCHANGES);
       return Reflect.ownKeys(target);
     },
     has(target, key) {
       // TODO: this observes all key changes instead of only the presence of the argument key
       // observing the key itself would observe value changes instead of presence changes
       // so we may need a finer grained system to distinguish observing value vs presence.
-      onReadTargetKey(target, KEYCHANGES, atom);
+      onReadTargetKey(target, KEYCHANGES);
       return Reflect.has(target, key);
     },
   } as ProxyHandler<T>;
@@ -266,7 +250,7 @@ function basicProxyHandler<T extends Target>(atom: Atom | null): ProxyHandler<T>
 function makeKeyObserver(methodName: "has" | "get", target: any, atom: Atom | null) {
   return (key: any) => {
     key = toRaw(key);
-    onReadTargetKey(target, key, null);
+    onReadTargetKey(target, key);
     return possiblyReactive(target[methodName](key), atom);
   };
 }
@@ -284,11 +268,11 @@ function makeIteratorObserver(
   atom: Atom | null
 ) {
   return function* () {
-    onReadTargetKey(target, KEYCHANGES, null);
+    onReadTargetKey(target, KEYCHANGES);
     const keys = target.keys();
     for (const item of target[methodName]()) {
       const key = keys.next().value;
-      onReadTargetKey(target, key, null);
+      onReadTargetKey(target, key);
       yield possiblyReactive(item, atom);
     }
   };
@@ -303,9 +287,9 @@ function makeIteratorObserver(
  */
 function makeForEachObserver(target: any, atom: Atom | null) {
   return function forEach(forEachCb: (val: any, key: any, target: any) => void, thisArg: any) {
-    onReadTargetKey(target, KEYCHANGES, null);
+    onReadTargetKey(target, KEYCHANGES);
     target.forEach(function (val: any, key: any, targetObj: any) {
-      onReadTargetKey(target, key, null);
+      onReadTargetKey(target, key);
       forEachCb.call(
         thisArg,
         possiblyReactive(val, atom),
@@ -380,7 +364,7 @@ const rawTypeToFuncHandlers = {
     forEach: makeForEachObserver(target, atom),
     clear: makeClearNotifier(target),
     get size() {
-      onReadTargetKey(target, KEYCHANGES, null);
+      onReadTargetKey(target, KEYCHANGES);
       return target.size;
     },
   }),
@@ -396,7 +380,7 @@ const rawTypeToFuncHandlers = {
     forEach: makeForEachObserver(target, atom),
     clear: makeClearNotifier(target),
     get size() {
-      onReadTargetKey(target, KEYCHANGES, null);
+      onReadTargetKey(target, KEYCHANGES);
       return target.size;
     },
   }),
@@ -428,7 +412,7 @@ function collectionsProxyHandler<T extends Collection>(
       if (objectHasOwnProperty.call(specialHandlers, key)) {
         return (specialHandlers as any)[key];
       }
-      onReadTargetKey(target, key, atom);
+      onReadTargetKey(target, key);
       return possiblyReactive(target[key], atom);
     },
   }) as ProxyHandler<T>;

--- a/packages/owl-core/src/proxy.ts
+++ b/packages/owl-core/src/proxy.ts
@@ -115,6 +115,26 @@ function onWriteTargetKey(target: Target, key: PropertyKey): void {
   onWriteAtom(keyToAtomItem.get(key)!);
 }
 
+/**
+ * Notify Reactives that are observing the indices an array dropped when its
+ * length was written: such a write does not go through the deleteProperty trap.
+ *
+ * @param target the array whose length was written
+ * @param newLength the length after the write
+ */
+function onWriteDroppedIndices(target: Target, newLength: number): void {
+  const keyToAtomItem = targetToKeysToAtomItem.get(target)!;
+  if (!keyToAtomItem) {
+    return;
+  }
+  const droppedKeys = [...keyToAtomItem.keys()].filter(
+    (key) => typeof key === "string" && Number(key) >= newLength && String(Number(key)) === key
+  );
+  for (const key of droppedKeys) {
+    onWriteTargetKey(target, key);
+  }
+}
+
 // Maps proxy objects to the underlying target
 const targets = new WeakMap<Reactive<Target>, Target>();
 const proxyCache = new WeakMap<Target, Reactive<Target>>();
@@ -211,10 +231,16 @@ function basicProxyHandler<T extends Target>(atom: Atom | null): ProxyHandler<T>
       if (keyCreated) {
         onWriteTargetKey(target, KEYCHANGES);
       }
-      // While Array length may trigger the set trap, it's not actually set by this
-      // method but is updated behind the scenes, and the trap is not called with the
-      // new value. We disable the "same-value-optimization" for it because of that.
-      if (valueChanged || (key === "length" && Array.isArray(target))) {
+      if (key === "length" && Array.isArray(target)) {
+        // While Array length may trigger the set trap, it's not actually set by this
+        // method but is updated behind the scenes, and the trap is not called with the
+        // new value. We disable the "same-value-optimization" for it because of that.
+        onWriteTargetKey(target, key);
+        if (target.length < (originalValue as number)) {
+          onWriteTargetKey(target, KEYCHANGES);
+          onWriteDroppedIndices(target, target.length);
+        }
+      } else if (valueChanged) {
         onWriteTargetKey(target, key);
       }
       return ret;

--- a/packages/owl-core/tests/signals.test.ts
+++ b/packages/owl-core/tests/signals.test.ts
@@ -169,6 +169,18 @@ describe("signal.Array", () => {
     await waitScheduler();
     expectSpy(e.spy, 2, { result: 1 });
   });
+
+  test("truncating through length invalidates the dropped indices", async () => {
+    const reactiveArray = signal.Array<number>([0, 1, 2]);
+
+    const e = spyEffect(() => reactiveArray()[2]);
+    e();
+    expectSpy(e.spy, 1, { result: 2 });
+
+    reactiveArray().length = 1;
+    await waitScheduler();
+    expectSpy(e.spy, 2, { result: undefined });
+  });
 });
 
 describe("signal.Object", () => {

--- a/packages/owl-core/tests/signals.test.ts
+++ b/packages/owl-core/tests/signals.test.ts
@@ -132,21 +132,42 @@ describe("signal.Array", () => {
   test("push an element invalidates the signal", async () => {
     const reactiveArray = signal.Array<number>([]);
 
-    const e = spyEffect(() => reactiveArray());
+    const e = spyEffect(() => [...reactiveArray()]);
     e();
     expectSpy(e.spy, 1);
 
     reactiveArray().push(1);
-    expectSpy(e.spy, 1, { result: [1] }); // array is changed inplace
+    expectSpy(e.spy, 1, { result: [] });
 
     await waitScheduler();
-    expectSpy(e.spy, 2, { result: [1] }); // reactive has been invalidated
+    expectSpy(e.spy, 2, { result: [1] });
 
     reactiveArray.set([2]);
     expectSpy(e.spy, 2, { result: [1] });
 
     await waitScheduler();
     expectSpy(e.spy, 3, { result: [2] });
+  });
+
+  test("writing an index only subscribes to that index", async () => {
+    const reactiveArray = signal.Array<number>([0, 1, 2]);
+
+    const e = spyEffect(() => reactiveArray()[0]);
+    e();
+    expectSpy(e.spy, 1, { result: 0 });
+
+    reactiveArray()[0] = 0;
+    await waitScheduler();
+    expectSpy(e.spy, 1, { result: 0 });
+
+    // writing an unobserved index must not trigger the effect
+    reactiveArray()[2] = 42;
+    await waitScheduler();
+    expectSpy(e.spy, 1, { result: 0 });
+
+    reactiveArray()[0] = 1;
+    await waitScheduler();
+    expectSpy(e.spy, 2, { result: 1 });
   });
 });
 
@@ -155,11 +176,11 @@ describe("signal.Object", () => {
     const reactiveObject = signal.Object<Record<string, number>>();
     expect(reactiveObject()).toEqual({});
 
-    const e = spyEffect(() => reactiveObject());
+    const e = spyEffect(() => reactiveObject().a);
     e();
     reactiveObject().a = 1;
     await waitScheduler();
-    expectSpy(e.spy, 2, { result: { a: 1 } });
+    expectSpy(e.spy, 2, { result: 1 });
   });
 
   test("simple use", async () => {
@@ -219,27 +240,44 @@ describe("signal.Object", () => {
   test("add or remove element on object", async () => {
     const reactiveObject = signal.Object<Record<string, any>>({});
 
-    const e = spyEffect(() => reactiveObject());
+    const e = spyEffect(() => ({ ...reactiveObject() }));
     e();
     expectSpy(e.spy, 1);
 
     reactiveObject().a = 1;
-    expectSpy(e.spy, 1, { result: { a: 1 } }); // array is changed inplace
+    expectSpy(e.spy, 1, { result: {} });
 
     await waitScheduler();
-    expectSpy(e.spy, 2, { result: { a: 1 } }); // reactive has been invalidated
+    expectSpy(e.spy, 2, { result: { a: 1 } });
 
     reactiveObject().b = 2;
-    expectSpy(e.spy, 2, { result: { a: 1, b: 2 } }); // array is changed inplace
+    expectSpy(e.spy, 2, { result: { a: 1 } });
 
     await waitScheduler();
-    expectSpy(e.spy, 3, { result: { a: 1, b: 2 } }); // reactive has been invalidated
+    expectSpy(e.spy, 3, { result: { a: 1, b: 2 } });
 
     delete reactiveObject().a;
-    expectSpy(e.spy, 3, { result: { b: 2 } }); // array is changed inplace
+    expectSpy(e.spy, 3, { result: { a: 1, b: 2 } });
 
     await waitScheduler();
-    expectSpy(e.spy, 4, { result: { b: 2 } }); // reactive has been invalidated
+    expectSpy(e.spy, 4, { result: { b: 2 } });
+  });
+
+  test("writing a key only subscribes to that key", async () => {
+    const reactiveObject = signal.Object<Record<string, number>>({ a: 0, b: 0 });
+
+    const e = spyEffect(() => reactiveObject().a);
+    e();
+    expectSpy(e.spy, 1, { result: 0 });
+
+    // writing an unobserved key must not trigger the effect
+    reactiveObject().b = 42;
+    await waitScheduler();
+    expectSpy(e.spy, 1, { result: 0 });
+
+    reactiveObject().a = 1;
+    await waitScheduler();
+    expectSpy(e.spy, 2, { result: 1 });
   });
 });
 
@@ -473,7 +511,7 @@ describe("signal.Set", () => {
   });
 });
 
-describe("signal write notifications", () => {
+describe("signal atom notifications", () => {
   // Counts how many times onWriteAtom is called on the signal's atom by
   // counting iterations of its observers set (onWriteAtom iterates it once
   // per call).
@@ -489,52 +527,38 @@ describe("signal write notifications", () => {
     return () => count;
   }
 
-  test("adding an element to a signal.Array notifies its atom only once", () => {
+  test("writing in a signal.Array does not notify its atom", () => {
     const reactiveArray = signal.Array<number>([0, 1]);
     const notified = countAtomNotifications(reactiveArray);
 
     reactiveArray()[2] = 2;
-    expect(notified()).toBe(1);
-  });
-
-  test("push on a signal.Array notifies its atom only once", () => {
-    const reactiveArray = signal.Array<number>([0]);
-    const notified = countAtomNotifications(reactiveArray);
-
-    reactiveArray().push(1);
-    expect(notified()).toBe(1);
-  });
-
-  test("writing the same value to a signal.Array does not notify", () => {
-    const reactiveArray = signal.Array<number>([0]);
-    const notified = countAtomNotifications(reactiveArray);
-
-    reactiveArray()[0] = 0;
+    reactiveArray().push(3);
+    reactiveArray().length = 1;
     expect(notified()).toBe(0);
   });
 
-  test("truncating a signal.Array through length notifies its atom only once", () => {
-    const reactiveArray = signal.Array<number>([0, 1, 2]);
+  test("replacing a signal.Array notifies its atom once", () => {
+    const reactiveArray = signal.Array<number>([0]);
     const notified = countAtomNotifications(reactiveArray);
 
-    reactiveArray().length = 1;
+    reactiveArray.set([1]);
     expect(notified()).toBe(1);
-    expect(reactiveArray()).toEqual([0]);
   });
 
-  test("adding a key to a signal.Object notifies its atom only once", () => {
+  test("writing in a signal.Object does not notify its atom", () => {
     const reactiveObject = signal.Object<Record<string, number>>({ a: 1 });
     const notified = countAtomNotifications(reactiveObject);
 
     reactiveObject().b = 2;
-    expect(notified()).toBe(1);
+    delete reactiveObject().a;
+    expect(notified()).toBe(0);
   });
 
-  test("deleting a key from a signal.Object notifies its atom only once", () => {
+  test("replacing a signal.Object notifies its atom once", () => {
     const reactiveObject = signal.Object<Record<string, number>>({ a: 1 });
     const notified = countAtomNotifications(reactiveObject);
 
-    delete reactiveObject().a;
+    reactiveObject.set({ b: 2 });
     expect(notified()).toBe(1);
   });
 });

--- a/packages/owl-runtime/tests/reactivity/proxy.test.ts
+++ b/packages/owl-runtime/tests/reactivity/proxy.test.ts
@@ -417,6 +417,18 @@ describe("Reactivity", () => {
     expect(state).toEqual([3]);
     expect(state.length).toBe(1);
   });
+  test("truncating an array through length is observed", async () => {
+    const spy = vi.fn();
+    const state: any = createProxy([0, 1, 2]);
+    effect(() => spy(state[2]));
+    expectSpy(spy, 1, [2]);
+
+    state.length = 1;
+    await waitScheduler();
+    expectSpy(spy, 2, [undefined]);
+    expect(state).toEqual([0]);
+  });
+
   test("object pushed into arrays are observed", async () => {
     const spy = vi.fn();
     const arr: any = createProxy([]);


### PR DESCRIPTION
Before this commit, reading one entry of a `signal.Array` or a `signal.Object` subscribed the reader to the whole collection: a component rendering `items()[0]` was patched again after `items()[2]` changed, a value it does not render.

This happens because a collection signal hands its atom to the proxy handler, which uses it for every read and every write, so all the keys share one atom. #1903 moved the Map, Set and WeakMap helpers back to per-key atoms and left the basic handler, the one arrays and plain objects go through, on the signal atom.

The first commit gives the basic handler the same per-key atoms, so a write only notifies the readers of that key. Reading the signal still subscribes to its atom and `set()` still notifies it, so replacing the whole value invalidates every reader. Note that in-place writes no longer notify that atom, which makes the coalescing added for #1972 pointless: what it merged lands on distinct atoms now, one call each.

The second commit closes the hole that granularity opens: a length write drops the indices above it without going through the deleteProperty trap, so `list().length = 1` left an effect reading `list()[2]` on the value it read before. `pop`, `shift`, `splice` and `delete` do not have the problem, they write or delete the indices themselves. `proxy` has the same hole today, so the fix covers both.

Closes odoo/owl#1991