### PR TITLE
[IMP] playground: add a Vim mode toggle to the code editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4816,6 +4816,16 @@
         "marked": "14.0.0"
       }
     },
+    "node_modules/monaco-vim": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/monaco-vim/-/monaco-vim-0.4.4.tgz",
+      "integrity": "sha512-LNChAb//WEm/W+eyeHG/0+pdVEHotk2hLTN+M3sQZx5E8cAlSWSgqcxpcRuQnxDybSln7pfHF9i63HmbIQvrWw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6842,6 +6852,7 @@
       "devDependencies": {
         "@shikijs/monaco": "^4.2.0",
         "monaco-editor": "^0.55.1",
+        "monaco-vim": "^0.4.4",
         "shiki": "^4.2.0"
       }
     },

--- a/tools/playground/build_monaco.mjs
+++ b/tools/playground/build_monaco.mjs
@@ -15,6 +15,24 @@ const outputFile = path.resolve(
   "libs/monaco/monaco.bundle.js"
 );
 
+// monaco-vim's ESM build imports monaco-editor submodules (e.g.
+// "monaco-editor/esm/vs/editor/editor.api") without a ".js" extension.
+// monaco-editor's package.json "exports" map ("./*": "./*") only matches
+// literal file paths, so esbuild can't resolve those on its own — add the
+// extension back ourselves.
+const monacoEsmExtensionPlugin = {
+  name: "monaco-editor-esm-js-extension",
+  setup(build) {
+    build.onResolve({ filter: /^monaco-editor\/esm\/vs\// }, (args) => {
+      if (args.path.endsWith(".js")) {
+        return null;
+      }
+      const rel = args.path.slice("monaco-editor/esm/vs/".length);
+      return { path: path.join(monacoRoot, rel + ".js") };
+    });
+  },
+};
+
 const tempEntry = path.resolve(
   rootDir,
   "temp_monaco_entry.mjs"
@@ -27,6 +45,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.main.js";
 import "monaco-editor/esm/vs/language/css/monaco.contribution.js";
 import "monaco-editor/esm/vs/language/html/monaco.contribution.js";
 import "monaco-editor/esm/vs/language/typescript/monaco.contribution.js";
+import { initVimMode } from "monaco-vim";
 
 export const {
   editor,
@@ -37,6 +56,8 @@ export const {
   KeyCode,
   typescript,
 } = monaco;
+
+export { initVimMode };
 `
 );
 
@@ -70,6 +91,17 @@ try {
     format: "esm",
     minify: true,
     target: "es2022",
+    // monaco-vim's "exports" map picks its standalone UMD build under the
+    // "browser" condition, which bundles its own separate copy of
+    // monaco-editor's internals. Alias straight to its ESM build instead,
+    // so it shares this bundle's single monaco-editor module graph.
+    alias: {
+      "monaco-vim": path.resolve(
+        rootDir,
+        "node_modules/monaco-vim/dist/index.mjs"
+      ),
+    },
+    plugins: [monacoEsmExtensionPlugin],
     loader: {
       ".ttf": "file",
       ".css": "css",

--- a/tools/playground/package.json
+++ b/tools/playground/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@shikijs/monaco": "^4.2.0",
     "monaco-editor": "^0.55.1",
+    "monaco-vim": "^0.4.4",
     "shiki": "^4.2.0"
   }
 }

--- a/tools/playground/src/components.js
+++ b/tools/playground/src/components.js
@@ -45,6 +45,8 @@ class CodeEditor extends Component {
     this.secondaryEditorNode = signal(null);
     this.primaryMarkdownPreview = signal(null);
     this.secondaryMarkdownPreview = signal(null);
+    this.primaryVimStatusBar = signal(null);
+    this.secondaryVimStatusBar = signal(null);
 
     this.panes = {
       primary: {
@@ -52,12 +54,14 @@ class CodeEditor extends Component {
         models: {},
         scrolls: {},
         lastFile: null,
+        vimAdapter: null,
       },
       secondary: {
         editor: null,
         models: {},
         scrolls: {},
         lastFile: null,
+        vimAdapter: null,
       },
     };
 
@@ -91,6 +95,7 @@ class CodeEditor extends Component {
       pane.editor = this.createEditor(pane,this.primaryEditorNode(), model);
       pane.lastFile = fileName;
       lastVersion = this.code.contentVersion();
+      this._applyVimMode(pane, this.primaryVimStatusBar());
     });
 
     useEffect(() => {
@@ -154,10 +159,12 @@ class CodeEditor extends Component {
         pane.editor = this.createEditor(pane, node, model);
         pane.models[fileName] = model;
         pane.lastFile = fileName;
+        this._applyVimMode(pane, this.secondaryVimStatusBar());
       }
       if (!split && this.panes.secondary.editor) {
+        this.panes.secondary.vimAdapter?.dispose();
         this.panes.secondary.editor.dispose();
-        this.panes.secondary = { editor: null, models: {}, scrolls: {}, lastFile: null };
+        this.panes.secondary = { editor: null, models: {}, scrolls: {}, lastFile: null, vimAdapter: null };
       }
     });
 
@@ -192,6 +199,13 @@ class CodeEditor extends Component {
             fontSize: size,
           });
         }
+      }
+    });
+
+    useEffect(() => {
+      this._applyVimMode(this.panes.primary, this.primaryVimStatusBar());
+      if (this.panes.secondary.editor) {
+        this._applyVimMode(this.panes.secondary, this.secondaryVimStatusBar());
       }
     });
 
@@ -233,6 +247,7 @@ class CodeEditor extends Component {
 
     onWillUnmount(() => {
       for (const pane of Object.values(this.panes)) {
+        pane.vimAdapter?.dispose();
         if (pane.editor) pane.editor.dispose();
         for (const model of Object.values(pane.models)) {
           model.dispose();
@@ -438,6 +453,18 @@ class CodeEditor extends Component {
     return editor;
   }
 
+  _applyVimMode(pane, statusBarNode) {
+    if (!pane.editor) return;
+    if (this.settings.vimMode()) {
+      if (!pane.vimAdapter) {
+        pane.vimAdapter = monaco.initVimMode(pane.editor, statusBarNode);
+      }
+    } else if (pane.vimAdapter) {
+      pane.vimAdapter.dispose();
+      pane.vimAdapter = null;
+    }
+  }
+
   createModel(content, fileName) {
     const lang = getFileType(fileName);
     const activeProject = this.project.activeProject();
@@ -581,6 +608,9 @@ class SettingsDialog extends Component {
   }
   onDarkModeChange(ev) {
     this.settings.setDarkMode(ev.target.checked);
+  }
+  onVimModeChange(ev) {
+    this.settings.setVimMode(ev.target.checked);
   }
   close() {
     this.dialog.closeDialog();

--- a/tools/playground/src/plugins.js
+++ b/tools/playground/src/plugins.js
@@ -1026,6 +1026,7 @@ class SettingsPlugin extends Plugin {
   fontSize = signal(parseInt(localStorage.getItem("owl-playground-font-size")) || 13);
   autoRun = signal(localStorage.getItem("owl-playground-auto-run") === "true");
   darkMode = signal(localStorage.getItem("owl-playground-dark-mode") !== "false");
+  vimMode = signal(localStorage.getItem("owl-playground-vim-mode") === "true");
   fullscreen = signal(false);
   leftPaneWidth = signal(Math.ceil((window.innerWidth + 160) / 2));
   sidebarWidth = signal(180);
@@ -1055,6 +1056,11 @@ class SettingsPlugin extends Plugin {
   setAutoRun(value) {
     this.autoRun.set(value);
     localStorage.setItem("owl-playground-auto-run", String(value));
+  }
+
+  setVimMode(value) {
+    this.vimMode.set(value);
+    localStorage.setItem("owl-playground-vim-mode", String(value));
   }
 
   setLeftPaneWidth(width) {

--- a/tools/playground/static/playground.css
+++ b/tools/playground/static/playground.css
@@ -767,6 +767,20 @@ body {
   overflow: auto;
 }
 
+.vim-status-bar {
+  flex-shrink: 0;
+  height: 20px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-family: monospace;
+  background: #1e293b;
+  color: #abb2bf;
+  border-top: 1px solid #0f172a;
+}
+
 /* MARKDOWN TOGGLE BUTTON ****************************************/
 .markdown-toggle-btn {
   display: inline-flex;
@@ -2528,6 +2542,12 @@ body {
 
 .light-mode .editor-tab-bar {
   background: #f0f1f3;
+}
+
+.light-mode .vim-status-bar {
+  background: #f0f1f3;
+  color: #3d3d4e;
+  border-top-color: #e0e0e8;
 }
 
 .light-mode .editor-tab {

--- a/tools/playground/static/templates.xml
+++ b/tools/playground/static/templates.xml
@@ -12,6 +12,7 @@
       <div class="editor-pane-content">
         <div class="code-editor" t-ref="this.primaryEditorNode" t-att-hidden="this.isPrimaryMarkdownPreview()"/>
         <div class="markdown-preview" t-ref="this.primaryMarkdownPreview" t-att-hidden="!this.isPrimaryMarkdownPreview()" t-att-style="'font-size: ' + this.settings.fontSize() + 'px'"/>
+        <div class="vim-status-bar" t-ref="this.primaryVimStatusBar" t-att-hidden="!this.settings.vimMode() || this.isPrimaryMarkdownPreview()"/>
       </div>
     </div>
     <div class="editor-split-separator" t-if="this.code.splitMode()" t-on-mousedown="this.onSplitSeparatorMouseDown"/>
@@ -27,6 +28,7 @@
       <div class="editor-pane-content">
         <div class="code-editor" t-ref="this.secondaryEditorNode" t-att-hidden="this.isSecondaryMarkdownPreview()"/>
         <div class="markdown-preview" t-ref="this.secondaryMarkdownPreview" t-att-hidden="!this.isSecondaryMarkdownPreview()" t-att-style="'font-size: ' + this.settings.fontSize() + 'px'"/>
+        <div class="vim-status-bar" t-ref="this.secondaryVimStatusBar" t-att-hidden="!this.settings.vimMode() || this.isSecondaryMarkdownPreview()"/>
       </div>
     </div>
   </div>
@@ -101,6 +103,16 @@
           <input type="checkbox" t-att-checked="this.settings.darkMode()" t-on-change="this.onDarkModeChange"/>
           <span t-if="this.settings.darkMode()">Dark</span>
           <span t-else="">Light</span>
+        </label>
+      </div>
+    </div>
+    <div class="settings-row">
+      <label>Vim mode</label>
+      <div class="settings-control">
+        <label class="theme-toggle-label">
+          <input type="checkbox" t-att-checked="this.settings.vimMode()" t-on-change="this.onVimModeChange"/>
+          <span t-if="this.settings.vimMode()">On</span>
+          <span t-else="">Off</span>
         </label>
       </div>
     </div>


### PR DESCRIPTION
This commit introduces a "Vim mode" setting to the playground (disabled by default). When enabled, it dynamically attaches `monaco-vim` to every open editor pane and displays a status bar showing the current Vim mode and command buffer. Like other playground settings, this preference is persisted in `localStorage`.

Technical note on bundling:
The `monaco-vim` library is bundled directly into the same esbuild entry point that produces `libs/monaco/monaco.bundle.js`, rather than as a separate bundle. Because its ESM build imports `monaco-editor` internals directly (instead of using the public API), it must share the exact same module graph as the rest of Monaco to avoid pulling in a duplicate copy.