### PR TITLE
[FIX] owl-runtime: make a destroyed root inert

### DIFF
--- a/doc/v3/owl/reference/app.md
+++ b/doc/v3/owl/reference/app.md
@@ -162,6 +162,28 @@ the DOM. `destroy()` still cleans up the prepared subtree in either case.
 `validateTarget` runs at `mount` time, not at `prepare`, so a bad
 target surfaces synchronously when you actually try to mount.
 
+### Destroying a root
+
+`destroy()` is terminal: a destroyed root is inert. A teardown racing with
+an in-flight `prepare`-then-`mount` sequence therefore needs no guard at
+the call site.
+
+- `mount()` does nothing: no target validation, no DOM insertion. The
+  promise it returns stays pending — the mount was cancelled, not
+  completed.
+- `prepare()` starts no render and resolves immediately. A promise already
+  returned by an in-flight `prepare()` resolves at destroy time as well, so
+  `await root.prepare()` never hangs.
+- `root.destroyed` says which of the two happened, for code that needs to
+  branch after the await.
+
+```js
+const root = app.createRoot(MyComponent, { props });
+await root.prepare();
+// Safe even if something destroyed the root during the await.
+root.mount(targetElement);
+```
+
 ## Loading templates
 
 Most applications load their templates from the server at startup:

--- a/packages/owl-runtime/src/app.ts
+++ b/packages/owl-runtime/src/app.ts
@@ -73,12 +73,19 @@ interface Root<T extends ComponentConstructor> {
   // prepare() to detect a fully-synchronous subtree (Suspense's no-flash fast
   // path). false while the render is still pending or not yet started.
   readonly prepared: boolean;
+  // true once destroy() has been called. A destroyed root is inert: prepare()
+  // and mount() become no-ops, so a teardown racing with an in-flight
+  // prepare-then-mount sequence needs no guard at the call site.
+  readonly destroyed: boolean;
   // Kick off rendering without a DOM target. Descendants' onWillStart fires
   // immediately and the bdom is built in memory. Idempotent — second call
-  // returns the same promise. Resolves when the render phase finishes.
+  // returns the same promise. Resolves when the render phase finishes, or as
+  // soon as the root is destroyed (the render phase will then never complete).
   prepare(): Promise<void>;
   // Mount the (possibly already-prepared) bdom into target, then fire
   // onMounted hooks. If prepare() was not called, mount() prepares first.
+  // On a destroyed root this does nothing and the returned promise stays
+  // pending: the mount was cancelled, not completed.
   mount(target: MountTarget, options?: MountOptions): Promise<ComponentInstance<T>>;
   destroy(): void;
 }
