### PR TITLE
[IMP] owl: declare signal and static props in the schema

### DIFF
--- a/doc/v3/owl/reference/props.md
+++ b/doc/v3/owl/reference/props.md
@@ -145,6 +145,62 @@ This only applies to props accessed through `useProps()`. The singular
 [`useProps.static()`](#the-usepropsstatic-method) helper keeps its static, reference-stable
 semantics.
 
+### Signal props
+
+A prop declared with `t.signal(...)` at the top level of the schema is a
+**signal prop**: the child reads it as a reactive value, and the prop itself
+is static (the parent must pass the same signal on every render; only its
+inner value changes).
+
+```js
+import { Component, useProps, t, xml } from "@odoo/owl";
+
+class Counter extends Component {
+  static template = xml`<span t-out="this.props.count()"/>`;
+  props = useProps({ count: t.signal(t.number()) });
+}
+```
+
+`this.props.count` is the reactive value itself, assigned once: reading it in
+the template, a computed or an effect subscribes to the signal, without any
+render of the parent involved.
+
+The child's view is **read-only by default**: when the parent passes a
+writable signal, the child receives a wrapping computed with no `set` method.
+A component that intends to write the received signal declares it:
+
+```js
+props = useProps({ value: t.signal(t.number(), { settable: true }) });
+```
+
+A settable prop exposes the original signal, and validation requires the
+received value to have a `set` method (a read-only computed is rejected).
+
+When the parent passes a **plain value** instead of a signal, the value is
+promoted: the child still reads a reactive value, updated when the parent
+re-renders with a new value. This keeps every caller working while they
+migrate to passing signals. A caller must not alternate between passing a
+plain value and a signal (dev mode throws).
+
+### Static props in the schema
+
+`.static()` marks a prop of the schema with the semantics of
+[`useProps.static`](#the-usepropsstatic-method), while keeping it declared
+with the other props:
+
+```js
+props = useProps({
+  todo: t.instanceOf(Todo).static(),
+  label: t.string().optional("untitled").static(),
+});
+```
+
+The value is read once and assigned directly to `this.props.todo` (no
+getter), and dev mode throws if the reference changes on a later render.
+`.static()` composes with `.optional()` in any order, and is only meaningful
+at the top level of a prop declaration: validation rejects it on a nested
+key. A signal prop does not need it: `t.signal(...)` is static by nature.
+
 ## The `useProps.static` method
 
 `useProps.static` is an alternative for components that only need to read a

--- a/doc/v3/owl/reference/props.md
+++ b/doc/v3/owl/reference/props.md
@@ -498,15 +498,27 @@ value at the call site:
 <Counter count.signal="this.state.count"/>
 ```
 
-Owl creates the signal once per call site (per loop iteration inside a
-`t-foreach`), keeps it across renders, and updates its value on each parent
-render. The signal reference is stable, so `effect` and `computed` subscriptions
-inside the child remain valid across parent updates.
+Owl creates a computed once per call site (per `t-key` inside a `t-foreach`,
+the same key that identifies the child component), keeps it across renders,
+and evaluates the expression inside that computed, not during the parent's
+render. The reference is stable and follows the child through list reorders,
+so `effect` and `computed` subscriptions inside the child remain valid across
+parent updates, a signal-prop static contract holds, and the child receives a
+read-only reactive value.
 
-`.signal` is an adapter, not a parent-side performance optimization: the parent
-still re-renders when its own state changes, and that re-render is what updates
-the wrapper's value. The suffix simply lets you use a signal-API component from
-a context where the data is not yet a signal.
+Because the expression runs inside the computed, the parent never subscribes
+to what it reads: when `this.state.count` changes above, the child updates and
+the parent does not re-render. This makes `.signal` a real parent-side
+optimization, in addition to being an adapter for signal-API components.
+
+Two consequences of the deferred evaluation:
+
+- render-scope variables (a `t-foreach` item, a `t-set` value) are captured
+  per parent render: when one of them changes, the computed re-evaluates with
+  the new capture,
+- an expression reading only non-reactive state evaluates once and never
+  refreshes. A constant is fine (`count.signal="7"`); a plain mutable field is
+  not, wrap it in a signal or a proxy instead.
 
 ## Good Practices
 

--- a/packages/owl-compiler/src/code_generator.ts
+++ b/packages/owl-compiler/src/code_generator.ts
@@ -1169,11 +1169,22 @@ export class CodeGenerator {
       let [name, suffix] = p.split(".");
 
       if (suffix === "signal") {
-        const compiledValue = compileExpr(ast.props![p]);
+        const { expr: compiledValue, freeVariables } = processExpr(
+          ast.props![p],
+          undefined,
+          true
+        );
         const propName = /^[a-z_]+$/i.test(name) ? name : `'${name}'`;
-        this.helpers.add("toSignal");
+        this.helpers.add("toComputed");
         const cacheKey = this.generateSignalCacheKey();
-        props.push(`${propName}: toSignal(node, ${cacheKey}, ${compiledValue})`);
+        if (freeVariables?.length) {
+          const captures = freeVariables.map((v) => `ctx['${v}']`).join(",");
+          props.push(
+            `${propName}: toComputed(node, ${cacheKey}, (__caps) => ${compiledValue}, [${captures}])`
+          );
+        } else {
+          props.push(`${propName}: toComputed(node, ${cacheKey}, () => ${compiledValue})`);
+        }
         continue;
       }
 

--- a/packages/owl-compiler/src/inline_expressions.ts
+++ b/packages/owl-compiler/src/inline_expressions.ts
@@ -268,10 +268,18 @@ interface ProcessedExpr {
 /**
  * Processes a javascript expression: compiles variable lookups and detects
  * top-level arrow functions with their free variables, all in a single pass.
+ * With `captureNonLocals` (`.signal=`), context variables compile to `__caps`
+ * lookups and are all returned as free variables.
  */
-export function processExpr(expr: string, seededLocals?: Set<string>): ProcessedExpr {
+export function processExpr(
+  expr: string,
+  seededLocals?: Set<string>,
+  captureNonLocals = false,
+  sharedCaptures?: Map<string, number>
+): ProcessedExpr {
   // scope entries carry the stack depth at which they were created
   const scopeStack: { vars: Set<string>; depth: number }[] = [];
+  const captureIndexes = sharedCaptures ?? new Map<string, number>();
 
   // Seed outer locals
   // depth: -Infinity so this scope never gets popped
@@ -342,7 +350,10 @@ export function processExpr(expr: string, seededLocals?: Set<string>): Processed
       for (const scope of scopeStack) {
         for (const v of scope.vars) currentLocals.add(v);
       }
-      token.value = token.replace!((expr: any) => compileExpr(expr, currentLocals));
+      // the interpolations share the capture indexes of the outer expression
+      token.value = token.replace!(
+        (expr: any) => processExpr(expr, currentLocals, captureNonLocals, captureIndexes).expr
+      );
     }
 
     if (nextToken && nextToken.type === "OPERATOR" && nextToken.value === "=>") {
@@ -374,7 +385,17 @@ export function processExpr(expr: string, seededLocals?: Set<string>): Processed
       token.varName = token.value;
       if (!isLocal(token.value)) {
         token.originalValue = token.value;
-        token.value = `ctx['${token.value}']`;
+        // `this` is the component, stable across renders: never a capture
+        if (captureNonLocals && token.value !== "this") {
+          let index = captureIndexes.get(token.value);
+          if (index === undefined) {
+            index = captureIndexes.size;
+            captureIndexes.set(token.value, index);
+          }
+          token.value = `__caps[${index}]`;
+        } else {
+          token.value = `ctx['${token.value}']`;
+        }
       } else {
         token.value = `_${token.value}`;
         token.isLocal = true;
@@ -383,9 +404,12 @@ export function processExpr(expr: string, seededLocals?: Set<string>): Processed
     i++;
   }
 
-  // Collect free variables from arrow function body
+  // Collect free variables from arrow function body (the whole expression,
+  // in capture-index order, when non-locals are captured)
   let freeVariables: string[] | null = null;
-  if (topLevelArrowIndex !== -1) {
+  if (captureNonLocals) {
+    freeVariables = [...captureIndexes.keys()];
+  } else if (topLevelArrowIndex !== -1) {
     freeVariables = [];
     const seen = new Set<string>();
     for (let i = topLevelArrowIndex + 1; i < tokens.length; i++) {

--- a/packages/owl-core/src/computations.ts
+++ b/packages/owl-core/src/computations.ts
@@ -6,7 +6,14 @@ export interface ReactiveValue<TRead, TWrite = TRead> {
    * Update the value of the reactive with a new value. If the new value is different
    * from the previous values, all computations that depends on this reactive will
    * be invalidated, and effects will rerun.
+   *
+   * Absent on a read-only reactive value: read-only is checked by the absence of `set`.
    */
+  set?(nextValue: TWrite): void;
+}
+
+export interface WritableReactiveValue<TRead, TWrite = TRead>
+  extends ReactiveValue<TRead, TWrite> {
   set(nextValue: TWrite): void;
 }
 

--- a/packages/owl-core/src/computed.ts
+++ b/packages/owl-core/src/computed.ts
@@ -8,8 +8,8 @@ import {
   toEqualsFn,
   updateComputation,
   createComputation,
+  WritableReactiveValue,
 } from "./computations";
-import { OwlError } from "./owl_error";
 import { getScope } from "./scope";
 
 interface ComputedOptions<TRead, TWrite = TRead> {
@@ -23,12 +23,14 @@ interface ComputedOptions<TRead, TWrite = TRead> {
   equals?: Equals<TRead>;
 }
 
-function readonlySetter(): never {
-  throw new OwlError(
-    "Cannot write to a read-only computed value. Pass a `set` option to make it writable."
-  );
-}
-
+export function computed<TRead, TWrite = TRead>(
+  getter: () => TRead,
+  options: ComputedOptions<TRead, TWrite> & { set(value: TWrite): void }
+): WritableReactiveValue<TRead, TWrite>;
+export function computed<TRead>(
+  getter: () => TRead,
+  options?: ComputedOptions<TRead, never>
+): ReactiveValue<TRead, never>;
 export function computed<TRead, TWrite = TRead>(
   getter: () => TRead,
   options: ComputedOptions<TRead, TWrite> = {}
@@ -60,7 +62,9 @@ export function computed<TRead, TWrite = TRead>(
     return computation.value;
   }
   readComputed[atomSymbol] = computation;
-  readComputed.set = options.set ?? readonlySetter;
+  if (options.set) {
+    readComputed.set = options.set;
+  }
 
   getScope()?.computations.push(computation);
 

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -24,6 +24,7 @@ export {
   untrack,
   type Equals,
   type ReactiveValue,
+  type WritableReactiveValue,
   type Atom,
   type ComputationAtom,
   ComputationState,

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -71,6 +71,8 @@ export {
   constructorType,
   applyDefaults,
   getDefault,
+  getSignalType,
+  isStaticType,
   type Constructor,
   type GetDefaultedKeys,
   type GetOptionalEntries,
@@ -82,6 +84,8 @@ export {
   type ResolveOptionalEntries,
   type ResolveReaderObjectType,
   type ShapeType,
+  type SignalTypeMeta,
+  type Static,
   type StripBrands,
   type Type,
   type UnionToIntersection,
@@ -91,6 +95,7 @@ export {
   // emitting declaration files, mirroring `isProps` (see owl#1958).
   type hasDefault,
   type isOptional,
+  type isStatic,
   type typeBrand,
 } from "./types";
 

--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -1,4 +1,4 @@
-import { atomSymbol, type ReactiveValue } from "./computations";
+import { atomSymbol, type ReactiveValue, type WritableReactiveValue } from "./computations";
 import { ValidationContext, ValidationIssue } from "./validation";
 
 export type Constructor<T = any> = { new (...args: any[]): T };
@@ -16,6 +16,12 @@ const elementTypeSymbol = Symbol("elementType");
 // Attached to validators created by `.optional()`: an object key with an
 // optional type may be omitted.
 const optionalSymbol = Symbol("optional");
+// Attached to validators created by `.static()`: the consumer of the schema
+// (props) reads such a key once and pins it.
+const staticSymbol = Symbol("static");
+// Attached to validators created by `types.signal()`, carrying the inner type
+// and the settable flag, so that props can give signal keys their behavior.
+const signalSymbol = Symbol("signal");
 // Attached to intersection validators (`and`), so that `applyDefaults` can
 // fold defaults from every member type into the value.
 const intersectionSymbol = Symbol("intersection");
@@ -25,11 +31,27 @@ const intersectionSymbol = Symbol("intersection");
 // so it can be recovered with `infer`. Exported so that dependent
 // declarations (e.g. a `Resource<T>` field) can be emitted across modules.
 export declare const hasDefault: unique symbol;
-export type WithDefault<T> = T & { [hasDefault]: T };
+export type WithDefault<T> = T & {
+  [hasDefault]: T;
+  static(): Static<T & { [hasDefault]: T }>;
+};
 
 // Type-level brand carried by `.optional()`, phantom like `hasDefault`.
 export declare const isOptional: unique symbol;
-export type Optional<T> = T & { [isOptional]: T };
+export type Optional<T> = T & {
+  [isOptional]: T;
+  static(): Static<T & { [isOptional]: T }>;
+};
+
+// Type-level brand carried by `.static()`, phantom like `hasDefault`.
+export declare const isStatic: unique symbol;
+export type Static<T> = T & {
+  [isStatic]: T;
+  optional(): Optional<T & { [isStatic]: T }>;
+  optional(
+    value: T extends Function ? () => T : T | (() => T)
+  ): WithDefault<T & { [isStatic]: T }>;
+};
 
 // Type-level brand carried by every type built by the `types` factories. It
 // is phantom: at runtime, only the `optional` method exists on the validator.
@@ -49,6 +71,11 @@ export type Type<T> = T & {
    * a function type must use the factory form.
    */
   optional(value: T extends Function ? () => T : T | (() => T)): WithDefault<T>;
+  /**
+   * Marks the type as static: props read such a key once and keep it. Only
+   * meaningful at the top level of a prop declaration.
+   */
+  static(): Static<T>;
 
   type: T;
 };
@@ -77,10 +104,11 @@ type HasDefault<T> = IsAny<T> extends true ? false : T extends { [hasDefault]: a
 type IsOptional<T> = IsAny<T> extends true ? false : T extends { [isOptional]: any } ? true : false;
 type StripDefault<T> = T extends { [hasDefault]: infer U } ? U : T;
 type StripOptional<T> = T extends { [isOptional]: infer U } ? U | undefined : T;
+type StripStatic<T> = T extends { [isStatic]: infer U } ? U : T;
 type StripType<T> = T extends { [typeBrand]: infer U } ? U : T;
 // Recovers the value type carried by a validator: brands are removed, and an
 // optional type resolves to `T | undefined`.
-export type StripBrands<T> = StripType<StripDefault<StripOptional<T>>>;
+export type StripBrands<T> = StripType<StripStatic<StripDefault<StripOptional<T>>>>;
 type StripBrandsAll<T extends any[]> = { [K in keyof T]: StripBrands<T[K]> };
 
 // Keys whose type carries a default. The distributive conditional makes the
@@ -145,7 +173,34 @@ export type UnionToIntersection<U> = (U extends any ? (_: U) => any : never) ext
  * schema, not a validation side-effect.
  */
 export function getDefault(type: any): (() => any) | undefined {
-  return typeof type === "function" ? type[defaultSymbol] : undefined;
+  return findInChain(type, defaultSymbol)?.[defaultSymbol];
+}
+
+// Walk the wrapper chain, as `.optional()` and `.static()` compose in any
+// order, so a brand can sit on any layer.
+function findInChain(type: any, symbol: symbol): any | undefined {
+  while (typeof type === "function") {
+    if (symbol in type) {
+      return type;
+    }
+    type = type[innerTypeSymbol];
+  }
+  return undefined;
+}
+
+/** Returns whether the type was marked with `.static()`. */
+export function isStaticType(type: any): boolean {
+  return !!findInChain(type, staticSymbol);
+}
+
+export interface SignalTypeMeta {
+  settable: boolean;
+  type: any;
+}
+
+/** Returns the signal metadata of a `types.signal(...)` type, if it is one. */
+export function getSignalType(type: any): SignalTypeMeta | undefined {
+  return findInChain(type, signalSymbol)?.[signalSymbol];
 }
 
 // Runtime implementation of the `optional` method declared on `Type`. With a
@@ -160,6 +215,7 @@ function makeOptional(type: any, value?: any): any {
   } as any;
   validate[optionalSymbol] = true;
   validate[innerTypeSymbol] = type;
+  validate.static = () => makeStatic(validate);
   if (value !== undefined) {
     validate[defaultSymbol] = typeof value === "function" ? value : () => value;
   }
@@ -167,13 +223,27 @@ function makeOptional(type: any, value?: any): any {
 }
 
 function isOptionalType(type: any): boolean {
-  return typeof type === "function" && optionalSymbol in type;
+  return !!findInChain(type, optionalSymbol);
 }
 
-// Attaches the `optional` method to a validator: every `types` factory
-// funnels its validator through this.
+function makeStatic(type: any): any {
+  const validate = makeType(function validateStatic(context: ValidationContext) {
+    if (context.path.length > 1) {
+      context.addIssue({ message: "a static type is only valid on a prop" });
+      return;
+    }
+    context.validate(type);
+  });
+  validate[staticSymbol] = true;
+  validate[innerTypeSymbol] = type;
+  return validate;
+}
+
+// Attaches the `optional` and `static` methods to a validator: every `types`
+// factory funnels its validator through this.
 function makeType(validate: (context: ValidationContext) => void): any {
   (validate as any).optional = (value?: any) => makeOptional(validate, value);
+  (validate as any).static = () => makeStatic(validate);
   return validate;
 }
 
@@ -554,15 +624,34 @@ function union<T extends unknown[]>(types: T): Type<StripBrands<T[number]>> {
   });
 }
 
+interface SignalTypeOptions {
+  /**
+   * The consumer writes the received signal: validation requires a `set`
+   * method on it.
+   */
+  settable?: boolean;
+}
+
 function reactiveValueType(): Type<ReactiveValue<any>>;
 function reactiveValueType<T>(): Type<ReactiveValue<T>>;
 function reactiveValueType<T>(type: T): Type<ReactiveValue<StripBrands<T>>>;
-function reactiveValueType(type?: any): any {
-  return makeType(function validateReactiveValue(context: ValidationContext) {
+function reactiveValueType<T>(
+  type: T,
+  options: { settable: true }
+): Type<WritableReactiveValue<StripBrands<T>>>;
+function reactiveValueType(type?: any, options?: SignalTypeOptions): any {
+  const settable = options?.settable ?? false;
+  const validate = makeType(function validateReactiveValue(context: ValidationContext) {
     if (typeof context.value !== "function" || !context.value[atomSymbol]) {
       context.addIssue({ message: "value is not a reactive value" });
+      return;
+    }
+    if (settable && typeof context.value.set !== "function") {
+      context.addIssue({ message: "value is not a settable reactive value" });
     }
   });
+  validate[signalSymbol] = { settable, type } satisfies SignalTypeMeta;
+  return validate;
 }
 
 function ref(): Type<HTMLElement | null>;

--- a/packages/owl-core/src/types.ts
+++ b/packages/owl-core/src/types.ts
@@ -643,7 +643,12 @@ function reactiveValueType(type?: any, options?: SignalTypeOptions): any {
   const settable = options?.settable ?? false;
   const validate = makeType(function validateReactiveValue(context: ValidationContext) {
     if (typeof context.value !== "function" || !context.value[atomSymbol]) {
-      context.addIssue({ message: "value is not a reactive value" });
+      if (settable) {
+        context.addIssue({ message: "value is not a reactive value" });
+      } else if (type) {
+        // A plain value is promoted to a signal by the consumer (props).
+        context.validate(type);
+      }
       return;
     }
     if (settable && typeof context.value.set !== "function") {

--- a/packages/owl-core/tests/computed.test.ts
+++ b/packages/owl-core/tests/computed.test.ts
@@ -552,13 +552,13 @@ describe("nested computed", () => {
 });
 
 describe("writable computed", () => {
-  test("set throws by default on a read-only computed", () => {
+  test("a read-only computed has no set method", () => {
     const percentage = signal(0.5);
     const value = computed(() => percentage() * 100);
     expect(percentage()).toBe(0.5);
     expect(value()).toBe(50);
 
-    expect(() => value.set(0.21)).toThrow(/read-only computed/);
+    expect(value.set).toBeUndefined();
     expect(percentage()).toBe(0.5);
     expect(value()).toBe(50);
   });
@@ -569,7 +569,7 @@ describe("writable computed", () => {
     expect(percentage()).toBe(0.5);
     expect(value()).toBe(0.5);
 
-    expect(() => value.set(0.21)).toThrow(/read-only computed/);
+    expect(value.set).toBeUndefined();
     expect(percentage()).toBe(0.5);
     expect(value()).toBe(0.5);
   });

--- a/packages/owl-core/tests/validation.test.ts
+++ b/packages/owl-core/tests/validation.test.ts
@@ -470,31 +470,30 @@ describe("promise", () => {
 });
 
 test("signal", () => {
+  // a plain value is accepted through the inner type: props promote it
   expect(validateType(123, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: 123 },
+    { message: "value is not a string", path: "", received: 123 },
   ]);
-  expect(validateType("abc", t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: "abc" },
-  ]);
+  expect(validateType("abc", t.signal(t.string()))).toEqual([]);
   expect(validateType(true, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: true },
+    { message: "value is not a string", path: "", received: true },
   ]);
   const arrowFn = () => {};
   expect(validateType(arrowFn, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: arrowFn },
+    { message: "value is not a string", path: "", received: arrowFn },
   ]);
   const fn = function () {};
   expect(validateType(fn, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: fn },
+    { message: "value is not a string", path: "", received: fn },
   ]);
   expect(validateType(A, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: A },
+    { message: "value is not a string", path: "", received: A },
   ]);
   class B {
     set() {}
   }
   expect(validateType(B, t.signal(t.string()))).toEqual([
-    { message: "value is not a reactive value", path: "", received: B },
+    { message: "value is not a string", path: "", received: B },
   ]);
   expect(validateType(signal(1), t.signal(t.number()))).toEqual([]);
   expect(

--- a/packages/owl-core/tests/validation.test.ts
+++ b/packages/owl-core/tests/validation.test.ts
@@ -505,6 +505,49 @@ test("signal", () => {
   ).toEqual([]);
 });
 
+test("settable signal", () => {
+  const s = signal(1);
+  expect(validateType(s, t.signal(t.number(), { settable: true }))).toEqual([]);
+  const readOnly = computed(s);
+  expect(validateType(readOnly, t.signal(t.number(), { settable: true }))).toEqual([
+    { message: "value is not a settable reactive value", path: "", received: readOnly },
+  ]);
+  const writable = computed(s, { set: (v: number) => s.set(v) });
+  expect(validateType(writable, t.signal(t.number(), { settable: true }))).toEqual([]);
+  expect(validateType(1, t.signal(t.number(), { settable: true }))).toEqual([
+    { message: "value is not a reactive value", path: "", received: 1 },
+  ]);
+});
+
+describe(".static()", () => {
+  test("validates like the wrapped type at the top of an object", () => {
+    expect(validateType({ n: 1 }, t.object({ n: t.number().static() }))).toEqual([]);
+    expect(validateType({ n: "a" }, t.object({ n: t.number().static() }))).toEqual([
+      { message: "value is not a number", path: "n", received: "a" },
+    ]);
+  });
+
+  test("composes with optional in both orders", () => {
+    expect(validateType({}, t.object({ n: t.number().optional().static() }))).toEqual([]);
+    expect(validateType({}, t.object({ n: t.number().static().optional() }))).toEqual([]);
+    expect(validateType({ n: 1 }, t.object({ n: t.number().optional().static() }))).toEqual([]);
+    expect(validateType({ n: 1 }, t.object({ n: t.number().static().optional() }))).toEqual([]);
+  });
+
+  test("keeps the default reachable in both orders", () => {
+    expect(getDefault(t.number().optional(5).static())!()).toBe(5);
+    expect(getDefault(t.number().static().optional(5))!()).toBe(5);
+  });
+
+  test("is invalid on a nested type", () => {
+    expect(
+      validateType({ o: { n: 1 } }, t.object({ o: t.object({ n: t.number().static() }) }))
+    ).toEqual([
+      { message: "a static type is only valid on a prop", path: "o > n", received: 1 },
+    ]);
+  });
+});
+
 test("record", () => {
   expect(validateType("abc", t.record(t.string()))).toEqual([
     { message: "value is not an object", path: "", received: "abc" },

--- a/packages/owl-runtime/src/error_boundary.ts
+++ b/packages/owl-runtime/src/error_boundary.ts
@@ -18,6 +18,6 @@ export class ErrorBoundary extends Component {
   props = props({ error: t.signal().optional(() => signal<any>(null)) });
 
   setup() {
-    onError((e) => this.props.error.set(e));
+    onError((e) => this.props.error.set!(e));
   }
 }

--- a/packages/owl-runtime/src/error_boundary.ts
+++ b/packages/owl-runtime/src/error_boundary.ts
@@ -1,7 +1,7 @@
 import { signal } from "@odoo/owl-core";
 import { Component } from "./component";
 import { onError } from "./lifecycle_hooks";
-import { props } from "./props";
+import { useProps } from "./props";
 import { xml } from "./template_set";
 import { types as t } from "./types";
 
@@ -15,9 +15,11 @@ export class ErrorBoundary extends Component {
     </t>
   `;
 
-  props = props({ error: t.signal().optional(() => signal<any>(null)) });
+  props = useProps({
+    error: t.signal(t.any(), { settable: true }).optional(() => signal<any>(null)),
+  });
 
   setup() {
-    onError((e) => this.props.error.set!(e));
+    onError((e) => this.props.error.set(e));
   }
 }

--- a/packages/owl-runtime/src/index.ts
+++ b/packages/owl-runtime/src/index.ts
@@ -63,6 +63,7 @@ export {
   type Equals,
   type ReactiveValue,
   type Signal,
+  type WritableReactiveValue,
 } from "@odoo/owl-core";
 export { useEffect, useListener, useOnChange, useApp } from "./hooks";
 export { batched, EventBus, htmlEscape, shallowEqual, whenReady, markup } from "./utils";

--- a/packages/owl-runtime/src/portal.ts
+++ b/packages/owl-runtime/src/portal.ts
@@ -1,4 +1,4 @@
-import { Signal } from "@odoo/owl-core";
+import { ReactiveValue } from "@odoo/owl-core";
 import { Component } from "./component";
 import { useEffect } from "./hooks";
 import { onWillDestroy } from "./lifecycle_hooks";
@@ -13,7 +13,12 @@ class PortalContent extends Component {
   static template = xml`<t t-call-slot="default"/>`;
 }
 
-export type PortalTarget = string | HTMLElement | Signal<HTMLElement | null> | null | undefined;
+export type PortalTarget =
+  | string
+  | HTMLElement
+  | ReactiveValue<HTMLElement | null>
+  | null
+  | undefined;
 
 export class Portal extends Component {
   static template = xml``;

--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -1,11 +1,17 @@
 import {
   assertType,
+  atomSymbol,
+  computed,
   getDefault,
   GetDefaultedKeys,
+  getSignalType,
+  isStaticType,
+  OwlError,
   ResolveObjectType,
   ResolveReaderObjectType,
   signal,
   Signal,
+  SignalTypeMeta,
 } from "@odoo/owl-core";
 import { getComponentScope } from "./component_node";
 import { staticProp } from "./prop";
@@ -94,10 +100,87 @@ function makeProps(type?: any): Props<{}> {
     }
   }
 
+  function isReactiveValue(value: any): boolean {
+    return typeof value === "function" && !!value[atomSymbol];
+  }
+
+  function defineValueProp(key: string, value: any) {
+    Reflect.defineProperty(result, key, { enumerable: true, configurable: true, value });
+  }
+
+  function guardStaticProp(key: string, initial: any, message: string) {
+    if (!app.dev) {
+      return;
+    }
+    node.willUpdateProps.push((nextProps: Record<string, any>) => {
+      if (resolveValue(nextProps, key) !== initial) {
+        throw new OwlError(`Prop '${key}' in component '${componentName}' ${message}`);
+      }
+    });
+  }
+
+  function defineSignalProp(key: string, meta: SignalTypeMeta) {
+    const raw = resolveValue(node.props, key);
+    if (isReactiveValue(raw)) {
+      defineValueProp(key, meta.settable || !raw.set ? raw : computed(raw));
+      guardStaticProp(
+        key,
+        raw,
+        "changed. A signal prop is static: pass the same signal (its inner value may change)."
+      );
+    } else if (meta.settable) {
+      defineValueProp(key, raw);
+    } else {
+      const promoted = signal(raw);
+      defineValueProp(key, computed(promoted));
+      promotedUpdates.push(() => promoted.set(resolveValue(node.props, key)));
+      if (app.dev) {
+        node.willUpdateProps.push((nextProps: Record<string, any>) => {
+          if (isReactiveValue(resolveValue(nextProps, key))) {
+            throw new OwlError(
+              `Prop '${key}' in component '${componentName}' changed from a plain value ` +
+                `to a signal. Pass the signal from the start instead.`
+            );
+          }
+        });
+      }
+    }
+  }
+
+  function defineStaticProp(key: string) {
+    const value = resolveValue(node.props, key);
+    defineValueProp(key, value);
+    guardStaticProp(
+      key,
+      value,
+      "changed. A static prop should not change. If the prop is a signal, pass the same " +
+        "signal reference (its inner value may change)."
+    );
+  }
+
+  const promotedUpdates: (() => void)[] = [];
+
   if (type) {
     const keys: string[] = Array.isArray(type) ? type : Object.keys(type);
-    defineProps(keys);
-    node.propsUpdated.push(() => updateSignals(keys));
+    const reactiveKeys: string[] = [];
+    for (const key of keys) {
+      const keyType = Array.isArray(type) ? undefined : type[key];
+      const signalMeta = keyType && getSignalType(keyType);
+      if (signalMeta) {
+        defineSignalProp(key, signalMeta);
+      } else if (keyType && isStaticType(keyType)) {
+        defineStaticProp(key);
+      } else {
+        defineProp(key);
+        reactiveKeys.push(key);
+      }
+    }
+    node.propsUpdated.push(() => {
+      updateSignals(reactiveKeys);
+      for (const update of promotedUpdates) {
+        update();
+      }
+    });
 
     if (app.dev) {
       if (defaults) {

--- a/packages/owl-runtime/src/rendering/template_helpers.ts
+++ b/packages/owl-runtime/src/rendering/template_helpers.ts
@@ -204,25 +204,41 @@ function callHandler(fn: any, ctx: any, ev: Event) {
   fn.call(ctx["this"], ev);
 }
 
-type CachedSignal<T> = Signal<T> & { readonly: ReactiveValue<T> };
+interface CachedComputed {
+  value: ReactiveValue<any>;
+  captures?: Signal<any[]>;
+}
 
-const signalCaches = new WeakMap<ComponentNode, Map<string, CachedSignal<any>>>();
+const computedCaches = new WeakMap<ComponentNode, Map<string, CachedComputed>>();
 
-function toSignal(node: ComponentNode, cacheKey: string, value: any): ReactiveValue<any> {
-  let cache = signalCaches.get(node);
+// `fn` runs inside the cached computed, never here, so the parent's render
+// does not subscribe to what the `.signal=` expression reads.
+function toComputed(
+  node: ComponentNode,
+  cacheKey: string,
+  fn: (captures: any[]) => any,
+  captures?: any[]
+): ReactiveValue<any> {
+  let cache = computedCaches.get(node);
   if (!cache) {
     cache = new Map();
-    signalCaches.set(node, cache);
+    computedCaches.set(node, cache);
   }
   const existing = cache.get(cacheKey);
   if (existing) {
-    existing.set(value);
-    return existing.readonly;
+    existing.captures?.set(captures!);
+    return existing.value;
   }
-  const s = signal(value) as CachedSignal<any>;
-  s.readonly = computed(s);
-  cache.set(cacheKey, s);
-  return s.readonly;
+  const entry: CachedComputed = {} as CachedComputed;
+  if (captures) {
+    const capturesSignal = signal(captures, { equals: shallowEqual });
+    entry.captures = capturesSignal;
+    entry.value = computed(() => fn(capturesSignal()));
+  } else {
+    entry.value = computed(fn as () => any);
+  }
+  cache.set(cacheKey, entry);
+  return entry.value;
 }
 
 function modelExpr(value: any) {
@@ -399,5 +415,5 @@ export const helpers = {
   createComponent,
   callTemplate,
   callHandler,
-  toSignal,
+  toComputed,
 };

--- a/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
@@ -73,11 +73,11 @@ exports[`.signal suffix accepts a signal-typed prop without validation error 1`]
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
-    const props1 = {count: toSignal(node, \`__sig_1\`, ctx['this'].state.val)};
+    const props1 = {count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)};
     return comp1(props1, key + \`__1\`, node, this, null);
   }
 }"
@@ -95,15 +95,177 @@ exports[`.signal suffix accepts a signal-typed prop without validation error 2`]
 }"
 `;
 
+exports[`.signal suffix lazy evaluation > a constant satisfies a signal-typed prop 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { toComputed, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {count: toComputed(node, \`__sig_1\`, () => 7)};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > a constant satisfies a signal-typed prop 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > a replaced t-foreach item reaches the child through the captures 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { prepareList, toComputed, createComponent, withKey } = helpers;
+  const comp1 = createComponent(app, \`Item\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const ctx1 = ctx;
+    const [k_block1, v_block1, l_block1, c_block1] = prepareList(ctx['this'].state.items);;
+    for (let i1 = 0; i1 < l_block1; i1++) {
+      let ctx = Object.create(ctx1);
+      ctx[\`item\`] = k_block1[i1];
+      const key1 = ctx['item'].id;
+      c_block1[i1] = withKey(comp1({value: toComputed(node, \`__sig_1__\${key1}\`, (__caps) => __caps[0].n, [ctx['item']])}, key + \`__1__\${key1}\`, node, this, null), key1);
+    }
+    return list(c_block1);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > a replaced t-foreach item reaches the child through the captures 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.value());
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > a template string interpolation reaches the captures 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { prepareList, toComputed, createComponent, withKey } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const ctx1 = ctx;
+    const [k_block1, v_block1, l_block1, c_block1] = prepareList(ctx['this'].state.items);;
+    for (let i1 = 0; i1 < l_block1; i1++) {
+      let ctx = Object.create(ctx1);
+      ctx[\`item\`] = k_block1[i1];
+      const key1 = ctx['item'].id;
+      c_block1[i1] = withKey(comp1({label: toComputed(node, \`__sig_1__\${key1}\`, (__caps) => \`item \${__caps[0].n}\`, [ctx['item']])}, key + \`__1__\${key1}\`, node, this, null), key1);
+    }
+    return list(c_block1);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > a template string interpolation reaches the captures 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.label());
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > the parent does not re-render when the read value changes 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { toComputed, createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  let block1 = createBlock(\`<div><block-child-0/></div>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = comp1({count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)}, key + \`__1\`, node, this, null);
+    return block1([], [b2]);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > the parent does not re-render when the read value changes 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > the wrapper follows the t-key across a reorder 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { prepareList, toComputed, createComponent, withKey } = helpers;
+  const comp1 = createComponent(app, \`Item\`, true, false, false, ["id"]);
+  
+  return function template(ctx, node, key = "") {
+    const ctx1 = ctx;
+    const [k_block1, v_block1, l_block1, c_block1] = prepareList(ctx['this'].state.items);;
+    for (let i1 = 0; i1 < l_block1; i1++) {
+      let ctx = Object.create(ctx1);
+      ctx[\`item\`] = k_block1[i1];
+      const key1 = ctx['item'].id;
+      c_block1[i1] = withKey(comp1({value: toComputed(node, \`__sig_1__\${key1}\`, (__caps) => __caps[0].n, [ctx['item']]),id: ctx['item'].id}, key + \`__1__\${key1}\`, node, this, null), key1);
+    }
+    return list(c_block1);
+  }
+}"
+`;
+
+exports[`.signal suffix lazy evaluation > the wrapper follows the t-key across a reorder 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  let block1 = createBlock(\`<span><block-child-0/></span>\`);
+  
+  return function template(ctx, node, key = "") {
+    const b2 = safeOutput(ctx['this'].props.value());
+    return block1([], [b2]);
+  }
+}"
+`;
+
 exports[`.signal suffix promotes a plain value to a signal 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
-    const props1 = {count: toSignal(node, \`__sig_1\`, ctx['this'].state.val)};
+    const props1 = {count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)};
     return comp1(props1, key + \`__1\`, node, this, null);
   }
 }"
@@ -125,7 +287,7 @@ exports[`.signal suffix works in a t-foreach loop 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { prepareList, toSignal, createComponent, withKey } = helpers;
+  let { prepareList, toComputed, createComponent, withKey } = helpers;
   const comp1 = createComponent(app, \`Item\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
@@ -135,7 +297,7 @@ exports[`.signal suffix works in a t-foreach loop 1`] = `
       let ctx = Object.create(ctx1);
       ctx[\`item\`] = k_block1[i1];
       const key1 = ctx['item'].id;
-      c_block1[i1] = withKey(comp1({value: toSignal(node, \`__sig_1__\${key1}\`, ctx['item'].n)}, key + \`__1__\${key1}\`, node, this, null), key1);
+      c_block1[i1] = withKey(comp1({value: toComputed(node, \`__sig_1__\${key1}\`, (__caps) => __caps[0].n, [ctx['item']])}, key + \`__1__\${key1}\`, node, this, null), key1);
     }
     return list(c_block1);
   }
@@ -161,11 +323,11 @@ exports[`.signal suffix: child re-reads updated value when parent state changes 
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
-    return comp1({count: toSignal(node, \`__sig_1\`, ctx['this'].state.val)}, key + \`__1\`, node, this, null);
+    return comp1({count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)}, key + \`__1\`, node, this, null);
   }
 }"
 `;
@@ -186,11 +348,11 @@ exports[`.signal suffix: child receives a read-only reactive value 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
-    return comp1({count: toSignal(node, \`__sig_1\`, ctx['this'].state.val)}, key + \`__1\`, node, this, null);
+    return comp1({count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)}, key + \`__1\`, node, this, null);
   }
 }"
 `;
@@ -211,11 +373,11 @@ exports[`.signal suffix: effects in child react to parent value changes 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, []);
   
   return function template(ctx, node, key = "") {
-    return comp1({count: toSignal(node, \`__sig_1\`, ctx['this'].state.val)}, key + \`__1\`, node, this, null);
+    return comp1({count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val)}, key + \`__1\`, node, this, null);
   }
 }"
 `;
@@ -236,11 +398,11 @@ exports[`.signal suffix: signal reference is stable across updates 1`] = `
 "function anonymous(app, bdom, helpers
 ) {
   let { text, createBlock, list, multi, html, toggler } = bdom;
-  let { toSignal, createComponent } = helpers;
+  let { toComputed, createComponent } = helpers;
   const comp1 = createComponent(app, \`Child\`, true, false, false, ["tick"]);
   
   return function template(ctx, node, key = "") {
-    return comp1({count: toSignal(node, \`__sig_1\`, ctx['this'].state.val),tick: ctx['this'].state.tick}, key + \`__1\`, node, this, null);
+    return comp1({count: toComputed(node, \`__sig_1\`, () => ctx['this'].state.val),tick: ctx['this'].state.tick}, key + \`__1\`, node, this, null);
   }
 }"
 `;

--- a/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
+++ b/packages/owl-runtime/tests/components/__snapshots__/props.test.ts.snap
@@ -1003,3 +1003,314 @@ exports[`schema defaults and signal-driven props 2`] = `
   }
 }"
 `;
+
+exports[`signal props declared in the schema > a plain value is promoted: the child reads a reactive value 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {count: ctx['this'].state.val};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a plain value is promoted: the child reads a reactive value 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a promoted prop keeps the same reactive value across updates 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({count: ctx['this'].state.val}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a promoted prop keeps the same reactive value across updates 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a received read-only computed is exposed as is 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({count: ctx['this'].view}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a received read-only computed is exposed as is 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a received signal reads through and its content updates the child 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({count: ctx['this'].count}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > a received signal reads through and its content updates the child 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > an absent optional signal prop reads undefined 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > an absent optional signal prop reads undefined 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > read-only by default: set is hidden on a received writable signal 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({count: ctx['this'].count}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > read-only by default: set is hidden on a received writable signal 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > settable exposes the original signal and the child writes it 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    return comp1({count: ctx['this'].count}, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > settable exposes the original signal and the child writes it 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > swapping the signal for another one throws in dev 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {count: ctx['this'].state.count};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > swapping the signal for another one throws in dev 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > switching a promoted prop to a signal throws in dev 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["count"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {count: ctx['this'].state.count};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`signal props declared in the schema > switching a promoted prop to a signal throws in dev 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { safeOutput } = helpers;
+  
+  return function template(ctx, node, key = "") {
+    return safeOutput(ctx['this'].props.count());
+  }
+}"
+`;
+
+exports[`static props declared in the schema > changing the value throws in dev 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["label"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {label: ctx['this'].state.label};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`static props declared in the schema > changing the value throws in dev 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`static props declared in the schema > composes with optional and a default 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, []);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`static props declared in the schema > composes with optional and a default 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;
+
+exports[`static props declared in the schema > the value is pinned and exposed unwrapped 1`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  let { createComponent } = helpers;
+  const comp1 = createComponent(app, \`Child\`, true, false, false, ["onClick"]);
+  
+  return function template(ctx, node, key = "") {
+    const props1 = {onClick: ctx['this'].onClick};
+    return comp1(props1, key + \`__1\`, node, this, null);
+  }
+}"
+`;
+
+exports[`static props declared in the schema > the value is pinned and exposed unwrapped 2`] = `
+"function anonymous(app, bdom, helpers
+) {
+  let { text, createBlock, list, multi, html, toggler } = bdom;
+  
+  let block1 = createBlock(\`<div/>\`);
+  
+  return function template(ctx, node, key = "") {
+    return block1();
+  }
+}"
+`;

--- a/packages/owl-runtime/tests/components/props.test.ts
+++ b/packages/owl-runtime/tests/components/props.test.ts
@@ -834,16 +834,12 @@ test(".signal suffix accepts a signal-typed prop without validation error", asyn
 });
 
 test(".signal suffix: child receives a read-only reactive value", async () => {
-  let childError: any;
+  let childSet: any = null;
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
     props = props({ count: t.signal(t.number()) });
     setup() {
-      try {
-        (this.props.count as any).set(99);
-      } catch (e) {
-        childError = e;
-      }
+      childSet = (this.props.count as any).set;
     }
   }
 
@@ -854,8 +850,7 @@ test(".signal suffix: child receives a read-only reactive value", async () => {
   }
 
   await mount(Parent, fixture);
-  expect(childError).toBeDefined();
-  expect(childError.message).toMatch(/read-only/);
+  expect(childSet).toBeUndefined();
   expect(fixture.innerHTML).toBe("3");
 });
 

--- a/packages/owl-runtime/tests/components/props.test.ts
+++ b/packages/owl-runtime/tests/components/props.test.ts
@@ -3,6 +3,7 @@ import {
   computed,
   effect,
   mount,
+  onPatched,
   onWillUpdateProps,
   props,
   proxy,
@@ -1249,5 +1250,129 @@ describe("static props declared in the schema", () => {
     render(parent);
     const error = await nextAppError(parent.__owl__.app);
     expect(error.message).toMatch("Prop 'label' in component 'Child' changed");
+  });
+});
+
+describe(".signal suffix lazy evaluation", () => {
+  test("the parent does not re-render when the read value changes", async () => {
+    let parentPatches = 0;
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`<div><Child count.signal="this.state.val"/></div>`;
+      static components = { Child };
+      state = proxy({ val: 1 });
+      setup() {
+        onPatched(() => parentPatches++);
+      }
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<div>1</div>");
+
+    parent.state.val = 2;
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<div>2</div>");
+    expect(parentPatches).toBe(0);
+  });
+
+  test("a replaced t-foreach item reaches the child through the captures", async () => {
+    class Item extends Component {
+      static template = xml`<span><t t-out="this.props.value()"/></span>`;
+      props = useProps({ value: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`
+        <t t-foreach="this.state.items" t-as="item" t-key="item.id">
+          <Item value.signal="item.n"/>
+        </t>`;
+      static components = { Item };
+      state = proxy({ items: [{ id: "a", n: 1 }] });
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<span>1</span>");
+
+    parent.state.items = [{ id: "a", n: 5 }];
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<span>5</span>");
+  });
+
+  test("the wrapper follows the t-key across a reorder", async () => {
+    const wrappers: Record<string, any[]> = { a: [], b: [] };
+    class Item extends Component {
+      static template = xml`<span><t t-out="this.props.value()"/></span>`;
+      props = useProps({ value: t.signal(t.number()), id: t.string() });
+      setup() {
+        wrappers[this.props.id].push(this.props.value);
+        onWillUpdateProps(() => wrappers[this.props.id].push(this.props.value));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`
+        <t t-foreach="this.state.items" t-as="item" t-key="item.id">
+          <Item value.signal="item.n" id="item.id"/>
+        </t>`;
+      static components = { Item };
+      state = proxy({
+        items: [
+          { id: "a", n: 1 },
+          { id: "b", n: 2 },
+        ],
+      });
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<span>1</span><span>2</span>");
+
+    parent.state.items = [
+      { id: "b", n: 2 },
+      { id: "a", n: 1 },
+    ];
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<span>2</span><span>1</span>");
+    expect(new Set(wrappers.a).size).toBe(1);
+    expect(new Set(wrappers.b).size).toBe(1);
+  });
+
+  test("a template string interpolation reaches the captures", async () => {
+    class Child extends Component {
+      static template = xml`<span><t t-out="this.props.label()"/></span>`;
+      props = useProps({ label: t.signal(t.string()) });
+    }
+    class Parent extends Component {
+      static template = xml({
+        raw: [
+          '<t t-foreach="this.state.items" t-as="item" t-key="item.id">' +
+            '<Child label.signal="`item ${item.n}`"/>' +
+            "</t>",
+        ],
+      });
+      static components = { Child };
+      state = proxy({ items: [{ id: "a", n: 1 }] });
+    }
+
+    const parent = await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("<span>item 1</span>");
+
+    parent.state.items = [{ id: "a", n: 5 }];
+    await nextTick();
+    expect(fixture.innerHTML).toBe("<span>item 5</span>");
+  });
+
+  test("a constant satisfies a signal-typed prop", async () => {
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`<Child count.signal="7"/>`;
+      static components = { Child };
+    }
+
+    await mount(Parent, fixture, { test: true });
+    expect(fixture.innerHTML).toBe("7");
   });
 });

--- a/packages/owl-runtime/tests/components/props.test.ts
+++ b/packages/owl-runtime/tests/components/props.test.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  computed,
   effect,
   mount,
   onWillUpdateProps,
@@ -7,11 +8,14 @@ import {
   proxy,
   signal,
   types as t,
+  useProps,
   xml,
 } from "../../src";
 import {
   makeTestFixture,
+  nextAppError,
   nextTick,
+  render,
   snapshotEverything,
   steps,
   useLogLifecycle,
@@ -992,5 +996,258 @@ describe("reactive props (issue #1908)", () => {
     await nextTick();
     expect(seen).toEqual([{ next: 2, current: 1 }]);
     expect(fixture.innerHTML).toBe("<span>2</span>");
+  });
+});
+
+describe("signal props declared in the schema", () => {
+  test("a received signal reads through and its content updates the child", async () => {
+    const count = signal(1);
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.count"/>`;
+      static components = { Child };
+      count = count;
+    }
+
+    await mount(Parent, fixture);
+    expect(fixture.innerHTML).toBe("1");
+
+    count.set(2);
+    await nextTick();
+    expect(fixture.innerHTML).toBe("2");
+  });
+
+  test("read-only by default: set is hidden on a received writable signal", async () => {
+    const count = signal(1);
+    let exposed: any;
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+      setup() {
+        exposed = this.props.count;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.count"/>`;
+      static components = { Child };
+      count = count;
+    }
+
+    await mount(Parent, fixture);
+    expect(typeof exposed).toBe("function");
+    expect(exposed.set).toBeUndefined();
+    expect(exposed()).toBe(1);
+  });
+
+  test("a received read-only computed is exposed as is", async () => {
+    const count = signal(1);
+    const view = computed(count);
+    let exposed: any;
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+      setup() {
+        exposed = this.props.count;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.view"/>`;
+      static components = { Child };
+      view = view;
+    }
+
+    await mount(Parent, fixture);
+    expect(exposed).toBe(view);
+  });
+
+  test("settable exposes the original signal and the child writes it", async () => {
+    const count = signal(1);
+    let exposed: any;
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number(), { settable: true }) });
+      setup() {
+        exposed = this.props.count;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.count"/>`;
+      static components = { Child };
+      count = count;
+    }
+
+    await mount(Parent, fixture);
+    expect(exposed).toBe(count);
+
+    exposed.set(5);
+    await nextTick();
+    expect(count()).toBe(5);
+    expect(fixture.innerHTML).toBe("5");
+  });
+
+  test("a plain value is promoted: the child reads a reactive value", async () => {
+    const observed: number[] = [];
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+      setup() {
+        effect(() => observed.push(this.props.count()));
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.state.val"/>`;
+      static components = { Child };
+      state = proxy({ val: 1 });
+    }
+
+    const parent = await mount(Parent, fixture, { test: true });
+    expect(fixture.innerHTML).toBe("1");
+    expect(observed).toEqual([1]);
+
+    parent.state.val = 2;
+    await nextTick();
+    expect(fixture.innerHTML).toBe("2");
+    expect(observed).toEqual([1, 2]);
+  });
+
+  test("a promoted prop keeps the same reactive value across updates", async () => {
+    let sameRef: boolean | null = null;
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+      setup() {
+        const initial = this.props.count;
+        onWillUpdateProps(() => {
+          sameRef = this.props.count === initial;
+        });
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.state.val"/>`;
+      static components = { Child };
+      state = proxy({ val: 1 });
+    }
+
+    const parent = await mount(Parent, fixture);
+    parent.state.val = 2;
+    await nextTick();
+    expect(sameRef).toBe(true);
+    expect(fixture.innerHTML).toBe("2");
+  });
+
+  test("an absent optional signal prop reads undefined", async () => {
+    let read: any = "unset";
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = useProps({ count: t.signal(t.number()).optional() });
+      setup() {
+        read = this.props.count?.();
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child/>`;
+      static components = { Child };
+    }
+
+    await mount(Parent, fixture, { test: true });
+    expect(read).toBeUndefined();
+  });
+
+  test("swapping the signal for another one throws in dev", async () => {
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.state.count"/>`;
+      static components = { Child };
+      state = proxy({ count: signal(1) });
+    }
+
+    const parent = await mount(Parent, fixture, { dev: true });
+    expect(getConsoleOutput()).toEqual([`info:Owl is running in 'dev' mode.`]);
+    parent.state.count = signal(2);
+    render(parent);
+    const error = await nextAppError(parent.__owl__.app);
+    expect(error.message).toMatch("Prop 'count' in component 'Child' changed");
+  });
+
+  test("switching a promoted prop to a signal throws in dev", async () => {
+    class Child extends Component {
+      static template = xml`<t t-out="this.props.count()"/>`;
+      props = useProps({ count: t.signal(t.number()) });
+    }
+    class Parent extends Component {
+      static template = xml`<Child count="this.state.count"/>`;
+      static components = { Child };
+      state = proxy({ count: 1 as any });
+    }
+
+    const parent = await mount(Parent, fixture, { dev: true });
+    parent.state.count = signal(2);
+    render(parent);
+    const error = await nextAppError(parent.__owl__.app);
+    expect(error.message).toMatch("changed from a plain value to a signal");
+  });
+});
+
+describe("static props declared in the schema", () => {
+  test("the value is pinned and exposed unwrapped", async () => {
+    const onClick = () => {};
+    let exposed: any;
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = useProps({ onClick: t.function([]).static() });
+      setup() {
+        exposed = this.props.onClick;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child onClick="this.onClick"/>`;
+      static components = { Child };
+      onClick = onClick;
+    }
+
+    await mount(Parent, fixture, { test: true });
+    expect(exposed).toBe(onClick);
+  });
+
+  test("composes with optional and a default", async () => {
+    let exposed: any = "unset";
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = useProps({ label: t.string().optional("hello").static() });
+      setup() {
+        exposed = this.props.label;
+      }
+    }
+    class Parent extends Component {
+      static template = xml`<Child/>`;
+      static components = { Child };
+    }
+
+    await mount(Parent, fixture, { test: true });
+    expect(exposed).toBe("hello");
+  });
+
+  test("changing the value throws in dev", async () => {
+    class Child extends Component {
+      static template = xml`<div/>`;
+      props = useProps({ label: t.string().static() });
+    }
+    class Parent extends Component {
+      static template = xml`<Child label="this.state.label"/>`;
+      static components = { Child };
+      state = proxy({ label: "a" });
+    }
+
+    const parent = await mount(Parent, fixture, { dev: true });
+    parent.state.label = "b";
+    render(parent);
+    const error = await nextAppError(parent.__owl__.app);
+    expect(error.message).toMatch("Prop 'label' in component 'Child' changed");
   });
 });


### PR DESCRIPTION
Before this commit, a signal prop cannot be declared in the schema: `useProps()` wraps a `t.signal` key like any other, so the child reads a signal of a signal, and declaring one takes `useProps.static(name, type)`, one call per prop, outside the schema. The schema also has no way to say that a component only reads the signal it receives, or that it writes on it, so handing a read-only value to a component that writes is only caught when the write crashes.

`.signal=` has its own limit: the expression is evaluated during the parent's render, so every change of what it reads re-renders the parent just to refresh the wrapper. The suffix adapts a plain value to a signal prop, it does not save a render.

These commits give the schema keys their own behavior and move the evaluation into the child:

- A `t.signal(...)` key is read once and exposed as is, read-only unless the prop is declared `settable`.
- A plain value on such a key is promoted through a signal owned by the child, so a child can declare `t.signal` without touching any caller.
- `.static()` brands any type, like `.optional()`, for a prop read once.
- A `.signal=` expression is compiled into an arrow evaluated inside the cached computed, so the parent's render never subscribes to what the expression reads and a change updates the child alone.

Read-only itself becomes the absence of `set`: a computed declared without a `set` option no longer carries one that throws.

Closes odoo/owl#1907
Closes odoo/owl#1909