### PR TITLE
Add "Proxies vs signals" step to Todo List tutorial

### DIFF
--- a/tools/playground/samples/v3/tutorials/todo_list/11/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/11/readme.md
@@ -1,0 +1,109 @@
+## Proxies vs Signals
+
+In this step, you will add a small toolbar to filter todos by status (All /
+Active / Completed) and sort them (by creation order or by name, ascending
+or descending). This is view state, not business data — it lives on the
+`TodoList` component, not the `TodoListPlugin`, the same way
+`useAutofocus`'s `input` ref does.
+
+The interesting part is *how* to store it. The natural shape is a small
+tree of settings:
+
+```js
+{
+    filter: { status: "all" },
+    sort: { by: "id", direction: "asc" },
+}
+```
+
+You might reach for `signal.Object` here, since it's a single plain object.
+But `signal.Object` has the exact same shallow-wrapping rule as
+`signal.Array`: it tracks its own top-level keys, and nothing below that. If
+`viewPrefs` were a `signal.Object`, then `viewPrefs().filter` and
+`viewPrefs().sort` would be returned as plain, non-reactive objects —
+writing `viewPrefs().filter.status = "active"` would change the value but
+notify nobody, because nothing ever wrapped `filter` itself.
+
+This is exactly the situation `proxy` is for: a tree with more than one
+level of nesting, where every level needs to be tracked. One `proxy(...)`
+call wraps `viewPrefs`, `viewPrefs.filter`, and `viewPrefs.sort` all at
+once, recursively — no matter how many levels deep you go.
+
+Here is what you need to do:
+
+- In `TodoList`, add `viewPrefs = proxy({ filter: { status: "all" }, sort: {
+  by: "id", direction: "asc" } })`
+- Add a `visibleTodos` computed value that reads `this.todoList.todos()`,
+  filters by `viewPrefs.filter.status`, and sorts by `viewPrefs.sort.by` /
+  `viewPrefs.sort.direction`
+- Add the toolbar to the template: two `<select>` elements for the filter
+  and the sort field, plus a button to flip the sort direction
+- Render `this.visibleTodos()` in the `t-foreach` instead of
+  `this.todoList.todos()`
+
+### Hints
+
+Bind the `<select>` elements with the `.proxy` modifier of `t-model`, using
+a dot-notation path:
+
+```xml
+<select t-model.proxy="this.viewPrefs.filter.status">
+    <option value="all">All</option>
+    <option value="active">Active</option>
+    <option value="completed">Completed</option>
+</select>
+```
+
+A `computed` can freely mix reads from a signal-based collection and a
+proxy — that's the point of having a single dependency-tracking mechanism
+underneath all four reactive primitives:
+
+```js
+visibleTodos = computed(() => {
+    let todos = this.todoList.todos();
+    const { status } = this.viewPrefs.filter;
+    if (status !== "all") {
+        const wantCompleted = status === "completed";
+        todos = todos.filter((todo) => todo.completed() === wantCompleted);
+    }
+    const { by, direction } = this.viewPrefs.sort;
+    return [...todos].sort((a, b) => {
+        const cmp = by === "text" ? a.text.localeCompare(b.text) : a.id - b.id;
+        return direction === "asc" ? cmp : -cmp;
+    });
+});
+```
+
+Flipping the sort direction is a plain property write on the proxy, just
+like any other mutation:
+
+```js
+toggleSortDirection() {
+    this.viewPrefs.sort.direction = this.viewPrefs.sort.direction === "asc" ? "desc" : "asc";
+}
+```
+
+## Notes
+
+`signal`, `signal.Array` / `signal.Object`, and `proxy` aren't ranked from
+"basic" to "advanced" — they solve different shapes of state:
+
+- `todos` is a collection you explicitly add to and remove from
+  (`push`/`splice`), so `signal.Array` — with its shallow tracking and
+  explicit whole-value `.set(...)` — is the right fit.
+- `viewPrefs` is a small, arbitrarily-nested settings tree you just read and
+  write properties on. `proxy` tracks it deeply with zero extra wrapping,
+  which is exactly what a settings-shaped object needs.
+
+Picking between them is a question of "how deep is my data, and do I need
+explicit control over whole-value replacement?" — not "which one is more
+powerful."
+
+## Bonus Exercises
+
+- Add a text-search field: `filter.search = ""`, and only show todos whose
+  text includes it (case-insensitively). Notice that adding this new nested
+  leaf requires no extra wrapping anywhere — that's `proxy`'s deep tracking
+  paying off as the settings tree grows.
+- Persist `viewPrefs` to `localStorage` using the `StoragePlugin` from the
+  previous step, the same way `todos` is persisted.

