### PR TITLE
[FIX] doc: correct v3 reference/playground inaccuracies found by doc audit

### DIFF
--- a/doc/v3/owl/owl3_design.md
+++ b/doc/v3/owl/owl3_design.md
@@ -214,16 +214,15 @@ So, with computed values, we have a dynamic graph of values (base values like
 signals and proxies, and derived values with compute functions). Owl will try
 to efficiently only recompute what it needs.
 
-A computed function can act like a signal, it has an empty `set` function. It is
-also possible to redefine the `.set` function, to make it writable, in some
-situations:
+A computed function can act like a signal, but by default it is read-only: its
+`set` function throws. It is also possible to redefine the `.set` function, to
+make it writable, in some situations:
 
 ```js
 const s = signal(3);
 const double = computed(() => 2*s());
 double();       // return 6
-double.set(5);  // nothing happens
-double();       // return 6
+double.set(5);  // throws: "Cannot write to a read-only computed value..."
 const triple = computed(() => 3*s(), {
   set: value => s.set(value/3);
 });
@@ -1571,8 +1570,8 @@ UI framework.
 
 ## Other ideas
 
-We discuss here some other ideas that we explored and decided not to include in
-Owl 3.
+We discuss here some other ideas that we explored during the design of Owl 3
+(most of which were decided against; one did ship — see below).
 
 ### Make it easy to output a simple reactive value
 
@@ -1609,6 +1608,9 @@ static tooling to work (in this case, the type of all signals is basically
 erased from the content of the template).
 
 ### Static prop helper
+
+This idea was explored here and, unlike the others in this section, ended up
+shipping as `useProps.static()`.
 
 It is often useful to only import a single component prop:
 

--- a/doc/v3/owl/reference/app.md
+++ b/doc/v3/owl/reference/app.md
@@ -38,8 +38,9 @@ await root.mount(document.body);
 
 - **`app.createRoot(Component, options?)`**: registers a root component and
   returns a `Root` object exposing `prepare`, `mount`, `destroy`, plus
-  `promise` (resolves to the component instance once mounted) and the
-  underlying `node`. `options` accepts `{ props }`.
+  `promise` (resolves to the component instance once mounted), `prepared`
+  (true once the render phase has finished), and `destroyed` (true once
+  `destroy()` has been called). `options` accepts `{ props }`.
 
 - **`app.destroy()`**: destroys every root, the plugin manager, and the
   application itself.
@@ -207,5 +208,3 @@ Dev mode activates some additional checks and developer amenities:
 - [Props validation](./props.md#props-validation) is performed
 - [t-foreach](./template_syntax.md#loops) loops check for key unicity
 - Lifecycle hooks are wrapped to report their errors in a more developer-friendly way
-- onWillStart will emit a warning in the console when it takes longer than 3
-  seconds in an effort to ease debugging the presence of deadlocks

--- a/doc/v3/owl/reference/effects.md
+++ b/doc/v3/owl/reference/effects.md
@@ -113,8 +113,10 @@ class MyComponent extends Component {
 }
 ```
 
-`useEffect` can also be called inside a [plugin](plugins.md)'s `setup`, where it
-is bound to the plugin's lifetime and disposed when the plugin is destroyed.
+`useEffect` can also be called inside a [plugin](plugins.md)'s `setup`. Individual
+plugins don't have their own lifetime, though: the effect is bound to the
+lifetime of the shared plugin manager, and is disposed only when that manager
+is destroyed.
 
 ## untrack
 

--- a/doc/v3/owl/reference/error_boundary.md
+++ b/doc/v3/owl/reference/error_boundary.md
@@ -61,8 +61,8 @@ the fallback will reappear.
 
 If you don't pass an `error` prop, ErrorBoundary creates its own internal
 signal. The fallback still renders on errors, but your code has no handle
-on the error value or on clearing it (short of grabbing a `t-ref` to the
-component and reaching into `.error`).
+on the error value or on clearing it — pass your own `error` signal as
+shown above if you need one.
 
 ## How it works
 
@@ -89,9 +89,7 @@ Props:
 - `error?: Signal<any>` — optional external signal the boundary writes
   the caught error to. If omitted, ErrorBoundary creates its own.
 
-Exposed fields, for code that needs programmatic access via
-`t-ref`/`useRef`:
-
-- `error: Signal<any>` — the signal holding the currently caught error
-  (the prop if provided, otherwise the internal one). Read with
-  `error()`, reset with `error.set(null)`.
+`t-ref` is not supported on components in Owl 3, so there's no way to
+reach the internal signal programmatically when the `error` prop is
+omitted — pass your own signal as `error` if you need to read or clear
+it, as shown above.

--- a/doc/v3/owl/reference/form_bindings.md
+++ b/doc/v3/owl/reference/form_bindings.md
@@ -77,7 +77,7 @@ Like event handling, the `t-model` directive accepts the following modifiers:
 | --------- | -------------------------------------------------------------------- |
 | `.lazy`   | update the value on the `change` event (default is on `input` event) |
 | `.number` | try to parse the value to a number (using `parseFloat`)              |
-| `.trim`   | trim the resulting value                                             |
+| `.trim`   | trim the resulting value; also implies `.lazy`                       |
 
 For example:
 
@@ -87,6 +87,10 @@ For example:
 
 These modifiers can be combined. For instance, `t-model.lazy.number` will only
 update a number whenever the change is done.
+
+Note that `.trim` silently switches the update event to `change` as well,
+even without `.lazy` — `t-model.trim` and `t-model.trim.lazy` behave
+identically.
 
 ## Using t-model with proxy objects
 

