### PR TITLE
[IMP] playground: add reference links to getting_started and todo_lis…

### DIFF
--- a/tools/playground/samples/v3/tutorials/getting_started/2/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/2/readme.md
@@ -40,7 +40,9 @@ class Root extends Component {
 }
 ```
 
-Each `<Counter />` instance will have its own independent state.
+Each `<Counter />` instance will have its own independent state. See the
+[Sub Components](https://odoo.github.io/owl/documentation/v3/owl/reference/component.html#sub-components)
+documentation for more details.
 
 To move a template to its own XML file, create a `counter.xml` with a
 `t-name` attribute, and reference it by name in the component:

--- a/tools/playground/samples/v3/tutorials/getting_started/3/readme.md
+++ b/tools/playground/samples/v3/tutorials/getting_started/3/readme.md
@@ -19,7 +19,9 @@ Here is what you need to do:
 ### Hints
 
 To define and validate props, use the `useProps` function together with `types`.
-The property name you assign it to is how you access it in the template:
+The property name you assign it to is how you access it in the template. See the
+[useProps](https://odoo.github.io/owl/documentation/v3/owl/reference/props.html#the-useprops-function)
+documentation for more details.
 
 ```js
 import { Component, useProps, t } from "@odoo/owl";
@@ -44,7 +46,7 @@ Calling `.optional()` on a type marks the prop as optional. When `dev: true`
 is set in the app, Owl will check that required props are provided and that
 their types match.
 
-The `types` helper supports many other types:
+The `types` helper supports many other [validators](https://odoo.github.io/owl/documentation/v3/owl/reference/types_validation.html#validators):
 
 - `t.boolean()`, `t.number()`, `t.string()`
 - `t.function()`

--- a/tools/playground/samples/v3/tutorials/todo_list/1/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/1/readme.md
@@ -27,7 +27,9 @@ Here is what you need to do:
 
 ### Hints
 
-To iterate over a list in a template, use `t-foreach` with a `t-key`:
+To iterate over a list in a template, use `t-foreach` with a `t-key`. See the
+[Loops](https://odoo.github.io/owl/documentation/v3/owl/reference/template_syntax.html#loops)
+documentation for more details.
 
 ```xml
 <t t-foreach="this.todos" t-as="todo" t-key="todo.id">

--- a/tools/playground/samples/v3/tutorials/todo_list/4/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/4/readme.md
@@ -21,7 +21,9 @@ Here is what you need to do:
 ### Hints
 
 The `t-ref` directive links a DOM element to a signal. After the component is
-mounted, the signal contains the actual DOM element:
+mounted, the signal contains the actual DOM element. See the
+[References](https://odoo.github.io/owl/documentation/v3/owl/reference/refs.html)
+documentation for more details.
 
 ```js
 import { signal, onMounted } from "@odoo/owl";
@@ -43,3 +45,8 @@ In the template:
 
 Note that the signal is `null` before mounting — that is why we need
 `onMounted` to safely access the DOM element.
+
+A function that starts with `use` and calls other hooks, like `useAutofocus`,
+is called a **custom hook**. See the
+[Hook Rule](https://odoo.github.io/owl/documentation/v3/owl/reference/hooks.html#the-hook-rule)
+documentation for more details.

--- a/tools/playground/samples/v3/tutorials/todo_list/5/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/5/readme.md
@@ -42,7 +42,7 @@ automatically:
 <input type="checkbox" t-model="this.props.todo.completed"/>
 ```
 
-To validate a signal prop, use `t.signal()`:
+To validate a signal prop, use [`t.signal()`](https://odoo.github.io/owl/documentation/v3/owl/reference/types_validation.html#tsignaltype):
 
 ```js
 props = useProps({

--- a/tools/playground/samples/v3/tutorials/todo_list/6/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/6/readme.md
@@ -17,7 +17,9 @@ Here is what you need to do:
 
 ### Hints
 
-`useEffect` runs a function whenever any signal read inside it changes:
+`useEffect` runs a function whenever any signal read inside it changes. See the
+[useEffect](https://odoo.github.io/owl/documentation/v3/owl/reference/effects.html#useeffect)
+documentation for more details.
 
 ```js
 import { useEffect } from "@odoo/owl";


### PR DESCRIPTION
…t tutorials

Before this commit, several steps in the `getting_started` and `todo_list` tutorials introduced core Owl concepts (such as sub-components, props validation, `t-foreach`/`t-key`, `t-ref`, custom hooks, `t.signal()`, and `useEffect`) without linking to the corresponding reference documentation. This was inconsistent with other steps that already provided these helpful links (e.g., the Signals link in step 1 of `getting_started`).

This commit adds the missing documentation links to the relevant steps. To keep the tutorials clean, care was taken to avoid duplicating references to concepts that are already linked elsewhere in either tutorial.