### PR TITLE
[IMP] playground: add reference links to getting_started tutorial

### DIFF
--- a/tools/playground/samples/v3/tutorials/getting_started/1/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/1/readme.md
@@ -7,7 +7,7 @@ on what you learned before.
 
 Use the navigation bar above the editor to move between steps. Each step
 includes hints and a solution you can reveal if you get stuck. You can also
-refer to the [Owl documentation](https://github.com/odoo/owl/tree/master#documentation)
+refer to the [Owl documentation](https://odoo.github.io/owl/documentation/v3/owl/)
 at any time. Let's begin!
 
 ---
@@ -30,7 +30,7 @@ A **signal** is a reactive container for a value. You create one with `signal(in
 read it by calling it as a function (`signal()`), and update it with `.set(newValue)`.
 Whenever a signal's value changes, Owl automatically re-renders every component
 that read that signal during its last render — you never have to manually
-trigger an update. See the [Signals](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/signals.md)
+trigger an update. See the [Signals](https://odoo.github.io/owl/documentation/v3/owl/reference/signals.html)
 documentation for more details.
 
 Import `signal` from `@odoo/owl` and create one as a class property:

--- a/tools/playground/samples/v3/tutorials/getting_started/4/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/4/readme.md
@@ -24,7 +24,8 @@ signal. When the user types, the signal is updated automatically:
 ```
 
 A `computed` value is derived from other signals. It updates automatically
-when its dependencies change:
+when its dependencies change. See the [Computed Values](https://odoo.github.io/owl/documentation/v3/owl/reference/computed_values.html)
+documentation for more details.
 
 ```js
 import { signal, computed } from "@odoo/owl";

--- a/tools/playground/samples/v3/tutorials/getting_started/5/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/5/readme.md
@@ -1,9 +1,12 @@
 ## Lifecycle Hooks
 
-Components have a lifecycle: they are created, mounted into the DOM, and
-eventually removed. Owl provides **hooks** to run code at specific moments in
-this lifecycle. In this step, you will build a `Timer` component that starts
-counting when mounted and cleans up when removed.
+Components have a [lifecycle](https://odoo.github.io/owl/documentation/v3/owl/reference/component.html#lifecycle):
+they are created, mounted into the DOM, and eventually removed. Owl provides
+**hooks** to run code at specific moments in this lifecycle. In this step, you
+will build a `Timer` component that starts counting when mounted and cleans up
+when removed. See the
+[Lifecycle Hooks](https://odoo.github.io/owl/documentation/v3/owl/reference/hooks.html#lifecycle-hooks)
+documentation for more details.
 
 Here is what you need to do:
 

--- a/tools/playground/samples/v3/tutorials/todo_list/2/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/2/readme.md
@@ -13,7 +13,7 @@ Here is what you need to do:
 You will quickly notice that pushing into the array does not update the UI.
 This is because Owl needs a reactive data structure to know when to re-render.
 You will need to convert the `todos` array into a `signal.Array`. See the
-[Signals](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/signals.md#collection-signals)
+[Signals](https://odoo.github.io/owl/documentation/v3/owl/reference/signals.html#collection-signals)
 documentation for more details on signals and `signal.Array`.
 
 ### Hints

--- a/tools/playground/samples/v3/tutorials/todo_list/8/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/8/readme.md
@@ -9,7 +9,7 @@ independently from any component. A plugin can hold reactive state (like our
 todo list), provide a service (like a notification system or a storage layer),
 or both. They allow you to separate business logic from UI code, and to share
 that logic across multiple components. See the
-[Plugins documentation](https://github.com/odoo/owl/blob/master/doc/v3/owl/reference/plugins.md)
+[Plugins documentation](https://odoo.github.io/owl/documentation/v3/owl/reference/plugins.html)
 for more details.
 
 In this step, you will extract the todo list management into a


### PR DESCRIPTION
In step 1 of the `getting_started` tutorial, there is already a helpful link to the Signals reference documentation. However, the subsequent steps lacked similar references.

This commit improves the tutorial by adding direct links to the "Computed Values" and "Lifecycle Hooks" reference pages. This matches the format of step 1 and ensures a consistent learning experience throughout the tutorial.