--- a/doc/v3/owl/reference/overview.md
+++ b/doc/v3/owl/reference/overview.md
@@ -54,7 +54,7 @@ Here is a list of everything exported by the Owl library.
 - [`Plugin`](plugins.md): base class for plugins
 - [`usePlugin`](plugins.md): import a plugin dependency
 - [`providePlugins`](plugins.md): make plugins available to a component subtree
-- [`config`](plugins.md#configuration): read a value from the plugin manager's config
+- [`useConfig`](plugins.md#configuration): read a value from the plugin manager's config
 
 ## Type Validation
 

--- a/doc/v3/owl/reference/precompiling_templates.md
+++ b/doc/v3/owl/reference/precompiling_templates.md
@@ -15,15 +15,16 @@ process is the following:
 1. write your templates in xml files (with a `t-name` directive to declare the name
    of the template)
 2. Compile them in a `templates.js` file
-3. get the `owl.iife.runtime.js` file (which is a owl build without the compiler)
-4. bundle `owl.iife.runtime.js` and `template.js` with your assets (owl needs to
+3. get the `owl-runtime.es.js` file (an owl build without the compiler)
+4. bundle `owl-runtime.es.js` and `template.js` with your assets (owl needs to
    be positioned before the templates)
 
 Here is a more detailed explanation on how to compile xml files into a js file:
 
 1. clone the owl repository locally
 2. `npm install` to install all the required tooling
-3. `npm run build:runtime` to build the `owl.iife.runtime.js` file
+3. `npm run build:runtime` to build the `owl-runtime.es.js` file (in
+   `packages/owl-runtime/dist/`)
 4. `npm run build:compiler` to build the template compiler
 5. `npm run compile_templates -- path/to/your/templates` will scan your target
    folder, find all xml files, get all templates, compile them, and generate a

--- a/doc/v3/owl/reference/scope.md
+++ b/doc/v3/owl/reference/scope.md
@@ -44,7 +44,8 @@ class MyComponent extends Component {
 
   setup() {
     const scope = useScope();
-    // scope.status === STATUS.NEW at this point
+    // scope.status === 0 at this point (freshly created; see "Lifetime and
+    // Status" below — STATUS itself isn't exported from @odoo/owl)
     // scope.abortSignal — lazily-allocated AbortSignal tied to this component
   }
 }
@@ -55,8 +56,10 @@ if you need to tolerate that case — it returns `Scope | null`.
 
 ## Lifetime and Status
 
-A scope's `status` transitions through three values, defined by the `STATUS`
-enum:
+A scope's `status` transitions through three numeric values, internally
+defined by a `STATUS` enum. `STATUS` itself is not exported from
+`@odoo/owl` — use the `status()` helper below for a readable check
+instead of importing it:
 
 | Status      | Meaning                                            |
 | ----------- | -------------------------------------------------- |
@@ -269,9 +272,10 @@ active. Reach for this only when the absence of a scope is meaningful.
 
 ### `Scope`
 
-- `status: STATUS` — current status (`NEW` / `MOUNTED` / `DESTROYED`).
+- `status: number` — current status (0 = `NEW`, 1 = `MOUNTED`, 2 =
+  `DESTROYED`; the `STATUS` enum itself isn't exported from `@odoo/owl` —
+  use the `status()` helper for a readable check).
 - `app: App` — the owning application.
-- `parent: Scope | null` — parent scope in the tree.
 - `abortSignal: AbortSignal` — an `AbortSignal` aborted when the scope dies.
   Lazily allocates an `AbortController` on first access.
 - `isDestroyed(): boolean` — true once the scope is destroyed (all cleanup

--- a/doc/v3/owl/reference/template_syntax.md
+++ b/doc/v3/owl/reference/template_syntax.md
@@ -468,8 +468,8 @@ The `t-key` directive is useful for lists (`t-foreach`). A key should be
 a unique number or string (objects will not work: they will be cast to the
 `"[object Object]"` string, which is obviously not unique).
 
-Also, the key can be set on a `t` tag or on its children. The following variations
-are all equivalent:
+Also, the key can be set on a `p` tag or on a wrapping `t` tag. The following
+variations are equivalent:
 
 ```xml
 <p t-foreach="this.items" t-as="item" t-key="item.id">
@@ -479,13 +479,11 @@ are all equivalent:
 <t t-foreach="this.items" t-as="item" t-key="item.id">
   <p t-out="item.text"/>
 </t>
-
-<t t-foreach="this.items" t-as="item">
-  <p t-key="item.id" t-out="item.text"/>
-</t>
 ```
 
-If there is no `t-key` directive, Owl will use the index as a default key.
+`t-key` must be set on the same element as `t-foreach`, not on one of its
+children. If it is missing, Owl throws `"Directive t-foreach should always
+be used with a t-key!"` — there is no fallback to the index.
 
 Note: the `t-foreach` directive only accepts arrays (lists) or objects. It does
 not work with other iterables, such as `Set`. However, it is only a matter of
@@ -617,13 +615,13 @@ modified by the function.
 This :
 
 ```xml
-<div t-custom-test_directive="click" />
+<div t-custom-test_directive="this.click" />
 ```
 
 will be replaced by :
 
 ```xml
-<div t-on-click="value"/>
+<div t-on-click="this.click"/>
 ```
 
 ## Fragments

--- a/doc/v3/owl/reference/translations.md
+++ b/doc/v3/owl/reference/translations.md
@@ -35,7 +35,8 @@ Once setup, all rendered templates will be translated using `translateFn`:
 
 - each text node will be replaced with its translation,
 - each of the following attribute values will be translated as well: `title`,
-  `placeholder`, `label` and `alt`,
+  `placeholder`, `label`, `alt`, `aria-label`, `aria-placeholder`,
+  `aria-roledescription` and `aria-valuetext`,
 - translating text nodes can be disabled with the special attribute `t-translation`,
   if its value is `off`.
 - the translate function receives as second parameter a context that can be used

--- a/tools/playground/samples/v3/tutorials/hibou_os/12/readme.md
+++ b/tools/playground/samples/v3/tutorials/hibou_os/12/readme.md
@@ -62,8 +62,8 @@ const APP_SCHEMA = t.object({
     name: t.string(),
     icon: t.string(),
     window: t.constructor(Component),
-    "systrayItems?": t.array(t.constructor(Component)),
-    "plugins?": t.array(t.constructor(Plugin)),
+    systrayItems: t.array(t.constructor(Component)).optional(),
+    plugins: t.array(t.constructor(Plugin)).optional(),
 });
 ```
 

--- a/tools/playground/samples/v3/tutorials/todo_list/7/readme.md
+++ b/tools/playground/samples/v3/tutorials/todo_list/7/readme.md
@@ -25,7 +25,7 @@ To declare an optional function prop:
 ```js
 props = useProps({
     todo: t.object({ ... }),
-    "onDelete?": t.function(),
+    onDelete: t.function().optional(),
 });
 ```
 

--- a/tools/playground/samples/v3/web_client/core/orm.js
+++ b/tools/playground/samples/v3/web_client/core/orm.js
@@ -1,4 +1,4 @@
-import { useContext, computed, signal } from "@odoo/owl";
+import { useScope, computed, signal } from "@odoo/owl";
 export class Model {
   id;
   orm;
@@ -339,7 +339,7 @@ export class ORM {
       }
     } else {
       try {
-        this._ctx = useContext();
+        this._ctx = useScope();
       } catch {
         this._ctx = null;
       }

--- a/tools/playground/samples/v3/web_client/readme.md
+++ b/tools/playground/samples/v3/web_client/readme.md
@@ -6,12 +6,12 @@ This example demonstrates how to build a web client application using OWL's plug
 
 - `core/` - Core utilities and plugins
   - `orm.js` - A reactive ORM for managing data models
-  - `action_plugin.js` - Plugin for handling actions/navigation
   - `notification_plugin.js` - Plugin for displaying notifications
   - `notification_container.js` - Component that renders notifications
 - `web_client/` - Main web client components
   - `web_client.js` - Root component
   - `navbar.js` - Top navigation bar
+  - `action_plugin.js` - Plugin for handling actions/navigation
 - `views/` - View components
   - `list_view.js` - List view for displaying records
   - `form_view.js` - Form view for editing records

--- a/tools/playground/static/playground.md
+++ b/tools/playground/static/playground.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Interactive IDE for learning and prototyping with the Owl framework. Runs entirely in the browser, executes user code in a sandboxed iframe with CodeMirror 6 for editing.
+Interactive IDE for learning and prototyping with the Owl framework. Runs entirely in the browser, executes user code in a sandboxed iframe, and edits with the Monaco editor (the same editor that powers VS Code). It can run either the current Owl v3 (bundled from this repo) or Owl v2 (loaded from a CDN), switchable per project.
 
 **Note:** There is no need to run the tests (`npm run test`), because they only test Owl itself, not the playground.
 
@@ -12,32 +12,41 @@ Interactive IDE for learning and prototyping with the Owl framework. Runs entire
 
 ### Entry Points
 
-- `index.html` - Main entry, loads `playground.js` as ES module
-- `playground.js` - Root `Playground` component and application bootstrap
-- `plugins.js` - State management via 7 Owl plugins
-- `components.js` - All UI components (CodeEditor, Explorer, ContentView, dialogs)
-- `samples.js` - Example templates and tutorials
-- `code_utils.js` - Code editor utilities (autocompletion, markdown parsing)
-- `file_utils.js` - File-related helpers (getFileType, makeFileEntry, etc.)
+- `static/index.html` - Main entry, loads `playground.js` as ES module
+- `src/playground.js` - Root `Playground` component and application bootstrap
+- `src/plugins.js` - State management via 8 Owl plugins
+- `src/components.js` - All UI components (CodeEditor, Explorer, ContentView, TutorialBar, dialogs)
+- `src/samples.js` - Example and tutorial catalogs (per Owl version) and file loading
+- `src/code_utils.js` - Markdown rendering for readmes (`marked` + `highlight.js`)
+- `src/file_utils.js` - File-related helpers (`getFileType`, `makeFileEntry`, path-tree parsing)
+- `src/versions.js` - The v2/v3 version catalog used by the version switcher
+- `src/monaco/` - Monaco setup: TypeScript-powered auto-import completions
+  (`auto_import.js`), Vim keybindings, snippets, and XML tag-rename support
+
+`src/playground.js` is bundled by `build.mjs` (esbuild) into `dist/playground.js`,
+which is what `static/index.html` actually loads at runtime — `static/` and
+`dist/` are served together (see `server.py`).
 
 ### Component Hierarchy
 
 ```
 Playground (root)
 ├── Explorer (sidebar)
-│   └── Project/file tree with expand/collapse
+│   └── Project/file tree with expand/collapse, context menus
 ├── CodeEditor (split-pane)
 │   ├── primary editor pane
 │   └── secondary editor pane (optional, split mode)
 ├── ContentView (preview area)
 │   ├── iframe (user code execution sandbox)
 │   └── console pane (log/error/warn output)
-└── Dialog overlays (settings, new file, project dialogs)
+├── TutorialBar (step navigation for tutorial projects)
+├── ProjectManager (template/tutorial picker dialog)
+└── Dialog overlays (settings, new file/folder/component, project, confirm)
 ```
 
 ### Plugin System
 
-Six plugins provided via `providePlugins()` at Playground mount:
+8 plugins provided via `providePlugins()` at Playground mount (`src/plugins.js`):
 
 #### 1. CodePlugin (`code`)
 
@@ -49,38 +58,35 @@ Manages file content and editor state.
 - `contents` - Object mapping filename → content
 - `primaryFile`, `secondaryFile` - Current file per pane
 - `activePane` - 'primary' or 'secondary'
-- `splitMode` - Boolean
-- `splitRatio` - Number (0.2-0.8)
+- `splitMode`, `splitRatio` - Split-pane state
 - `contentVersion` - Increments on file load
-- `runCode` - Triggers execution
-- `userModified` - Dirty flag
+- `runCode` - Snapshot passed to `ContentView` to trigger execution
+- `modifiedFiles` - Set of dirty filenames
+- `markdownPreviewMode` - Per-file preview/edit toggle for `.md` files
 
 **Key methods:**
 
-- `loadFiles(fileNames, contents, editorState?)` - Load project
+- `loadFiles(fileNames, contents, editorState?)` - Load a project
 - `setContent(fileName, value)` - Update file content
-- `run()` - Execute code (collects js/css/xml, creates iframe)
-- `getSnapshot()` - Get all file contents
+- `run()` - Collects js/css/xml file contents and publishes them to `runCode`
+- `getSnapshot()` - Get all file contents (used by export and localStorage)
 - `addFile()`, `renameFile()`, `deleteFile()`
 
-#### 2. TemplatePlugin (`templates`)
+#### 2. VersionPlugin (`version`)
 
-Lists sample templates from `samples/` directory.
+Tracks which Owl version (`v3` or `v2`) the current project runs against.
+`src/versions.js` maps each version to a `path` (`../owl.js` for v3, an
+`esm.sh` CDN URL for v2) used to build the preview iframe's import map, and a
+`types` URL used to feed Monaco's TypeScript autocompletion the matching
+`.d.ts`.
 
-**Structure:**
+#### 3. TemplatePlugin (`templates`)
 
-```javascript
-{
-  category: "Examples" | "Demos" | "Tutorials",
-  id: "template_id",  // Technical identifier (used as project name when applied)
-  description: "Display name",
-  files: ["main.js", ...],
-  isTutorial: boolean,
-  code: async () => { filename: content }
-}
-```
+Exposes the example/tutorial catalog for the active Owl version (from
+`EXAMPLES`/`TUTORIALS` in `samples.js`), grouped by category, plus
+`openTutorial()` to load a tutorial's steps into a new project.
 
-#### 3. ProjectPlugin (`project`)
+#### 4. ProjectPlugin (`project`)
 
 Multi-project management with dirty tracking.
 
@@ -89,293 +95,201 @@ Multi-project management with dirty tracking.
 - `projects` - Array of project objects
 - `activeProjectId` - Current project
 
-**Project object:**
-
-```javascript
-{
-  id: string,
-  name: string,
-  fileNames: string[],
-  readonly: boolean,
-  files: { filename: content },
-  originalFiles: { filename: content }, // for dirty check
-  templateDesc: string | null,
-  editorState: { splitMode, primaryFile, secondaryFile, activePane, splitRatio }
-}
-```
-
 **Key methods:**
 
-- `createProject()`, `switchProject()`, `deleteProject()`
+- `createProject()`, `createTutorialProject()`, `switchProject()`, `deleteProject()`
 - `addFileToProject()`, `renameFileInProject()`, `deleteFileFromProject()`
-- `applyTemplate()` - Replace files with template
-- `isCurrentProjectDirty()` - Compare against originalFiles
-- `serialize()`, `restore()` - For localStorage persistence
+- `applyTemplate()` - Replace files with a template's
+- `isProjectDirty()` - Compare current files against the originals
+- `markProjectAsRun()` - Tracked so auto-run only kicks in after a first manual run
 
-#### 4. LocalStoragePlugin (`localStorage`)
+#### 5. LocalStoragePlugin (`localStorage`)
 
-Auto-saves to `localStorage` every 1s when dirty.
+Persists projects to `localStorage`.
 
-**Key:**
+#### 6. SettingsPlugin (`settings`)
 
-- `owl-playground-projects` - New format (multi-project)
-- `owl-playground-local-sample` - Legacy format (migrated automatically)
+**State**, each persisted to `localStorage`:
 
-#### 5. SettingsPlugin (`settings`)
+- `fontSize` - Number, editor font size
+- `autoRun` - Boolean, run on change with a 500ms debounce
+- `darkMode` - Boolean, toggles the `light-mode` class on `<html>` and the
+  Monaco theme (`slate-dark` / `github-light`)
+- `vimMode` - Boolean, attaches Vim keybindings to the editor
+- `fullscreen`, `leftPaneWidth`, `sidebarWidth` - Layout state
 
-**State:**
+#### 7. DialogPlugin (`dialog`)
 
-- `fontSize` - Number (10-20), persisted to localStorage
-- `autoRun` - Boolean, run on change with 500ms debounce
-- `fullscreen` - Boolean, hide editor
-- `leftPaneWidth` - Number (pixels)
+Modal management (`showDialog(Component, props)` / `closeDialog()`).
 
-#### 6. DialogPlugin (`dialog`)
+#### 8. ViewPlugin (`view`)
 
-Modal management.
-
-**State:**
-
-- `dialogComponent` - Component class or null
-- `dialogProps` - Props object
-
-**Methods:**
-
-- `showDialog(Component, props)` - Open modal
-- `closeDialog()` - Close modal
+Small bit of shared UI state — currently just whether the `ProjectManager`
+dialog is open (`showProjectManager`).
 
 ### Key Components
 
-#### CodeEditor (`playground.js:658-934`)
+All in `src/components.js` (1995 lines):
 
-CodeMirror 6 integration with split-pane support.
+#### CodeEditor (`components.js:34-509`)
+
+Monaco integration with split-pane support.
 
 **Features:**
 
-- Language support: js, css, xml, md (via `LANGUAGES` map)
-- Tab sizes: js/css=4, xml/md=2
-- OneDark theme
-- State preservation per file (scroll position, editor state)
-- Companion file detection (js↔xml pairing)
-
-**Key signals:**
-
-- `primaryEditorNode`, `secondaryEditorNode` - DOM refs
-- `panes` - `{primary, secondary}` each with `{view, states, scrolls, lastFile}`
+- Language support: js, css, xml, md (`LANGUAGES` map in `file_utils.js`)
+- Tab sizes: js/css=4, xml/md=2 (`TAB_SIZES` in `file_utils.js`)
+- Theme follows dark mode: `slate-dark` (dark) / `github-light` (light)
+- Optional Vim mode per pane, with its own status bar
+- Markdown files can toggle between an editable view and a rendered preview
+- State preservation per file (Monaco model, scroll position)
 
 **Effects:**
 
 - Content version change → reset panes
-- Primary/secondary file change → switch pane file
+- Primary/secondary file change → switch pane file, reapply Vim mode
 - Split mode toggle → create/destroy secondary editor
-- Font size change → reconfigure theme
+- Dark mode change → reconfigure Monaco theme
 
-#### ContentView (`playground.js:1267-1460`)
+#### ContentView (`components.js:1648-1929`)
 
-User code execution in sandboxed iframe.
-
-**Features:**
-
-- Console capture: log/warn/error/info
-- Error count badge
-- Welcome screen when no code run
-- Fullscreen toggle
-
-**run() method:**
-
-1. Creates iframe
-2. Builds import map with `@odoo/owl` → `../owl.js`
-3. Rewrites relative imports to blob URLs
-4. Injects templates as `TEMPLATES` global
-5. Captures console methods and errors
-
-#### Explorer (`playground.js:1130-1242`)
-
-Sidebar with project tree.
+User code execution in a sandboxed iframe.
 
 **Features:**
 
-- Expand/collapse projects
-- File selection with active highlighting
-- Double-click to edit project/file
-- Template preset dropdown
-- New file/project buttons
+- Console capture: log/warn/error/info, with `cause` chains for errors
+- Welcome screen when no code has run yet
+- Auto-run (debounced) once a project has been run manually at least once
 
-## Code Execution System
+**`run({ jsFiles, css, xml })` (`components.js:1776`):**
 
-### How User Code Runs
+1. Creates an iframe
+2. Builds an import map: `{ "@odoo/owl": <path for the active version> }`,
+   plus a blob URL per non-entry JS file (rewriting each file's relative
+   imports across several passes to support import chains between them)
+3. Injects a `<script type="module">` defining a `TEMPLATES` global followed
+   by the entry file's (`main.js`) content
+4. Injects the collected CSS as a `<style>` tag
 
-1. `CodePlugin.run()` collects js, css, xml files
-2. Creates iframe with base styles
-3. Builds import map:
-   ```javascript
-   {
-     imports: {
-       "@odoo/owl": "../owl.js",
-       "./otherFile.js": "blob:...",
-       ...
-     }
-   }
-   ```
-4. For multi-file projects:
-   - Non-main files converted to blob URLs
-   - Import statements rewritten to use blob URLs
-5. Injects `<script type="module">` with:
-   ```javascript
-   const TEMPLATES = `...xml...`;
-   // main.js content
-   ```
+The js/css/xml collection itself happens in `CodePlugin.run()`
+(`plugins.js:177`).
 
-### Import Rewriting
+#### Explorer (`components.js:1027-1647`)
 
-The `rewriteImports()` function handles:
+Sidebar with the project/file tree.
 
-- `import ... from "./x"` → `import ... from "blob:..."`
-- `export ... from "./x"` → `export ... from "blob:..."`
-- `import("./x")` → `import("blob:...")`
+**Features:**
+
+- Expand/collapse folders, per-file and per-folder context menus
+- New file / new folder / new component dialogs
+- Template/tutorial picker via `ProjectManager`
+
+#### TutorialBar (`components.js:1930-1995`)
+
+Step navigation (previous/next, jump to step) shown for projects created
+from a tutorial, plus buttons to reveal the current step's solution or reset
+it back to the step's starting files.
 
 ## Sample Applications
 
-### Examples Category
+Catalogs live in `src/samples.js`. Examples are split per Owl version
+(`EXAMPLES_V3` / `EXAMPLES_V2`); tutorials only exist for v3 (`TUTORIALS_V3`).
+The tables below are the v3 catalog, the default and the one under active
+development.
 
-| ID               | Sample           | Files                                   | Demonstrates                                                                        |
-| ---------------- | ---------------- | --------------------------------------- | ----------------------------------------------------------------------------------- |
-| hello_world      | Hello World      | main.js                                 | Basic mount, inline xml template                                                    |
-| simple_component | Simple Component | main.js, main.css                       | Component class, static template, styling                                           |
-| props_list       | Props/List       | main.js, product_card.js/xml, main.css  | Parent-child props, component reuse, XML templates                                  |
-| lifecycle        | Lifecycle Demo   | helpers.js, chat_window.js, main.js/xml | Hooks: onMounted, onPatched, onWillDestroy, onWillPatch, onWillStart, onWillUnmount |
-| reactivity       | Reactivity       | main.js/xml                             | signal(), proxy(), computed(), effect(), reactive state patterns                    |
-| canvas           | Canvas           | main.js                                 | t-ref for DOM access, useEffect for side effects                                    |
-| form             | Form             | main.js/xml                             | t-model two-way binding                                                             |
-| slots            | Slots            | dialog.js/xml/css, main.js              | Generic components, slot content projection                                         |
-| plugins          | Plugins          | core_plugins.js, form_view.js, main.js  | Plugin system, dependency injection, cross-plugin communication                     |
+### Examples
 
-### Demos Category
+| ID               | Description                | Files                                                          |
+| ---------------- | --------------------------- | --------------------------------------------------------------- |
+| hello_world      | Hello World                 | main.js                                                          |
+| sub_component    | Sub-component                | main.js                                                          |
+| props             | Props and validation         | main.js, main.css, product_card.js/xml                          |
+| list_reactivity  | Reactive list (proxy + computed) | main.js                                                     |
+| form_binding     | Form binding (t-model)       | main.js, main.xml                                                |
+| dom_ref          | DOM access (t-ref)           | main.js                                                          |
+| slots            | Slots (default + named)      | dialog.css/js/xml, main.js                                       |
+| plugins          | Plugins (shared state)       | main.js                                                          |
+| async_suspense   | Async + Suspense             | main.js                                                          |
 
-| ID           | Sample       | Files                                       | Description                             |
-| ------------ | ------------ | ------------------------------------------- | --------------------------------------- |
-| kanban_board | Kanban Board | main.js/xml/css                             | Multi-column task board with add/delete |
-| html_editor  | HTML Editor  | html_editor/html_editor.js/xml, main.js/css | Contenteditable with formatting toolbar |
-| web_client   | Web Client   | main.js/xml/css                             | Mock Odoo-style web client with navbar  |
+Two more samples, `kanban_board` and `web_client`, still have their source
+under `samples/v3/`, but their catalog entries in `samples.js` are commented
+out ("not ready yet, ... re-enable these entries once the demos are
+polished"), so they don't appear in the picker today.
 
-### Tutorials Category
+### Tutorials
 
-| ID           | Sample       | Files                 | Description                                               |
-| ------------ | ------------ | --------------------- | --------------------------------------------------------- |
-| todo_list    | Todo List    | main.js/xml/css       | Full TodoMVC implementation with localStorage persistence |
-| time_tracker | Time Tracker | readme.md/main.js/xml | Timer with step-by-step tutorial (7 progressive steps)    |
+| ID              | Name           | Steps | Description                          |
+| ---------------- | -------------- | ----- | -------------------------------------- |
+| getting_started  | Getting Started | 5     | Owl fundamentals, step by step         |
+| todo_list        | Todo List       | 10    | Build a complete todo app with Owl     |
+| hibou_os         | Hibou OS        | 15    | Build a mini desktop environment       |
 
-**Time Tracker Tutorial:** The `readme.md` file contains a comprehensive tutorial building a Pomodoro timer in 7 incremental steps, each introducing core Owl concepts:
-
-1. Static Display - Component, xml template, mount
-2. Reactive State - signal(), computed()
-3. Start/Pause - Event handlers, onWillUnmount
-4. Reset - Multiple signals, state coordination
-5. Work/Break Phases - Conditional rendering, t-att-class
-6. Progress Bar - Computed + styling, t-att-style
-7. Session History - signal.Array, t-foreach
+Each tutorial step can carry its own `readme.md`, starting files, and an
+optional solution; `TemplatePlugin.openTutorial()` loads all of a tutorial's
+steps into one project, and `TutorialBar` walks between them.
 
 ## File Structure
 
 ```
-docs/playground/
-├── index.html              # Entry point
-├── playground.js           # Main application (~292 lines)
-├── playground.css          # Styles (~981 lines)
-├── templates.xml           # Owl templates (~256 lines)
-├── utils.js                # debounce, loadJS utilities
-├── file_utils.js           # File helpers: LANGUAGES, TAB_SIZES, getFileType, etc.
-├── code_utils.js           # Editor config, markdown parsing, OWL autocompletion
-├── samples.js              # EXAMPLES, TUTORIALS, file loading
-├── plugins.js              # All 7 Owl plugins (Code, Template, Project, etc.)
-├── components.js           # All 13 UI components + useAutoscroll hook
+tools/playground/
+├── build.mjs                # esbuild bundling of src/playground.js → dist/
+├── build_monaco.mjs         # Bundles Monaco + Shiki into libs/monaco/
+├── server.py                # Dev server (serves static/, dist/, and repo-root owl.js)
+├── src/
+│   ├── playground.js        # Root component + bootstrap (343 lines)
+│   ├── plugins.js           # All 8 Owl plugins (1117 lines)
+│   ├── components.js        # All UI components + hooks (1995 lines)
+│   ├── samples.js           # EXAMPLES/TUTORIALS catalogs, file loading (1091 lines)
+│   ├── code_utils.js        # Markdown rendering (marked + highlight.js)
+│   ├── file_utils.js        # LANGUAGES, TAB_SIZES, getFileType, path-tree helpers
+│   ├── versions.js          # v2/v3 version catalog
+│   ├── utils.js             # debounce, loadJS
+│   ├── asset_url.js         # Resolves an asset path relative to this module
+│   └── monaco/              # Monaco setup: auto-import, Vim mode, snippets, XML rename
+├── static/
+│   ├── index.html           # Served entry point
+│   ├── playground.css       # Styles
+│   ├── monaco.bundle.css    # Monaco's own stylesheet
+│   ├── templates.xml        # Owl templates, one per component
+│   ├── playground.md        # This file
+│   └── tutorials.md         # How to write a tutorial
 ├── libs/
-│   ├── codemirror.bundle.js  # CodeMirror 6 editor bundle
 │   ├── jszip.min.js          # ZIP creation for export
 │   ├── FileSaver.min.js      # File download helper
 │   ├── marked.min.js         # Markdown parser (vendored, was CDN)
 │   ├── marked-highlight.min.js # marked <-> highlight.js bridge (vendored, was CDN)
-│   └── highlight.min.js      # Syntax highlighting (vendored, was CDN)
-├── standalone_app/
-│   ├── app.py              # Python HTTP server (port 3600)
-│   └── index.html          # Standalone app template
+│   ├── highlight.min.js      # Syntax highlighting (vendored, was CDN)
+│   └── monaco/                # Bundled Monaco + Shiki (via build_monaco.mjs)
 └── samples/
-    ├── components/         # Simple component example
-    ├── product_card/       # Props and list example
-    ├── lifecycle_demo/     # Hooks demonstration
-    ├── reactivity/          # Signals and proxy
-    ├── canvas/              # t-ref and DOM access
-    ├── form/                # t-model binding
-    ├── slots/               # Slot content projection
-    ├── plugins/             # Plugin system example
-    ├── kanban_board/        # Kanban demo
-    ├── html_editor/         # HTML editor demo
-    ├── web_client/          # Web client demo
-    ├── todo_app/            # TodoMVC tutorial
-    └── timer_app/           # Timer tutorial
+    └── v3/                   # One folder per example id, plus tutorials/<name>/<step>/
 ```
 
 ## Important Implementation Details
 
-### Split Editor State Management
-
-Each pane maintains separate state:
-
-```javascript
-panes: {
-  primary: { view: EditorView, states: {}, scrolls: {}, lastFile: string },
-  secondary: { view: EditorView, states: {}, scrolls: {}, lastFile: string }
-}
-```
-
-When switching files:
-
-1. Save current state to `states[lastFile]`
-2. Save scroll position to `scrolls[lastFile]`
-3. Load or create state for new file
-4. Restore scroll position
-
-### File Companion Detection
-
-`_getCompanion(file)` finds matching js/xml pair:
-
-- For `foo.js` → looks for `foo.xml`
-- For `foo.xml` → looks for `foo.js`
-
-Shows companion button (icon) to auto-split editor.
-
 ### Auto-run Feature
 
-When `SettingsPlugin.autoRun()` is true:
+When `SettingsPlugin.autoRun()` is true and the current project has already
+been run manually at least once, editing a non-markdown file triggers a
+debounced (500ms) `code.run()`.
 
-- Debounced (500ms) `run()` triggers on content change
-- Only runs if `userModified` is true
+### Code Sharing
 
-### Code Sharing (URL Hash)
-
-`shareCode()` encodes snapshot to base64 URL hash:
-
-```javascript
-window.location.hash = btoa(JSON.stringify({ "main.js": "...", ... }));
-```
-
-On load, `hashData` is parsed and creates "Shared Code" project.
-
-Supports legacy format: `{js, css, xml}` → migrated to new format.
+`ProjectPlugin` supports `serialize()`/`restore()` for `localStorage`
+persistence (via `LocalStoragePlugin`), keyed per project.
 
 ### Standalone Export
 
-`exportStandaloneApp()` creates ZIP:
-
-1. Loads JSZip and FileSaver libraries dynamically
-2. Fetches standalone app template files
-3. Bundles user code:
-   - `app.js` - All JS with template import
-   - `app.css` - All CSS concatenated
-   - `app.xml` - All templates wrapped
-4. Adds `owl.js`, `index.html`, `app.py`
+`exportStandaloneApp()` (`playground.js:318-329`) is deliberately simple: it
+snapshots the current project's files (`code.getSnapshot()`) and zips them
+as-is with `jszip`, then triggers a download via `FileSaver`. It does not
+bundle Owl, does not produce combined `app.js`/`app.css`/`app.xml` files,
+and there is no companion server or standalone-app template anywhere in the
+repo — the ZIP just contains the project's own files.
 
 ## Key Imports from Owl
+
+`playground.js`, `components.js`, and `plugins.js` import from `@odoo/owl`,
+including:
 
 ```javascript
 import {
@@ -383,13 +297,11 @@ import {
   __info__, // Version info
   Component, // Base class
   mount, // Mount function
-  xml, // Template tag
 
   // Reactivity
   signal, // Reactive value
   computed, // Computed value
-  effect, // Side effect
-  proxy, // Reactive proxy
+  untrack, // Untracked read
 
   // Lifecycle hooks
   onMounted,
@@ -399,37 +311,40 @@ import {
   onWillStart,
   onWillUnmount,
 
-  // Effect hooks
+  // Effects
   useEffect,
-  untrack, // Untracked read
 
   // Plugin system
   Plugin, // Base plugin class
-  plugin, // Plugin decorator
-  providePlugins, // Provide plugins to subtree
+  usePlugin, // Import a plugin dependency
+  providePlugins, // Provide plugins to a subtree
 
   // Props
-  props, // Props definition helper
-} from "../owl.js";
+  useProps, // Props declaration hook
+  t, // Type-validation builders
+} from "@odoo/owl";
 ```
 
 ## Templates (templates.xml)
 
-### Component Templates
+One template per component, matched by name:
 
-| Template Name    | Component        | Purpose                      |
-| ---------------- | ---------------- | ---------------------------- |
-| CodeEditor       | CodeEditor       | Split-pane editor UI         |
-| ConfirmDialog    | ConfirmDialog    | Yes/No confirmation          |
-| NewProjectDialog | NewProjectDialog | Create project with template |
-| SettingsDialog   | SettingsDialog   | Font size, auto-run          |
-| NewFileDialog    | NewFileDialog    | Create new file              |
-| FileDialog       | FileDialog       | Rename/delete file           |
-| ProjectDialog    | ProjectDialog    | Rename/delete project        |
-| Explorer         | Explorer         | Sidebar project tree         |
-| ProjectManager   | ProjectManager   | Project list dialog          |
-| ContentView      | ContentView      | Preview + console            |
-| Playground       | Playground       | Root layout                  |
+| Template Name     | Component         |
+| ------------------ | ------------------ |
+| CodeEditor          | CodeEditor          |
+| TutorialBar         | TutorialBar         |
+| ConfirmDialog        | ConfirmDialog        |
+| NewProjectDialog     | NewProjectDialog     |
+| SettingsDialog       | SettingsDialog       |
+| NewFileDialog        | NewFileDialog        |
+| NewFolderDialog      | NewFolderDialog      |
+| NewComponentDialog   | NewComponentDialog   |
+| FileDialog           | FileDialog           |
+| ProjectDialog        | ProjectDialog        |
+| ProjectManager       | ProjectManager       |
+| Explorer             | Explorer             |
+| ContentView          | ContentView          |
+| Playground           | Playground           |
 
 ## CSS Architecture (playground.css)
 
@@ -443,47 +358,19 @@ import {
 }
 ```
 
-### Color Scheme
+### Theming
 
-Dark theme for editor (OneDark):
-
-- Background: `#21252b`, `#282c34`
-- Text: `#abb2bf`, `#e6edf3`
-- Accent: `#58a6ff`
-- Border: `#181a1f`
-
-Light theme for preview:
-
-- Background: `#f8f9fa`
-- Border: `#d0d0d0`
+There's no CSS custom-property theme layer: colors are set per-selector, and
+dark/light mode is a single `light-mode` class toggled on `<html>` by
+`SettingsPlugin._applyTheme()` — most rules are written dark-first, with
+`.light-mode` overrides layered on top (see `.light-mode .editor-area`,
+`.light-mode .sidebar`, etc.). The Monaco editor tracks the same toggle via
+its own `slate-dark`/`github-light` themes (see CodeEditor above).
 
 ### Key Classes
 
-- `.editor-area` - Flex column for split editor
+- `.editor-area` - Flex column for the split editor
 - `.editor-pane` - Single editor pane
 - `.editor-split-separator` - Draggable divider
-- `.file-icon-{js,xml,css,md}` - File type icons (colored squares)
+- `.file-icon-{js,xml,css,md}` - File type icons
 - `.console-msg` - Log output with type-specific colors
-
-## Standalone App (standalone_app/)
-
-### app.py
-
-Simple Python HTTP server:
-
-- Port 3600
-- Sets `.js` MIME type to `application/javascript`
-- Run with `python3 app.py`
-
-### index.html
-
-Template for exported apps:
-
-```html
-<script type="importmap">
-  { "imports": { "@odoo/owl": "./owl.js" } }
-</script>
-<script type="module" src="app.js"></script>
-```
-
-Checks for `file://` protocol and shows instructions.


### PR DESCRIPTION
## Summary

Fixes 15 confirmed inaccuracies found by a full-repo audit of `doc/v3` and `tools/playground/samples/v3` against current source (`packages/{owl-core,owl-compiler,owl-runtime,owl}`):

- **Component & App core** — `app.md`'s `Root` object claimed a `node` property that doesn't exist (real fields: `prepared`/`destroyed`) and a fabricated "3-second onWillStart deadlock warning"; `overview.md` pointed at the deprecated `config` alias instead of `useConfig`.
- **Hooks & Effects** — `effects.md` claimed an effect created inside a plugin is disposed with that plugin; it's actually bound to the shared plugin manager's lifetime.
- **Props & Bindings** — `form_bindings.md` didn't disclose that `.trim` silently forces `.lazy`-style change-event timing too.
- **Templates** — `template_syntax.md` showed an invalid `t-key` placement and a false "falls back to index" claim (it throws), plus a wrong custom-directive output example; `precompiling_templates.md` referenced a nonexistent `owl.iife.runtime.js` build artifact (v2 leftover); `translations.md`'s translatable-attribute list was missing 4 `aria-*` attributes.
- **DOM & Control Flow** — `error_boundary.md` pointed at a dead `t-ref`/`useRef` access path (`t-ref` isn't supported on components in v3).
- **Plugins & Infra** — `scope.md` documented a nonexistent `Scope.parent` field and examples importing the never-exported `STATUS` enum.
- **Migration & Design Narrative** — `owl3_design.md` claimed a read-only computed's `.set()` silently no-ops (it throws), and filed `useProps.static()` as a rejected idea despite it being shipped.
- **Playground samples** — `web_client/core/orm.js` imported the nonexistent `useContext` instead of `useScope`; `web_client/readme.md` misplaced a file in its documented structure; two tutorial readmes (`todo_list/7`, `hibou_os/12`) taught a `"key?"` optional-prop syntax that doesn't work (real syntax is `.optional()`, matching each step's own solution file).
- **Playground architecture doc** — `playground.md` was rewritten from scratch: it described a prior CodeMirror-based playground (wrong editor, self-contradicting plugin count, 6/9 fabricated sample IDs, a tutorial that was never built, a "Standalone Export" feature bundling files + a Python server that don't exist, wrong file structure and component line citations) and omitted Vim mode, dark mode, and the v2/v3 version switcher entirely. Rewritten against the current `tools/playground/src/` implementation.

## Test plan

- [ ] Doc-only + one sample file (`orm.js`) change — no build/test impact expected
- [ ] `npm run test:doc-links` (checks doc cross-references still resolve)
- [ ] Spot-check `playground.md` renders correctly in the playground's own markdown viewer