--- a/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.css
+++ b/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.css
@@ -1,0 +1,75 @@
+.todo-app {
+    max-width: 400px;
+    margin: 20px;
+    font-family: sans-serif;
+
+    .todo-header {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+
+        .todo-input {
+            flex: 1;
+            padding: 8px 12px;
+            font-size: 14px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            outline: none;
+
+            &:focus {
+                border-color: #66afe9;
+            }
+        }
+
+        .todo-add-btn {
+            padding: 8px 16px;
+            font-size: 14px;
+            background: #5cb85c;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+
+            &:hover {
+                background: #449d44;
+            }
+        }
+    }
+
+    .todo-toolbar {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+
+        select,
+        .todo-sort-direction {
+            font: inherit;
+            font-size: 13px;
+            padding: 4px 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: white;
+        }
+
+        .todo-sort-direction {
+            cursor: pointer;
+
+            &:hover {
+                background: #f5f5f5;
+            }
+        }
+    }
+
+    .todo-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .todo-footer {
+        text-align: right;
+        padding: 8px 12px;
+        font-size: 13px;
+        color: #666;
+    }
+}

--- a/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.js
+++ b/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.js
@@ -1,0 +1,53 @@
+import { Component, signal, proxy, computed, providePlugins, usePlugin } from "@odoo/owl";
+import { TodoItem } from "./todo_item";
+import { TodoListPlugin } from "./todo_list_plugin";
+import { useAutofocus } from "./utils";
+
+export class TodoList extends Component {
+    static template = "tutorial.TodoList";
+    static components = { TodoItem };
+
+    input = signal.ref();
+
+    viewPrefs = proxy({
+        filter: { status: "all" },
+        sort: { by: "id", direction: "asc" },
+    });
+
+    visibleTodos = computed(() => {
+        let todos = this.todoList.todos();
+        const { status } = this.viewPrefs.filter;
+        if (status !== "all") {
+            const wantCompleted = status === "completed";
+            todos = todos.filter((todo) => todo.completed() === wantCompleted);
+        }
+        const { by, direction } = this.viewPrefs.sort;
+        const sorted = [...todos].sort((a, b) => {
+            const cmp = by === "text" ? a.text.localeCompare(b.text) : a.id - b.id;
+            return direction === "asc" ? cmp : -cmp;
+        });
+        return sorted;
+    });
+
+    setup() {
+        providePlugins([TodoListPlugin]);
+        this.todoList = usePlugin(TodoListPlugin);
+        useAutofocus(this.input);
+    }
+
+    addTodo(ev) {
+        if (ev.type === "click" || ev.key === "Enter") {
+            const input = ev.type === "click" ? ev.target.previousElementSibling : ev.target;
+            this.todoList.addTodo(input.value);
+            input.value = "";
+        }
+    }
+
+    toggleSortDirection() {
+        this.viewPrefs.sort.direction = this.viewPrefs.sort.direction === "asc" ? "desc" : "asc";
+    }
+
+    sortDirectionLabel() {
+        return this.viewPrefs.sort.direction === "asc" ? "↑" : "↓";
+    }
+}