@@ -153,10 +160,17 @@ export class App extends TemplateSet {
 
     let fiber: MountFiber | null = null;
     let preparedPromise: Promise<void> | null = null;
+    let resolvePrepared: (() => void) | null = null;
+    let destroyed = false;
 
     const prepare = (): Promise<void> => {
       if (preparedPromise) {
         return preparedPromise;
+      }
+      if (destroyed) {
+        // Destroyed before the render phase started: no fiber, and no
+        // onWillStart on an already finalized component.
+        return (preparedPromise = Promise.resolve());
       }
       if (error) {
         return Promise.reject(error);
@@ -177,6 +191,7 @@ export class App extends TemplateSet {
       });
 
       const ready = new Promise<void>((res) => {
+        resolvePrepared = res;
         fiber!.onPrepared = () => res();
       });
       preparedPromise = ready;
@@ -213,6 +228,12 @@ export class App extends TemplateSet {
     };
 
     const mount = (target: MountTarget, options?: MountOptions): Promise<ComponentInstance<T>> => {
+      if (destroyed) {
+        // Inert: no target validation, no dom insertion. Committing here would
+        // insert a finalized subtree into the document and flip it back to
+        // MOUNTED, with nothing left to ever clean it up.
+        return promise;
+      }
       if (error) {
         return promise;
       }
@@ -229,12 +250,23 @@ export class App extends TemplateSet {
         // set later, when the scheduler runs complete() in the next frame.)
         return fiber ? fiber.counter === 0 : false;
       },
+      get destroyed() {
+        return destroyed;
+      },
       promise,
       prepare,
       mount,
       destroy: () => {
+        if (destroyed) {
+          return;
+        }
+        destroyed = true;
         this.roots.delete(root);
         node?.destroy();
+        // The scheduler drops fibers whose node is destroyed, so complete()
+        // (and with it onPrepared) will never run. Resolve here instead, so
+        // `await root.prepare()` does not hang forever.
+        resolvePrepared?.();
       },
     };
     this.roots.add(root);

--- a/packages/owl-runtime/tests/app/prepare_mount.test.ts
+++ b/packages/owl-runtime/tests/app/prepare_mount.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, onMounted, onWillStart, xml } from "../../src";
+import { App, Component, onMounted, onWillDestroy, onWillStart, status, xml } from "../../src";
 import { makeDeferred, makeTestFixture, nextTick } from "../helpers";
 
 let fixture: HTMLElement;
@@ -158,5 +158,135 @@ test("prepare-then-mount renders in parallel with another root", async () => {
   await nextTick();
   await nextTick();
   expect(order).toContain("a:end");
+  app.destroy();
+});
+
+test("mount() after destroy() is a no-op", async () => {
+  const steps: string[] = [];
+
+  class Root extends Component {
+    static template = xml`<span>ok</span>`;
+    setup() {
+      onMounted(() => steps.push("mounted"));
+      onWillDestroy(() => steps.push("willDestroy"));
+    }
+  }
+
+  const app = new App();
+  const root = app.createRoot(Root);
+  await root.prepare();
+  root.destroy();
+  expect(root.destroyed).toBe(true);
+
+  // The target is perfectly valid here: nothing but the destroyed flag stops
+  // the commit from resurrecting the finalized subtree.
+  let mounted = false;
+  root.mount(fixture).then(() => (mounted = true));
+  await nextTick();
+  expect(steps).toEqual(["willDestroy"]);
+  expect(fixture.innerHTML).toBe("");
+  // The mount was cancelled, not completed: its promise never settles.
+  expect(mounted).toBe(false);
+  app.destroy();
+});
+
+test("mount() after destroy() does not validate the target", async () => {
+  class Root extends Component {
+    static template = xml`<span>ok</span>`;
+  }
+
+  const app = new App();
+  const root = app.createRoot(Root);
+  await root.prepare();
+  root.destroy();
+  // A teardown often detaches the target before the root is destroyed: that
+  // must not turn into a mount-time crash.
+  const detached = document.createElement("div");
+  expect(() => root.mount(detached)).not.toThrow();
+  app.destroy();
+});
+
+test("destroy() while the render phase is pending resolves prepare()", async () => {
+  const steps: string[] = [];
+  const rpc = makeDeferred<string>();
+
+  class Root extends Component {
+    static template = xml`<span t-out="this.data"/>`;
+    data = "";
+    setup() {
+      onWillStart(async () => {
+        this.data = await rpc;
+        steps.push("willStart:end");
+      });
+      onMounted(() => steps.push("mounted"));
+    }
+  }
+
+  const app = new App();
+  const root = app.createRoot(Root);
+  const prepared = root.prepare();
+  await nextTick();
+
+  // Destroyed mid-render: the scheduler will drop the fiber, so complete()
+  // never runs and prepare() would otherwise hang forever.
+  root.destroy();
+  rpc.resolve("hello");
+  await prepared;
+
+  root.mount(fixture);
+  await nextTick();
+  expect(steps).toEqual(["willStart:end"]);
+  expect(fixture.innerHTML).toBe("");
+  app.destroy();
+});
+
+test("prepare() after destroy() does not start a render", async () => {
+  const steps: string[] = [];
+
+  class Root extends Component {
+    static template = xml`<span>ok</span>`;
+    setup() {
+      onWillStart(() => steps.push("willStart"));
+    }
+  }
+
+  const app = new App();
+  const root = app.createRoot(Root);
+  root.destroy();
+
+  const p1 = root.prepare();
+  const p2 = root.prepare();
+  expect(p1).toBe(p2);
+  await p1;
+  expect(steps).toEqual([]);
+  expect(root.prepared).toBe(false);
+  app.destroy();
+});
+
+test("destroy() is idempotent and keeps the component destroyed", async () => {
+  const steps: string[] = [];
+
+  class Root extends Component {
+    static template = xml`<span>ok</span>`;
+    setup() {
+      onWillDestroy(() => steps.push("willDestroy"));
+    }
+  }
+
+  const app = new App();
+  const root = app.createRoot(Root);
+  const component = await root.mount(fixture);
+  expect(fixture.innerHTML).toBe("<span>ok</span>");
+
+  root.destroy();
+  root.destroy();
+  expect(steps).toEqual(["willDestroy"]);
+  expect(fixture.innerHTML).toBe("");
+  expect(status(component)).toBe("destroyed");
+
+  root.mount(fixture);
+  await nextTick();
+  expect(fixture.innerHTML).toBe("");
+  expect(status(component)).toBe("destroyed");
   app.destroy();
 });


### PR DESCRIPTION
Reported on the forum: with

```js
const root = app.createRoot(Component, { props });
await root.prepare();
root.mount(target);
```

a `root.destroy()` landing during the `await` still let `mount()` run
`validateTarget(target)`, which throws if the teardown detached the target
in the meantime.

The throw turns out to be the lucky path. On a *valid* target nothing stops
the commit: the finalized subtree is inserted into the document, the node's
status flips back to `MOUNTED` and `onMounted` fires after `onWillDestroy`.
Its scope is already finalized, so it never re-renders, and `destroy()` has
dropped the root from `app.roots`, so `app.destroy()` won't collect it
either — a permanent zombie subtree.

`prepare()` had the symmetric problems: called after `destroy()` it ran
`onWillStart` on a finalized component, and a `destroy()` during the render
phase left it pending forever (the scheduler drops fibers whose node is
destroyed, so `complete()` — and with it `onPrepared` — never runs).

The root now tracks its own destroyed state instead of leaving it for the
scheduler to notice:

- `mount()` returns before touching the target: no validation, no DOM
  insertion.
- `prepare()` starts no render and resolves immediately.
- `destroy()` resolves an in-flight prepared promise, so
  `await root.prepare()` cannot hang.
- `root.destroyed` is exposed for callers that need to branch after an await.

`prepare()`-then-`mount()` is now safe with no guard at the call site.

### Design note

The cancelled mount's promise stays **pending** rather than rejecting.
Rejecting would be more explicit, but it turns every teardown race into an
unhandled rejection — precisely the guard-everywhere burden this is meant to
remove — and resolving it would hand out a destroyed instance. Pending also
matches what already happened when a root was destroyed mid-render. The cost:
`await root.mount(target)` never returns on a destroyed root; `root.destroyed`
is the escape hatch for code that must continue.
