### PR TITLE
[FIX] doc: update broken reference links to v3

### DIFF
--- a/packages/owl-runtime/tests/components/lifecycle.test.ts
+++ b/packages/owl-runtime/tests/components/lifecycle.test.ts
@@ -948,7 +948,7 @@ describe("lifecycle hooks", () => {
     expect(created).toBe(true);
   });
 
-  // TODO: rename (corresponds to https://github.com/odoo/owl/blob/master/doc/reference/concurrency_model.md#semantics)
+  // TODO: rename (corresponds to https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/concurrency_model.md#semantics)
   test("component semantics", async () => {
     class TestWidget extends Component {
       name: string = "test";

--- a/tools/playground/samples/v3/tutorials/getting_started/1/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/1/readme.md
@@ -30,8 +30,8 @@ A **signal** is a reactive container for a value. You create one with `signal(in
 read it by calling it as a function (`signal()`), and update it with `.set(newValue)`.
 Whenever a signal's value changes, Owl automatically re-renders every component
 that read that signal during its last render — you never have to manually
-trigger an update. See the [Signals](https://github.com/odoo/owl/blob/master/doc/reference/reactivity.md#signals)
-section for more details.
+trigger an update. See the [Signals](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/signals.md)
+documentation for more details.
 
 Import `signal` from `@odoo/owl` and create one as a class property:
 

--- a/tools/playground/samples/v3/tutorials/todo_list/2/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/2/readme.md
@@ -13,7 +13,7 @@ Here is what you need to do:
 You will quickly notice that pushing into the array does not update the UI.
 This is because Owl needs a reactive data structure to know when to re-render.
 You will need to convert the `todos` array into a `signal.Array`. See the
-[Reactivity](https://github.com/odoo/owl/blob/master/doc/reference/reactivity.md)
+[Signals](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/signals.md#collection-signals)
 documentation for more details on signals and `signal.Array`.
 
 ### Hints

--- a/tools/playground/samples/v3/tutorials/todo_list/8/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/8/readme.md
@@ -9,7 +9,7 @@ independently from any component. A plugin can hold reactive state (like our
 todo list), provide a service (like a notification system or a storage layer),
 or both. They allow you to separate business logic from UI code, and to share
 that logic across multiple components. See the
-[Plugins documentation](https://github.com/odoo/owl/blob/master/doc/reference/plugins.md)
+[Plugins documentation](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/plugins.md)
 for more details.
 
 In this step, you will extract the todo list management into a


### PR DESCRIPTION
Before this commit, several playground samples and a test comment linked to the old `doc/reference/*.md` paths. These links returned a 404 error because the documentation was recently moved to `doc/v3/owl/reference/`.

Additionally, step 2 of the `todo_list` tutorial incorrectly linked to `reactivity.md` to explain `signal.Array`.

This commit updates all outdated paths to point to the new `v3` folders. It also fixes the `todo_list` link so it correctly points to `signals.md#collection-signals`, where `signal.Array` is actually documented.