--- a/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.xml
+++ b/tools/playground/samples/v3/tutorials/todo_list/11/todo_list_solution.xml
@@ -1,0 +1,29 @@
+<templates>
+  <t t-name="tutorial.TodoList">
+    <div class="todo-app">
+      <div class="todo-header">
+        <input class="todo-input" t-ref="this.input" placeholder="What needs to be done?" t-on-keyup="this.addTodo"/>
+        <button class="todo-add-btn" t-on-click="this.addTodo">Add</button>
+      </div>
+      <div class="todo-toolbar">
+        <select t-model.proxy="this.viewPrefs.filter.status">
+          <option value="all">All</option>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+        </select>
+        <select t-model.proxy="this.viewPrefs.sort.by">
+          <option value="id">Sort: created</option>
+          <option value="text">Sort: name</option>
+        </select>
+        <button class="todo-sort-direction" t-on-click="this.toggleSortDirection"
+                title="Toggle sort direction" t-out="this.sortDirectionLabel()"/>
+      </div>
+      <ul class="todo-list">
+        <t t-foreach="this.visibleTodos()" t-as="todo" t-key="todo.id">
+          <TodoItem todo="todo"/>
+        </t>
+      </ul>
+      <div class="todo-footer"><t t-out="this.todoList.remaining()"/> remaining items</div>
+    </div>
+  </t>
+</templates>

--- a/tools/playground/src/samples.js
+++ b/tools/playground/src/samples.js
@@ -480,6 +480,27 @@ const TUTORIALS_V3 = [
           "storage_plugin.js": "tutorials/todo_list/10/storage_plugin.js",
         },
       },
+      {
+        title: "Proxies vs signals",
+        files: {
+          "readme.md": "tutorials/todo_list/11/readme.md",
+          "main.js": "tutorials/todo_list/10/main_solution.js",
+          "todo_list/todo_list.js": "tutorials/todo_list/8/todo_list_solution.js",
+          "todo_list/todo_list.xml": "tutorials/todo_list/9/todo_list_solution.xml",
+          "todo_list/todo_list.css": "tutorials/todo_list/9/todo_list.css",
+          "todo_list/todo_list_plugin.js": "tutorials/todo_list/10/todo_list_plugin_solution.js",
+          "todo_list/todo_item.js": "tutorials/todo_list/8/todo_item_solution.js",
+          "todo_list/todo_item.xml": "tutorials/todo_list/8/todo_item_solution.xml",
+          "todo_list/todo_item.css": "tutorials/todo_list/7/todo_item_solution.css",
+          "todo_list/utils.js": "tutorials/todo_list/4/utils.js",
+          "storage_plugin.js": "tutorials/todo_list/10/storage_plugin.js",
+        },
+        solution: {
+          "todo_list/todo_list.js": "tutorials/todo_list/11/todo_list_solution.js",
+          "todo_list/todo_list.xml": "tutorials/todo_list/11/todo_list_solution.xml",
+          "todo_list/todo_list.css": "tutorials/todo_list/11/todo_list_solution.css",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
Adds a new final step to the Todo List playground tutorial that teaches `proxy` by contrast with the reactive primitives already used throughout the tutorial (`signal`, `signal.Array`).

The `todos` list itself is left untouched — still `signal.Array`, with each todo's `completed` flag as its own `signal(false)`. The exercise instead adds a small, separate filter/sort toolbar on `TodoList`, backed by a `proxy` with two levels of nesting (`viewPrefs.filter.status`, `viewPrefs.sort.by` / `viewPrefs.sort.direction`). The readme explains why `signal.Object` wouldn't be enough here either — it has the same shallow-wrapping rule as `signal.Array` — which is what actually motivates reaching for `proxy`.

A `computed` (`visibleTodos`) shows the four reactive primitives composing freely, mixing reads from the plugin's signal-based `todos()` and the component's proxy-based `viewPrefs` in a single derived value.