### PR TITLE
[FIX] owl-runtime: detach the element before unbinding its refs

### DIFF
--- a/packages/owl-runtime/src/blockdom/block_compiler.ts
+++ b/packages/owl-runtime/src/blockdom/block_compiler.ts
@@ -655,6 +655,14 @@ function createBlockClass(template: HTMLElement, ctx: BlockCtx): BlockClass {
     };
 
     Block.prototype.remove = function remove() {
+      // Detach first, unbind the refs after. The removal is where the browser
+      // hands control back to user code: chrome dispatches `change` and `blur`
+      // synchronously from inside remove() on a focused input whose value is not
+      // committed yet, and both a t-on handler and a useListener one run there.
+      // Unbinding first would leave them reading a null ref while their element
+      // is still in the document.
+      elementRemove.call(this.el);
+
       if (cbRefs.length) {
         const data = this.data!;
         const refs = this.refs!;
@@ -663,8 +671,6 @@ function createBlockClass(template: HTMLElement, ctx: BlockCtx): BlockClass {
           fn(null, refs[locRefIdxs[cbRef]]);
         }
       }
-
-      elementRemove.call(this.el);
     };
   }
   return Block;

--- a/packages/owl-runtime/tests/components/__snapshots__/refs.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/refs.test.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`refs > a listener firing during the removal still sees its ref 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  let block2 = createBlock(\`<input block-ref="0"/>\`);
+  
+  return function template(ctx, node, key = "") {
+    let b2;
+    if (ctx['this'].show()) {
+      let ref1 = createRef(ctx['this'].input, node);
+      b2 = block2([ref1]);
+    }
+    return block1([], [b2]);
+  }
+}"
+`;
+
 exports[`refs > basic use 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
@@ -326,6 +346,26 @@ exports[`refs > ref is unset even when a sub-root is destroyed re-entrantly mid-
   
   return function template(ctx, node, key = "") {
     const b2 = callSlot(ctx, node, key, 'default', false, {});
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`refs > ref is unset only once its element is detached 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createRef } = helpers;
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  let block2 = createBlock(\`<span block-ref="0"/>\`);
+  
+  return function template(ctx, node, key = "") {
+    let b2;
+    if (ctx['this'].show()) {
+      let ref1 = createRef(ctx['this'].myRef, node);
+      b2 = block2([ref1]);
+    }
     return block1([], [b2]);
   }
 }"

--- a/packages/owl-runtime/tests/components/refs.test.ts
+++ b/packages/owl-runtime/tests/components/refs.test.ts
@@ -11,11 +11,27 @@ import {
   signal,
   computed,
   Resource,
+  useListener,
 } from "../../src";
 import { logStep, makeTestFixture, nextAppError, nextTick, snapshotEverything } from "../helpers";
 
 snapshotEverything();
 let fixture: HTMLElement;
+
+// Browsers dispatch events synchronously from inside remove(): chrome fires
+// `change` when a focused input whose value is not committed yet gets detached.
+// jsdom does not, so an element opts in by carrying the event it should fire on
+// removal. Installed here rather than inside a test because blockdom captures
+// Element.prototype.remove when it builds a block class, and those classes are
+// cached across tests.
+const originalElementRemove = Element.prototype.remove;
+Element.prototype.remove = function (this: Element) {
+  const eventName = (this as any).fireOnRemove;
+  if (eventName) {
+    this.dispatchEvent(new Event(eventName));
+  }
+  originalElementRemove.call(this);
+};
 
 beforeEach(() => {
   fixture = makeTestFixture();
@@ -459,5 +475,59 @@ describe("refs", () => {
     root.show.set(false);
     await nextTick();
     expect(root.myRef()).toBeNull();
+  });
+
+  test("ref is unset only once its element is detached", async () => {
+    const steps: string[] = [];
+    class Test extends Component {
+      static template = xml`<div><span t-if="this.show()" t-ref="this.myRef"/></div>`;
+      show = signal(true);
+      el: HTMLElement | null = null;
+      myRef = {
+        set: (el: HTMLElement | null) => {
+          if (el) {
+            this.el = el;
+          } else {
+            steps.push(`unset, element connected=${this.el!.isConnected}`);
+          }
+        },
+      };
+    }
+
+    const test = await mount(Test, fixture);
+    expect(test.el).toBe(fixture.querySelector("span"));
+
+    test.show.set(false);
+    await nextTick();
+    expect(steps).toEqual(["unset, element connected=false"]);
+  });
+
+  test("a listener firing during the removal still sees its ref", async () => {
+    // Reached in practice because owl patches on an animation frame: the frame
+    // can land between the keydown handler that hides the input and the key
+    // press that commits its value, so the input is still dirty when detached.
+    const steps: string[] = [];
+    class Test extends Component {
+      static template = xml`<div><input t-if="this.show()" t-ref="this.input"/></div>`;
+      show = signal(true);
+      input = signal.ref(HTMLInputElement);
+      setup() {
+        useListener(this.input, "change", () => {
+          const el = this.input();
+          steps.push(`change: ref=${el ? el.value : null}`);
+        });
+      }
+    }
+
+    const test = await mount(Test, fixture);
+    const input = fixture.querySelector("input")!;
+    input.value = "hello";
+    (input as any).fireOnRemove = "change";
+
+    test.show.set(false);
+    await nextTick();
+
+    expect(steps).toEqual(["change: ref=hello"]);
+    expect(test.input()).toBeNull();
   });
 });


### PR DESCRIPTION
Typing in a `t-ref` input and pressing Enter to hide it could crash with `Cannot read properties of null` inside a `useListener(ref, "change", ...)` handler: `this.input()` was already null while the input was still in the document.

`Block.remove` unbound the refs before calling `elementRemove`, and chrome dispatches `change` and `blur` synchronously from inside `remove()` when a focused input whose value is not committed yet gets detached. The handler therefore ran between the ref write and the detach, with the listener still attached, since `useListener` tears down through `useEffect` and that cleanup is batched to the next microtask.

Reaching it takes a race with the animation frame, which is why it looked intermittent and why typing fast is what surfaced it. Chrome splits one Enter press into separate `rawKeyDown` and `char` tasks, and the `char` is what carries the commit-the-value default action. Owl patches on rAF, so a frame landing between the two removes the input while it is still dirty. Driving chrome over CDP with an injected gap between the two halves of the key press, it crashes from about 10ms up and is clean below 5ms, one frame phase.

### Why this order and not the mirror of mount

The obvious objection is symmetry: `mount` inserts the node and then sets the ref, so the mirror image would unset the ref and then detach. That order protects *ref is non-null implies the element is in the dom*, and this patch protects the opposite, *the element is in the dom implies the ref is non-null*. Both cannot hold: the ref write and the dom mutation are two operations, and the browser can run script between them.

The tie-break is that the two sides differ in what they call back into. Insertion does not hand control to user code, removal does. Chrome fires the event before it finishes detaching, so `isConnected` is still true inside the handler, and the observable states are:

```
unbind first:   ref=null, connected    <- the handler runs here
                ref=null, detached

detach first:   ref=el,   connected    <- the handler runs here
                ref=el,   detached     <- owl-only, no user code can observe it
                ref=null, detached
```

The stale window still exists, it just moves to where nothing can see it. One hole is left: a block carrying two refs, where the first `set(null)` is user code that reads the second and finds it pointing at a detached element. Narrow, and it was equally odd before with the null on the other side.

This is also not a `useListener` quirk. A compiled `t-on-change` fires during the same removal, since `t-on` attaches a native listener on the element and guards on `inOwnerDocument`, which is still true at that point. So `t-on-change="() => this.save(this.input().value)"` was the same latent crash.

### Tests

Two in `refs.test.ts`, one on the invariant and one reproducing the crash. The second patches `Element.prototype.remove` at module scope, because blockdom captures it when it builds a block class and those classes are cached across tests. `npm test` passes.

One gap remains. Firefox fires no `change` at all when a dirty input is detached, so there the typed value is silently dropped rather than crashing. That is inherent to removing a focused input mid-edit and wants `t-model` or an explicit commit rather than an ordering change.
