### PR TITLE
[FIX] playground: fix props validation readme in getting_started tuto…

### DIFF
--- a/tools/playground/samples/v3/tutorials/getting_started/3/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/3/readme.md
@@ -28,7 +28,7 @@ class ProductCard extends Component {
   props = useProps({
     name: t.string(),
     price: t.number(),
-    "image?": t.string(),
+    image: t.string().optional(),
   });
 }
 ```
@@ -40,8 +40,9 @@ Since we named the property `props`, we access values in the template with
 <span t-out="this.props.name"/>
 ```
 
-A `?` suffix marks a prop as optional. When `dev: true` is set in the app,
-Owl will check that required props are provided and that their types match.
+Calling `.optional()` on a type marks the prop as optional. When `dev: true`
+is set in the app, Owl will check that required props are provided and that
+their types match.
 
 The `types` helper supports many other types:
 
@@ -51,14 +52,12 @@ The `types` helper supports many other types:
 - `t.signal()`
 - `t.array(t.string())`
 
-The `useProps` function accepts a second argument for **default values**:
+Passing a value to `.optional(value)` also declares a **default value**:
 
 ```js
 props = useProps({
     name: t.string(),
-    "image?": t.string(),
-}, {
-    image: "📦",
+    image: t.string().optional("📦"),
 });
 ```
 


### PR DESCRIPTION
…rial

Before this commit, the readme for step 3 of the `getting_started` tutorial documented a `"key?"` suffix and a `useProps(schema, defaults)` signature. Neither of these syntaxes actually exist in the OWL API.

This commit updates the tutorial to reflect the real API. It now correctly demonstrates the chainable `.optional()` and `.optional(value)` syntax, aligning the readme with the code in `product_card.js` and the official documentation in `reference/props.md`.