### PR TITLE
[FIX] owl-core: ignore the in flight event in useListener

### DIFF
--- a/doc/v3/owl/reference/hooks.md
+++ b/doc/v3/owl/reference/hooks.md
@@ -212,6 +212,11 @@ useListener(ref, "scroll", (ev) => this.onScroll(ev));
 > useListener(window, "click", this.closeMenu.bind(this), { capture: true });
 > ```
 
+> **Note:** an event already being dispatched when the listener is attached is
+> never delivered. A dialog displayed by a click handler is created while that
+> click still bubbles, so its `window` listener would otherwise fire for the
+> click that created it.
+
 ### `useApp`
 
 The `useApp` hook returns the current `App` instance:

--- a/packages/owl-core/src/hooks.ts
+++ b/packages/owl-core/src/hooks.ts
@@ -103,6 +103,9 @@ export function useOnChange<T extends unknown[]>(
  * it `this` is the event target, not the calling component. Wrap a method in an
  * arrow function (or bind it) if it relies on `this`.
  *
+ * An event already being dispatched when the listener is attached is never
+ * delivered to `handler` (see `currentEvent`).
+ *
  * Example — close a menu when the user clicks anywhere on `window`:
  *   useListener(window, "click", () => this.close());
  */
@@ -117,15 +120,42 @@ export function useListener(
     useEffect(() => {
       const el = target();
       if (el) {
-        el.addEventListener(eventName, handler, eventParams);
-        return () => el.removeEventListener(eventName, handler, eventParams);
+        const listener = makeListener(handler);
+        el.addEventListener(eventName, listener, eventParams);
+        return () => el.removeEventListener(eventName, listener, eventParams);
       }
       return;
     });
   } else {
-    target.addEventListener(eventName, handler, eventParams);
-    onWillDestroy(() => target.removeEventListener(eventName, handler, eventParams));
+    const listener = makeListener(handler);
+    target.addEventListener(eventName, listener, eventParams);
+    onWillDestroy(() => target.removeEventListener(eventName, listener, eventParams));
   }
+}
+
+/**
+ * The last native event owl started dispatching. Kept past the end of its own
+ * handler, since a component created by that handler is set up a few microtasks
+ * later, while the event is still bubbling. Nothing clears it, and an `Event`
+ * keeps its `target` alive, hence the `WeakRef`.
+ */
+let currentEvent: WeakRef<Event> | null = null;
+
+export function setCurrentEvent(ev: Event): void {
+  if (currentEvent?.deref() !== ev) {
+    currentEvent = new WeakRef(ev);
+  }
+}
+
+function makeListener(handler: EventListener): EventListener {
+  const attachedDuring = currentEvent?.deref();
+  return function (this: EventTarget, ev: Event) {
+    if (ev === attachedDuring) {
+      return;
+    }
+    setCurrentEvent(ev);
+    handler.call(this, ev);
+  };
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -107,6 +107,8 @@ export {
 
 // Hooks
 export {
+  // not a hook, used by the runtime's `mainEventHandler`
+  setCurrentEvent,
   useApp,
   useEffect,
   useListener,

--- a/packages/owl-runtime/src/event_handling.ts
+++ b/packages/owl-runtime/src/event_handling.ts
@@ -1,8 +1,10 @@
 import { filterOutModifiersFromData } from "./blockdom/config";
 import { STATUS } from "./status";
-import { OwlError } from "@odoo/owl-core";
+import { OwlError, setCurrentEvent } from "@odoo/owl-core";
 
 export const mainEventHandler = (data: any, ev: Event, currentTarget?: EventTarget | null) => {
+  // lets `useListener` skip an event older than the listener
+  setCurrentEvent(ev);
   const { data: _data, modifiers } = filterOutModifiersFromData(data);
   data = _data;
   let stopped = false;

--- a/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/hooks.test.ts.snap
@@ -255,6 +255,119 @@ exports[`hooks > useListener 2`] = `
 }"
 `;
 
+exports[`hooks > useListener ignores the event that created its component 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const hdlr_fn1 = (ctx)=>ctx['this'].show.set(true);
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  let block2 = createBlock(\`<button block-handler-0="click">open</button>\`);
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    let hdlr1 = [hdlr_fn1, ctx];
+    b2 = block2([hdlr1]);
+    if (ctx['this'].show()) {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`hooks > useListener ignores the event that created its component 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div>child</div>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useListener ignores the event that created its component, from another useListener 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    let b2;
+    if (ctx['this'].show()) {
+      b2 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2]);
+  }
+}"
+`;
+
+exports[`hooks > useListener ignores the event that created its component, from another useListener 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div>child</div>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useListener keeps the event target as \`this\` 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`hooks > useListener still receives an event dispatched while it is being attached 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const hdlr_fn1 = (ctx)=>ctx['this'].show.set(true);
+  const comp1 = createComponent(app, \`MyComponent\`, true, false, false, []);
+  
+  let block2 = createBlock(\`<button block-handler-0="click">open</button>\`);
+  
+  return function template(ctx, node, key = "") {
+    let b2, b3;
+    let hdlr1 = [hdlr_fn1, ctx];
+    b2 = block2([hdlr1]);
+    if (ctx['this'].show()) {
+      b3 = comp1({}, key + \`__1\`, node, this, null);
+    }
+    return multi([b2, b3]);
+  }
+}"
+`;
+
+exports[`hooks > useListener still receives an event dispatched while it is being attached 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
 exports[`hooks > useListener work with references 1`] = `
 "function anonymous(app, bdom, helpers
 ) {

--- a/packages/owl-runtime/tests/components/hooks.test.ts
+++ b/packages/owl-runtime/tests/components/hooks.test.ts
@@ -333,6 +333,134 @@ describe("hooks", () => {
     expect(fixture.innerHTML).toBe("<span>1</span>");
   });
 
+  // jsdom dispatches with a non-empty JS stack, so no microtask checkpoint
+  // happens mid-dispatch and a component cannot really be created while its
+  // creating event still bubbles. The tests below recreate that by dispatching
+  // the same event object a second time, which is what the guard keys on.
+  test("useListener ignores the event that created its component", async () => {
+    const steps: string[] = [];
+
+    class Child extends Component {
+      static template = xml`<div>child</div>`;
+      setup() {
+        useListener(window, "click", () => steps.push("clicked"));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`
+        <button t-on-click="() => this.show.set(true)">open</button>
+        <Child t-if="this.show()"/>`;
+      static components = { Child };
+      show = signal(false);
+    }
+
+    await mount(Parent, fixture);
+    const button = fixture.getElementsByTagName("button")[0];
+
+    const ev = new MouseEvent("click", { bubbles: true });
+    button.dispatchEvent(ev);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<button>open</button><div>child</div>");
+
+    // the click that created Child is still propagating: Child must not see it
+    window.dispatchEvent(ev);
+    expect(steps).toEqual([]);
+
+    // any subsequent click is a normal one
+    window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(steps).toEqual(["clicked"]);
+  });
+
+  test("useListener ignores the event that created its component, from another useListener", async () => {
+    const steps: string[] = [];
+
+    class Child extends Component {
+      static template = xml`<div>child</div>`;
+      setup() {
+        useListener(window, "click", () => steps.push("clicked"));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child t-if="this.show()"/>`;
+      static components = { Child };
+      show = signal(false);
+      setup() {
+        useListener(window, "click", () => this.show.set(true));
+      }
+    }
+
+    await mount(Parent, fixture);
+
+    const ev = new MouseEvent("click", { bubbles: true });
+    window.dispatchEvent(ev);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div>child</div>");
+
+    window.dispatchEvent(ev);
+    expect(steps).toEqual([]);
+
+    window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(steps).toEqual(["clicked"]);
+  });
+
+  test("useListener still receives an event dispatched while it is being attached", async () => {
+    // the guard only skips an event that was already in flight: an event
+    // dispatched by `setup()` itself is newer than the listener
+    let n = 0;
+
+    class MyComponent extends Component {
+      static template = xml`<div/>`;
+      setup() {
+        useListener(window, "click", () => n++);
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`
+        <button t-on-click="() => this.show.set(true)">open</button>
+        <MyComponent t-if="this.show()"/>`;
+      static components = { MyComponent };
+      show = signal(false);
+    }
+
+    await mount(Parent, fixture);
+    fixture
+      .getElementsByTagName("button")[0]
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+
+    expect(n).toBe(1);
+  });
+
+  test("useListener keeps the event target as `this`", async () => {
+    let receiver: any = null;
+    let reference: any = null;
+
+    class MyComponent extends Component {
+      static template = xml`<div/>`;
+      setup() {
+        useListener(window, "click", function (this: EventTarget) {
+          receiver = this;
+        });
+      }
+    }
+
+    await mount(MyComponent, fixture);
+    // compare with what a plain listener receives, rather than with `window`
+    // itself: jsdom's global `window` is not the object handed to listeners
+    window.addEventListener(
+      "click",
+      function (this: EventTarget) {
+        reference = this;
+      },
+      { once: true }
+    );
+    window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(reference).not.toBe(null);
+    expect(receiver).toBe(reference);
+  });
+
   describe("useEffect hook", () => {
     test("effect runs on mount, is reapplied on patch, and is cleaned up on unmount and before reapplying", async () => {
       let cleanupRun = 0;


### PR DESCRIPTION
`useListener(window, "click", ...)` in a component created by a click handler receives that very click, so a dialog closing on an outside click closes itself on the click that opened it. Guarding on `dialogRef().contains(ev.target)` does not help either, because the component is not in the DOM yet.

Owl renders in a microtask, and browsers drain them between two listeners of the same event, so owl sets the component up while the click is still bubbling towards `window`. A synthetic `el.click()` never reproduces it, which is why no test caught it.

`mainEventHandler` and `useListener` now record the event being dispatched and keep it past the end of the handler, so the microtask that creates the component can read it. `useListener` drops that exact event object, and only that one. The record is a `WeakRef`, since nothing clears it and an `Event` keeps its `target` alive.

Nothing new in the public types. Four tests in `hooks.test.ts`, `npm test` and `npm run test:types` pass.

One gap remains. A state change from a listener registered outside owl stays invisible to the guard.
