### PR TITLE
[IMP] owl: remove deprecated hook names and directive

### DIFF
--- a/packages/owl-compiler/src/parser.ts
+++ b/packages/owl-compiler/src/parser.ts
@@ -829,15 +829,11 @@ function parseComponent(node: Element, ctx: ParsingContext): AST | null {
 // -----------------------------------------------------------------------------
 
 function parseTCallSlot(node: Element, ctx: ParsingContext): AST | null {
-  if (!node.hasAttribute("t-call-slot") && !node.hasAttribute("t-slot")) {
+  if (!node.hasAttribute("t-call-slot")) {
     return null;
   }
-  if (node.hasAttribute("t-slot")) {
-    console.warn(`t-slot has been renamed t-call-slot.`);
-  }
-  const name = (node.getAttribute("t-call-slot") || node.getAttribute("t-slot"))!;
+  const name = node.getAttribute("t-call-slot")!;
   node.removeAttribute("t-call-slot");
-  node.removeAttribute("t-slot");
   let attrs: Attrs | null = null;
   let attrsTranslationCtx: Attrs | null = null;
   let on: ASTComponent["on"] = null;

--- a/packages/owl-core/src/index.ts
+++ b/packages/owl-core/src/index.ts
@@ -122,9 +122,7 @@ export {
 
 export {
   useConfig,
-  config,
   usePlugin,
-  plugin,
   type PluginInstance,
 } from "./plugin_hooks";
 

--- a/packages/owl-core/src/plugin_hooks.ts
+++ b/packages/owl-core/src/plugin_hooks.ts
@@ -24,9 +24,6 @@ export function usePlugin<T extends PluginConstructor>(pluginType: T): PluginIns
   return (scoped ? scoped(plugin, scope) : plugin) as PluginInstance<T>;
 }
 
-/** @deprecated alias for {@link usePlugin} */
-export const plugin = usePlugin;
-
 export function useConfig<T = any>(key: string): T;
 export function useConfig<T>(key: string, type: WithDefault<T>): T;
 export function useConfig<T>(key: string, type: Optional<T>): T | undefined;
@@ -42,6 +39,3 @@ export function useConfig(key: string, type?: any): any {
   const configValue = scope.config[key];
   return configValue === undefined ? getDefault(type)?.() : configValue;
 }
-
-/** @deprecated alias for {@link useConfig} */
-export const config = useConfig;

--- a/packages/owl-runtime/src/error_boundary.ts
+++ b/packages/owl-runtime/src/error_boundary.ts
@@ -1,7 +1,7 @@
 import { signal } from "@odoo/owl-core";
 import { Component } from "./component";
 import { onError } from "./lifecycle_hooks";
-import { props } from "./props";
+import { useProps } from "./props";
 import { xml } from "./template_set";
 import { types as t } from "./types";
 
@@ -15,7 +15,7 @@ export class ErrorBoundary extends Component {
     </t>
   `;
 
-  props = props({ error: t.signal().optional(() => signal<any>(null)) });
+  props = useProps({ error: t.signal().optional(() => signal<any>(null)) });
 
   setup() {
     onError((e) => this.props.error.set(e));

--- a/packages/owl-runtime/src/index.ts
+++ b/packages/owl-runtime/src/index.ts
@@ -40,7 +40,7 @@ export type { ComponentConstructor } from "./component";
 export { ErrorBoundary } from "./error_boundary";
 export { Portal } from "./portal";
 export { Suspense } from "./suspense";
-export { useProps, props } from "./props";
+export { useProps } from "./props";
 // `isProps` is a phantom (declare const) brand symbol referenced by the public
 // `Props`/`PropsWithDefaults`/`GetProps` types. It must be exported from the
 // package's type surface so downstream projects can name it when emitting their
@@ -92,7 +92,7 @@ export type {
   WithDefault,
 } from "@odoo/owl-core";
 export { OwlError } from "@odoo/owl-core";
-export { useConfig, config, usePlugin, plugin, providePlugins } from "./plugin_hooks";
+export { useConfig, usePlugin, providePlugins } from "./plugin_hooks";
 export type { PluginInstance } from "./plugin_hooks";
 export { Plugin } from "@odoo/owl-core";
 export type { PluginConstructor } from "@odoo/owl-core";

--- a/packages/owl-runtime/src/plugin_hooks.ts
+++ b/packages/owl-runtime/src/plugin_hooks.ts
@@ -1,7 +1,7 @@
 import { onWillDestroy, onWillStart, PluginConstructor, PluginManager, Resource, startPlugins, STATUS } from "@odoo/owl-core";
 import { getComponentScope } from "./component_node";
 
-export { useConfig, config, usePlugin, plugin, type PluginInstance } from "@odoo/owl-core";
+export { useConfig, usePlugin, type PluginInstance } from "@odoo/owl-core";
 
 export function providePlugins(
   pluginConstructors: PluginConstructor[] | Resource<PluginConstructor>,

--- a/packages/owl-runtime/src/portal.ts
+++ b/packages/owl-runtime/src/portal.ts
@@ -2,7 +2,7 @@ import { Signal } from "@odoo/owl-core";
 import { Component } from "./component";
 import { useEffect } from "./hooks";
 import { onWillDestroy } from "./lifecycle_hooks";
-import { props } from "./props";
+import { useProps } from "./props";
 import { forwardErrorToParent } from "./rendering/error_handling";
 import { xml } from "./template_set";
 import { types as t } from "./types";
@@ -18,7 +18,7 @@ export type PortalTarget = string | HTMLElement | Signal<HTMLElement | null> | n
 export class Portal extends Component {
   static template = xml``;
 
-  props = props({
+  props = useProps({
     slots: t.object(["default"]),
     target: t.or([t.string(), t.signal(t.instanceOf(HTMLElement)), t.instanceOf(HTMLElement)]),
   });

--- a/packages/owl-runtime/src/props.ts
+++ b/packages/owl-runtime/src/props.ts
@@ -156,6 +156,3 @@ function makeProps(type?: any): Props<{}> {
 }
 
 export const useProps = Object.assign(makeProps, { static: staticProp }) as PropsFunction;
-
-/** @deprecated alias for {@link useProps} */
-export const props = useProps;

--- a/packages/owl-runtime/src/suspense.ts
+++ b/packages/owl-runtime/src/suspense.ts
@@ -2,7 +2,7 @@ import { signal } from "@odoo/owl-core";
 import { Component } from "./component";
 import { useEffect } from "./hooks";
 import { onMounted, onWillDestroy } from "./lifecycle_hooks";
-import { props } from "./props";
+import { useProps } from "./props";
 import { forwardErrorToParent } from "./rendering/error_handling";
 import { xml } from "./template_set";
 import { types as t } from "./types";
@@ -33,7 +33,7 @@ export class Suspense extends Component {
     </t>
   `;
 
-  props = props({ slots: t.object({ default: t.any(), fallback: t.any().optional() }) });
+  props = useProps({ slots: t.object({ default: t.any(), fallback: t.any().optional() }) });
 
   private prepared = signal(false);
   private mounted = signal(false);

--- a/packages/owl-runtime/tests/app/app.test.ts
+++ b/packages/owl-runtime/tests/app/app.test.ts
@@ -1,17 +1,17 @@
 import { compile } from "@odoo/owl-compiler";
-import { App, Component, onMounted, onWillPatch, onWillStart, props, proxy, xml } from "../../src";
+import { App, Component, onMounted, onWillPatch, onWillStart, proxy, useProps, xml } from "../../src";
 import { useApp } from "../../src/hooks";
 import { STATUS, status } from "../../src/status";
 import {
-  makeTestFixture,
-  snapshotEverything,
-  nextTick,
   elem,
-  useLogLifecycle,
   makeDeferred,
+  makeTestFixture,
   nextMicroTick,
-  steps,
+  nextTick,
   render,
+  snapshotEverything,
+  steps,
+  useLogLifecycle,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -40,7 +40,7 @@ describe("app", () => {
   test("can configure an app with props", async () => {
     class SomeComponent extends Component {
       static template = xml`<div t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     const app = new App();

--- a/packages/owl-runtime/tests/compiler/t_call_slot.test.ts
+++ b/packages/owl-runtime/tests/compiler/t_call_slot.test.ts
@@ -1,6 +1,4 @@
-import { parseXML } from "@odoo/owl-compiler";
-import { compile } from "@odoo/owl-compiler";
-import { getConsoleOutput } from "../helpers";
+import { compile, parseXML } from "@odoo/owl-compiler";
 
 describe("t-call-slot", () => {
   test("compile t-props correctly multiple time", () => {
@@ -12,12 +10,5 @@ describe("t-call-slot", () => {
 
     const fn2 = compile(parsedTemplate);
     expect(fn2.toString()).toBe(fn1.toString());
-  });
-
-  test("warn on t-slot", () => {
-    const template = `<t t-slot="default"/>`;
-    const parsedTemplate = parseXML(template).firstChild as Element;
-    compile(parsedTemplate);
-    expect(getConsoleOutput()).toEqual(["warn:t-slot has been renamed t-call-slot."]);
   });
 });

--- a/packages/owl-runtime/tests/compiler/translation.test.ts
+++ b/packages/owl-runtime/tests/compiler/translation.test.ts
@@ -1,4 +1,4 @@
-import { Component, mount, props, xml } from "../../src";
+import { Component, mount, useProps, xml } from "../../src";
 import { makeTestFixture, snapshotEverything } from "../helpers";
 
 let fixture: HTMLElement;
@@ -255,7 +255,7 @@ describe("translation context", () => {
   test("props with modifier .translate are translated in context", async () => {
     class ChildComponent extends Component {
       static template = xml`<span t-out="this.props.text"/>`;
-      props = props(["text"]);
+      props = useProps(["text"]);
     }
 
     class SomeComponent extends Component {
@@ -278,7 +278,7 @@ describe("translation context", () => {
         <div t-translation-context="ja">
           <t t-call-slot="a"/>
         </div>`;
-      props = props();
+      props = useProps();
     }
 
     class SomeComponent extends Component {
@@ -313,7 +313,7 @@ describe("translation context", () => {
             foo
           </t>
         </div>`;
-      props = props();
+      props = useProps();
     }
 
     const translateFn = vi.fn((expr: string, translationCtx: string) =>

--- a/packages/owl-runtime/tests/components/basics.test.ts
+++ b/packages/owl-runtime/tests/components/basics.test.ts
@@ -1,14 +1,14 @@
-import { App, Component, mount, props, proxy, status, types as t, toRaw, xml } from "../../src";
+import { App, Component, mount, proxy, status, types as t, toRaw, useProps, xml } from "../../src";
 import { markup } from "../../src/utils";
 import {
   elem,
+  getConsoleOutput,
   makeTestFixture,
   nextTick,
   render,
   snapshotEverything,
   steps,
   useLogLifecycle,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -48,7 +48,7 @@ describe("basics", () => {
   test("can mount a simple component with props", async () => {
     class Test extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     const component = await mount(Test, fixture, { props: { value: 3 } });
@@ -129,7 +129,7 @@ describe("basics", () => {
     const p = {};
     class Test extends Component {
       static template = xml`<span>simple vnode</span>`;
-      props = props();
+      props = useProps();
       setup() {
         expect(toRaw(this.props)).not.toBe(p);
       }
@@ -144,7 +144,7 @@ describe("basics", () => {
     const p = { a: 1 };
     class Test extends Component {
       static template = xml`<span>simple vnode</span>`;
-      props = props();
+      props = useProps();
       setup() {
         expect(Object.prototype.hasOwnProperty.call(this.props, "a")).toBe(true);
       }
@@ -158,7 +158,7 @@ describe("basics", () => {
     const p = { a: 1 };
     class Test extends Component {
       static template = xml`<span>simple vnode</span>`;
-      props = props({
+      props = useProps({
         a: t.any(),
         b: t.number().optional(1),
       });
@@ -341,7 +341,7 @@ describe("basics", () => {
   test("class parent, class child component with props", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.value" /></div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -459,7 +459,7 @@ describe("basics", () => {
   test("can handle empty props", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.val"/></span>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<div><Child val=""/></div>`;
@@ -473,7 +473,7 @@ describe("basics", () => {
   test("child can be updated", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -502,7 +502,7 @@ describe("basics", () => {
     class Child extends Component {
       static template = xml`<ChildA t-if="this.props.child==='a'"/><ChildB t-else=""/>`;
       static components = { ChildA, ChildB };
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -588,7 +588,7 @@ describe("basics", () => {
   test("same t-keys in two different places", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.blip"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -786,7 +786,7 @@ describe("basics", () => {
     // twice.
     class Child extends Component {
       static template = xml`<span>abc<t t-if="this.props.flag">def</t></span>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<Child flag="this.state.flag"/>`;
@@ -819,7 +819,7 @@ describe("basics", () => {
         <div class="widget-subkey">
           <t t-out="this.props.key"/>__<t t-out="this.props.subKey"/>
         </div>`;
-      props = props();
+      props = useProps();
     }
     class Child extends Component {
       static components = { Custom };
@@ -828,7 +828,7 @@ describe("basics", () => {
           t-key="this.props.subKey"
           key="this.props.key"
           subKey="this.props.subKey"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -948,7 +948,7 @@ describe("basics", () => {
     class Child extends Component {
       static components = { GrandChild };
       static template = xml`<GrandChild t-if="this.props.displayGrandChild" />`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {

--- a/packages/owl-runtime/tests/components/concurrency.test.ts
+++ b/packages/owl-runtime/tests/components/concurrency.test.ts
@@ -8,8 +8,8 @@ import {
   onWillStart,
   onWillUnmount,
   onWillUpdateProps,
-  props,
   proxy,
+  useProps,
   xml,
 } from "../../src";
 import { Fiber } from "../../src/rendering/fibers";
@@ -86,7 +86,7 @@ test("destroying/recreating a subwidget with different props (if start is not ov
   let n = 0;
   class Child extends Component {
     static template = xml`<span>child:<t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       n++;
@@ -307,7 +307,7 @@ test("creating two async components, scenario 2", async () => {
 
   class ChildA extends Component {
     static template = xml`<span>a<t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => defA);
@@ -316,7 +316,7 @@ test("creating two async components, scenario 2", async () => {
 
   class ChildB extends Component {
     static template = xml`<span>b<t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillStart(() => defB);
@@ -393,7 +393,7 @@ test("creating two async components, scenario 3 (patching in the same frame)", a
 
   class ChildA extends Component {
     static template = xml`<span>a<t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => defA);
@@ -401,7 +401,7 @@ test("creating two async components, scenario 3 (patching in the same frame)", a
   }
   class ChildB extends Component {
     static template = xml`<span>b<t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillStart(() => defB);
@@ -476,7 +476,7 @@ test("update a sub-component twice in the same frame", async () => {
   let index = 0;
   class ChildA extends Component {
     static template = xml`<span><t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       onWillUpdateProps(() => defs[index++]);
       useLogLifecycle(this);
@@ -540,7 +540,7 @@ test("update a sub-component twice in the same frame", async () => {
 test("update a sub-component twice in the same frame, 2", async () => {
   class ChildA extends Component {
     static template = xml`<span><t t-out="this.val()"/></span>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -632,7 +632,7 @@ test("properly behave when destroyed/unmounted while rendering ", async () => {
   class Child extends Component {
     static template = xml`<div><SubChild val="this.props.val"/></div>`;
     static components = { SubChild };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -761,7 +761,7 @@ test("concurrent renderings scenario 1", async () => {
 
   class ComponentC extends Component {
     static template = xml`<span><t t-out="this.props.fromA"/><t t-out="this.someValue()"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => def);
@@ -775,7 +775,7 @@ test("concurrent renderings scenario 1", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC fromA="this.props.fromA" fromB="this.state.fromB" /></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
     state = proxy({ fromB: "b" });
 
     setup() {
@@ -853,7 +853,7 @@ test("concurrent renderings scenario 2", async () => {
   let stateB: any = null;
   class ComponentC extends Component {
     static template = xml`<span><t t-out="this.props.fromA"/><t t-out="this.props.fromB"/></span>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -864,7 +864,7 @@ test("concurrent renderings scenario 2", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC fromA="this.props.fromA" fromB="this.state.fromB" /></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
     state = proxy({ fromB: "b" });
 
     setup() {
@@ -943,7 +943,7 @@ test("concurrent renderings scenario 2bis", async () => {
   let stateB: any = null;
   class ComponentC extends Component {
     static template = xml`<span><t t-out="this.props.fromA"/><t t-out="this.props.fromB"/></span>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -954,7 +954,7 @@ test("concurrent renderings scenario 2bis", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC fromA="this.props.fromA" fromB="this.state.fromB" /></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
     state = proxy({ fromB: "b" });
 
     setup() {
@@ -1036,7 +1036,7 @@ test("concurrent renderings scenario 3", async () => {
 
   class ComponentD extends Component {
     static template = xml`<i><t t-out="this.props.fromA"/><t t-out="this.someValue()"/></i>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1051,7 +1051,7 @@ test("concurrent renderings scenario 3", async () => {
   class ComponentC extends Component {
     static template = xml`<span><ComponentD fromA="this.props.fromA" fromC="this.state.fromC" /></span>`;
     static components = { ComponentD };
-    props = props();
+    props = useProps();
     state = proxy({ fromC: "c" });
     setup() {
       useLogLifecycle(this);
@@ -1062,7 +1062,7 @@ test("concurrent renderings scenario 3", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC fromA="this.props.fromA" /></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1073,7 +1073,7 @@ test("concurrent renderings scenario 3", async () => {
   class ComponentA extends Component {
     static components = { ComponentB };
     static template = xml`<div><ComponentB fromA="this.state.fromA"/></div>`;
-    props = props();
+    props = useProps();
     state = proxy({ fromA: 1 });
 
     setup() {
@@ -1150,7 +1150,7 @@ test("concurrent renderings scenario 4", async () => {
 
   class ComponentD extends Component {
     static template = xml`<i><t t-out="this.props.fromA"/><t t-out="this.someValue()"/></i>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1165,7 +1165,7 @@ test("concurrent renderings scenario 4", async () => {
   class ComponentC extends Component {
     static template = xml`<span><ComponentD fromA="this.props.fromA" fromC="this.state.fromC" /></span>`;
     static components = { ComponentD };
-    props = props();
+    props = useProps();
     state = proxy({ fromC: "c" });
     setup() {
       useLogLifecycle(this);
@@ -1176,7 +1176,7 @@ test("concurrent renderings scenario 4", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC fromA="this.props.fromA" /></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1267,7 +1267,7 @@ test("concurrent renderings scenario 5", async () => {
 
   class ComponentB extends Component {
     static template = xml`<p><t t-out="this.someValue()" /></p>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1345,7 +1345,7 @@ test("concurrent renderings scenario 6", async () => {
 
   class ComponentB extends Component {
     static template = xml`<p><t t-out="this.someValue()" /></p>`;
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -1421,7 +1421,7 @@ test("concurrent renderings scenario 6", async () => {
 test("concurrent renderings scenario 7", async () => {
   class ComponentB extends Component {
     static template = xml`<p><t t-out="this.props.fromA" /><t t-out="this.someValue()" /></p>`;
-    props = props();
+    props = useProps();
     state = proxy({ fromB: "b" });
 
     setup() {
@@ -1479,7 +1479,7 @@ test("concurrent renderings scenario 8", async () => {
   let stateB: any = null;
   class ComponentB extends Component {
     static template = xml`<p><t t-out="this.props.fromA" /><t t-out="this.state.fromB" /></p>`;
-    props = props();
+    props = useProps();
     state = proxy({ fromB: "b" });
     setup() {
       useLogLifecycle(this);
@@ -1555,7 +1555,7 @@ test("concurrent renderings scenario 9", async () => {
 
   class ComponentD extends Component {
     static template = xml`<span><t t-out="this.props.fromA"/><t t-out="this.props.fromC"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -1564,7 +1564,7 @@ test("concurrent renderings scenario 9", async () => {
   class ComponentC extends Component {
     static template = xml`<p><ComponentD fromA="this.props.fromA" fromC="this.state.fromC" /></p>`;
     static components = { ComponentD };
-    props = props();
+    props = useProps();
     state = proxy({ fromC: "b1" });
 
     setup() {
@@ -1574,7 +1574,7 @@ test("concurrent renderings scenario 9", async () => {
   }
   class ComponentB extends Component {
     static template = xml`<b><t t-out="this.props.fromA"/></b>`;
-    props = props();
+    props = useProps();
 
     setup() {
       onWillUpdateProps(() => def);
@@ -1673,7 +1673,7 @@ test("concurrent renderings scenario 10", async () => {
   let rendered = 0;
   class ComponentC extends Component {
     static template = xml`<span><t t-out="this.value"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillStart(() => defC);
@@ -1687,7 +1687,7 @@ test("concurrent renderings scenario 10", async () => {
   class ComponentB extends Component {
     static template = xml`<p><ComponentC t-if="this.state.hasChild" value="this.props.value"/></p>`;
     static components = { ComponentC };
-    props = props();
+    props = useProps();
     state = proxy({ hasChild: false });
     setup() {
       useLogLifecycle(this);
@@ -1767,7 +1767,7 @@ test("concurrent renderings scenario 11", async () => {
   let child: any = null;
   class Child extends Component {
     static template = xml`<span><t t-out="this.props.val"/>|<t t-out="this.val"/></span>`;
-    props = props();
+    props = useProps();
     val = 3;
 
     setup() {
@@ -1832,7 +1832,7 @@ test("concurrent renderings scenario 12", async () => {
 
   class Child extends Component {
     static template = xml`<span><t t-out="this.props.val"/></span>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => def);
@@ -1992,7 +1992,7 @@ test("concurrent renderings scenario 14", async () => {
         <span t-out="this.state.fromC"/>
        </p>`;
 
-    props = props();
+    props = useProps();
     state = proxy({ fromC: 3 });
     setup() {
       useLogLifecycle(this);
@@ -2006,7 +2006,7 @@ test("concurrent renderings scenario 14", async () => {
       useLogLifecycle(this);
       b = this;
     }
-    props = props();
+    props = useProps();
     state = proxy({ fromB: 2 });
   }
 
@@ -2086,7 +2086,7 @@ test("concurrent renderings scenario 15", async () => {
         <span t-out="this.state.fromC"/>
        </p>`;
 
-    props = props();
+    props = useProps();
     state = proxy({ fromC: 3 });
     setup() {
       useLogLifecycle(this);
@@ -2100,7 +2100,7 @@ test("concurrent renderings scenario 15", async () => {
       useLogLifecycle(this);
       b = this;
     }
-    props = props();
+    props = useProps();
     state = proxy({ fromB: 2 });
   }
   class A extends Component {
@@ -2197,7 +2197,7 @@ test("concurrent renderings scenario 16", async () => {
         <t t-out="this.props.fromA"/>:<t t-out="this.props.fromB"/>:<t t-out="this.state.fromC"/>:
         <D t-if="this.state.fromC === 13"/>`;
     static components = { D };
-    props = props();
+    props = useProps();
     state = { fromC: 3 }; // not proxy
     setup() {
       useLogLifecycle(this);
@@ -2211,7 +2211,7 @@ test("concurrent renderings scenario 16", async () => {
       useLogLifecycle(this);
       b = this;
     }
-    props = props();
+    props = useProps();
     state = { fromB: 2 };
   }
   class A extends Component {
@@ -2303,14 +2303,14 @@ test("calling render in destroy", async () => {
       <div>
         <t t-out="this.props.fromA"/>
       </div>`;
-    props = props();
+    props = useProps();
   }
 
   let flag = false;
   class B extends Component {
     static template = xml`<C fromA="this.props.fromA"/>`;
     static components = { C };
-    props = props();
+    props = useProps();
 
     setup() {
       useLogLifecycle(this);
@@ -2497,7 +2497,7 @@ test("two renderings initiated between willPatch and patched", async () => {
 
   class Panel extends Component {
     static template = xml`<abc><t t-out="this.props.val"/><t t-out="this.mounted" /></abc>`;
-    props = props();
+    props = useProps();
     mounted: any;
     setup() {
       useLogLifecycle(this);
@@ -2602,7 +2602,7 @@ test("parent and child rendered at exact same time", async () => {
 
   class Child extends Component {
     static template = xml`<t t-out="this.props.value"/>`;
-    props = props();
+    props = useProps();
     setup() {
       child = this;
       useLogLifecycle(this);
@@ -2653,7 +2653,7 @@ test("delay willUpdateProps", async () => {
 
   class Child extends Component {
     static template = xml`<t t-out="this.props.value"/>_<t t-out="this.state.int" />`;
-    props = props();
+    props = useProps();
     state: any;
     setup() {
       useLogLifecycle(this);
@@ -2745,7 +2745,7 @@ test("delay willUpdateProps with rendering grandchild", async () => {
   // Delayed willUpdateProps
   class DelayedChild extends Component {
     static template = xml`<t t-out="this.props.value"/>_<t t-out="this.state.int" />`;
-    props = props();
+    props = useProps();
     state: any;
     setup() {
       useLogLifecycle(this);
@@ -2771,7 +2771,7 @@ test("delay willUpdateProps with rendering grandchild", async () => {
   class Parent extends Component {
     static template = xml`<DelayedChild value="this.props.state.value"/><ReactiveChild />`;
     static components = { DelayedChild, ReactiveChild };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -2867,7 +2867,7 @@ test("delay willUpdateProps with rendering grandchild", async () => {
 test("two sequential renderings before an animation frame", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.value"/>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -2937,7 +2937,7 @@ test("t-key on dom node having a component", async () => {
   let def: any;
   class Child extends Component {
     static template = xml`<t t-out="this.props.key" />`;
-    props = props();
+    props = useProps();
     setup() {
       onWillStart(() => def);
       useLogLifecycle(this, this.props.key);
@@ -2996,7 +2996,7 @@ test("t-key on dynamic async component (toggler is never patched)", async () => 
   let def: any;
   class Child extends Component {
     static template = xml`<div t-out="this.props.key" />`;
-    props = props();
+    props = useProps();
     setup() {
       onWillStart(() => def);
       useLogLifecycle(this, this.props.key);
@@ -3055,7 +3055,7 @@ test("t-foreach with dynamic async component", async () => {
   let def: any;
   class Child extends Component {
     static template = xml`<div t-out="this.props.key" />`;
-    props = props();
+    props = useProps();
     setup() {
       onWillStart(() => def);
       useLogLifecycle(this, this.props.key);
@@ -3118,7 +3118,7 @@ test("Cascading renders after microtaskTick", async () => {
 
   class Element extends Component {
     static template = xml`<t t-out="this.props.id" />`;
-    props = props();
+    props = useProps();
   }
 
   class Child extends Component {
@@ -3162,7 +3162,7 @@ test("Cascading renders after microtaskTick", async () => {
 test("rendering parent twice, with different props on child and stuff", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.value"/>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -3236,7 +3236,7 @@ test("delayed rendering, but then initial rendering is cancelled by yet another 
   class C extends Component {
     static template = xml`<D/><p><t t-out="this.props.value"/></p>`;
     static components = { D };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => promC);
@@ -3246,7 +3246,7 @@ test("delayed rendering, but then initial rendering is cancelled by yet another 
   class B extends Component {
     static template = xml`<C value="this.state.someValue + this.props.value"/>`;
     static components = { C };
-    props = props();
+    props = useProps();
     state = proxy({ someValue: 3 });
     setup() {
       useLogLifecycle(this);
@@ -3341,7 +3341,7 @@ test("delayed rendering, reusing fiber and stuff", async () => {
   class B extends Component {
     static template = xml`<t t-out="this.props.value"/><C /><t t-set="noop" t-value="this.notify()"/>`;
     static components = { C };
-    props = props();
+    props = useProps();
     notify: any;
 
     setup() {
@@ -3438,7 +3438,7 @@ test("delayed rendering, then component is destroyed and  stuff", async () => {
   class B extends Component {
     static template = xml`<t t-out="this.props.value"/><t t-if="this.props.value lt 10"><C /></t>`;
     static components = { C };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => prom1);
@@ -3517,7 +3517,7 @@ test("delayed rendering, reusing fiber then component is destroyed and  stuff", 
   class B extends Component {
     static template = xml`<t t-out="this.props.value"/><C />`;
     static components = { C };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => prom1);
@@ -3597,7 +3597,7 @@ test("another scenario with delayed rendering", async () => {
   class B extends Component {
     static template = xml`<t t-out="this.props.value"/><C />`;
     static components = { C };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => prom1);
@@ -3759,7 +3759,7 @@ test("destroyed component causes other soon to be destroyed component to rerende
 
   class B extends Component {
     static template = xml`<t t-set="noop" t-value="this.notify()"/><t t-out="this.props.value"/>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillDestroy(() => {
@@ -3773,7 +3773,7 @@ test("destroyed component causes other soon to be destroyed component to rerende
   }
   class C extends Component {
     static template = xml`<t t-out="this.state.val + this.props.value"/>`;
-    props = props();
+    props = useProps();
     state = proxy({ val: 0 });
     setup() {
       c = c || this;
@@ -3858,7 +3858,7 @@ test("delayed rendering, destruction, stuff happens", async () => {
   class C extends Component {
     static template = xml`C<D/><p><t t-out="this.props.value"/></p>`;
     static components = { D };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => promC);
@@ -3868,7 +3868,7 @@ test("delayed rendering, destruction, stuff happens", async () => {
   class B extends Component {
     static template = xml`B<t t-if="this.state.hasChild"><C value="this.state.someValue + this.props.value"/></t>`;
     static components = { C };
-    props = props();
+    props = useProps();
     state = proxy({ someValue: 3, hasChild: true });
     setup() {
       useLogLifecycle(this);
@@ -3963,7 +3963,7 @@ test("renderings, destruction, patch, stuff, ... yet another variation", async (
   class B extends Component {
     static template = xml`B<t t-if="this.props.value === 33"><C/></t>`;
     static components = { C };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => promB);
@@ -4102,7 +4102,7 @@ test.skip("delayed render is not cancelled by upcoming render", async () => {
         <t t-out="this.props.state.groups.length"/>
         <t t-out="this.props.state.config.test"/>`;
 
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       b = this;

--- a/packages/owl-runtime/tests/components/error_handling.test.ts
+++ b/packages/owl-runtime/tests/components/error_handling.test.ts
@@ -1,17 +1,23 @@
-import { App, Component, mount, onWillDestroy, props, types } from "../../src";
+import { getCurrentComputation, useScope } from "@odoo/owl-core";
 import {
+  App,
+  Component,
+  mount,
   onError,
   onMounted,
   onPatched,
+  onWillDestroy,
   onWillPatch,
   onWillStart,
   onWillUnmount,
   onWillUpdateProps,
   proxy,
+  types,
+  useProps,
   xml,
 } from "../../src";
-import { getCurrentComputation, useScope } from "@odoo/owl-core";
 import {
+  getConsoleOutput,
   logStep,
   makeTestFixture,
   nextAppError,
@@ -21,7 +27,6 @@ import {
   snapshotEverything,
   steps,
   useLogLifecycle,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -36,7 +41,7 @@ describe("basics", () => {
   test("no component catching error lead to full app destruction", async () => {
     class ErrorComponent extends Component {
       static template = xml`<div>hey<t t-out="this.props.flag and this.state.this.will.crash"/></div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -128,12 +133,12 @@ describe("basics", () => {
   test("a sync re-render error deep in the tree is only wrapped once", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.flag and this.state.this.will.crash"/></div>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<Child flag="this.props.flag"/>`;
       static components = { Child };
-      props = props();
+      props = useProps();
     }
     class GrandParent extends Component {
       static template = xml`<Parent flag="this.state.flag"/>`;
@@ -161,7 +166,7 @@ describe("basics", () => {
   test("currentComputation does not leak when an uncaught render error propagates", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.flag and this.state.this.will.crash"/></div>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<Child flag="this.state.flag"/>`;
@@ -309,7 +314,7 @@ function(app, bdom, helpers) {
   test("render from above on error -- handler is not a Root or MountFiber", async () => {
     class Boom extends Component {
       static template = xml`<div t-out="a.b.c"/>`;
-      props = props({ onError: types.function() });
+      props = useProps({ onError: types.function() });
       setup() {
         onError((err) => {
           this.props.onError(err);
@@ -587,7 +592,7 @@ describe("can catch errors", () => {
   test("can catch an error in a component render function", async () => {
     class ErrorComponent extends Component {
       static template = xml`<div>hey<t t-out="this.props.flag and this.state.this.will.crash"/></div>`;
-      props = props();
+      props = useProps();
     }
     class ErrorBoundary extends Component {
       static template = xml`
@@ -595,7 +600,7 @@ describe("can catch errors", () => {
             <t t-if="this.state.error">Error handled</t>
             <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -840,7 +845,7 @@ describe("can catch errors", () => {
             <t t-if="this.state.error">Error handled</t>
             <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -871,7 +876,7 @@ describe("can catch errors", () => {
             <t t-if="this.state.error">Error handled</t>
             <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -905,7 +910,7 @@ describe("can catch errors", () => {
               <t t-if="this.state.error">Error handled</t>
               <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -939,7 +944,7 @@ describe("can catch errors", () => {
               <t t-if="this.state.error">Error handled</t>
               <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -974,7 +979,7 @@ describe("can catch errors", () => {
             <t t-if="this.state.error">Error handled</t>
             <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -1008,7 +1013,7 @@ describe("can catch errors", () => {
               <t t-if="this.state.error">Error handled</t>
               <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -1042,7 +1047,7 @@ describe("can catch errors", () => {
        <t t-if="this.state.error">Error handled</t>
        <t t-else=""><t t-call-slot="default" /></t>
       </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -1196,7 +1201,7 @@ describe("can catch errors", () => {
        <t t-if="this.state.error">Error handled</t>
        <t t-else=""><t t-call-slot="default" /></t>
       </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -1246,7 +1251,7 @@ describe("can catch errors", () => {
   test("can catch an error in the willPatch call", async () => {
     class ErrorComponent extends Component {
       static template = xml`<div><t t-out="this.props.message"/></div>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillPatch(() => {
           throw new Error("NOOOOO");
@@ -1259,7 +1264,7 @@ describe("can catch errors", () => {
             <t t-if="this.state.error">Error handled</t>
             <t t-else=""><t t-call-slot="default" /></t>
           </div>`;
-      props = props();
+      props = useProps();
       state = proxy({ error: false });
 
       setup() {
@@ -1444,7 +1449,7 @@ describe("can catch errors", () => {
 
     class ErrorHandler extends Component {
       static template = xml`<t t-call-slot="default" />`;
-      props = props();
+      props = useProps();
       setup() {
         onError(() => {
           this.props.onError();
@@ -1491,7 +1496,7 @@ describe("can catch errors", () => {
   test("catching in child makes parent render", async () => {
     class Child extends Component {
       static template = xml`<div t-out="'Child ' + this.props.id" />`;
-      props = props();
+      props = useProps();
     }
 
     class ErrorComp extends Component {
@@ -1503,7 +1508,7 @@ describe("can catch errors", () => {
 
     class Catch extends Component {
       static template = xml`<t t-call-slot="default" />`;
-      props = props();
+      props = useProps();
       setup() {
         onError((e) => {
           this.props.onError(e);
@@ -1833,7 +1838,7 @@ describe("errors in onWillUpdateProps", () => {
     let error: any;
     class Child extends Component {
       static template = xml`<div/>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillUpdateProps(() => {
           throw new Error("sync boom");
@@ -1861,7 +1866,7 @@ describe("errors in onWillUpdateProps", () => {
     let error: any;
     class Child extends Component {
       static template = xml`<div/>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillUpdateProps(async () => {
           await Promise.resolve();
@@ -1891,7 +1896,7 @@ describe("errors in onWillUpdateProps", () => {
     let error: any;
     class Child extends Component {
       static template = xml`<div/>`;
-      props = props();
+      props = useProps();
       setup() {
         onError((e) => (error = e));
         onWillUpdateProps(async () => {

--- a/packages/owl-runtime/tests/components/higher_order_component.test.ts
+++ b/packages/owl-runtime/tests/components/higher_order_component.test.ts
@@ -1,5 +1,5 @@
-import { Component, mount, props, proxy, xml } from "../../src";
-import { makeTestFixture, nextTick, snapshotEverything, render } from "../helpers";
+import { Component, mount, proxy, useProps, xml } from "../../src";
+import { makeTestFixture, nextTick, render, snapshotEverything } from "../helpers";
 
 let fixture: HTMLElement;
 
@@ -13,7 +13,7 @@ describe("basics", () => {
   test("basic use", async () => {
     class Child extends Component {
       static template = xml`<span>child<t t-out="this.props.p"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {

--- a/packages/owl-runtime/tests/components/hooks.test.ts
+++ b/packages/owl-runtime/tests/components/hooks.test.ts
@@ -8,22 +8,21 @@ import {
   onWillStart,
   onWillUnmount,
   onWillUpdateProps,
-  OwlError,
-  props,
   proxy,
   signal,
   useEffect,
   useListener,
   useOnChange,
+  useProps,
   xml,
 } from "../../src";
 import {
   elem,
+  getConsoleOutput,
   logStep,
   makeTestFixture,
   nextTick,
   snapshotEverything,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -182,7 +181,7 @@ describe("hooks", () => {
     }
     class MyComponent extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         useMyHook();
         use2ndHook();
@@ -222,7 +221,7 @@ describe("hooks", () => {
     let received: any = undefined;
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillUpdateProps((nextProps) => {
           received = nextProps;
@@ -249,7 +248,7 @@ describe("hooks", () => {
     let received: any = undefined;
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillUpdateProps((nextProps) => {
           received = nextProps;
@@ -280,7 +279,7 @@ describe("hooks", () => {
 
     class MyComponent extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         useListener(window, "click", this.increment);
         window.dispatchEvent(new Event("click"));

--- a/packages/owl-runtime/tests/components/lifecycle.test.ts
+++ b/packages/owl-runtime/tests/components/lifecycle.test.ts
@@ -2,30 +2,30 @@ import {
   App,
   Component,
   mount,
-  proxy,
-  xml,
-  onWillPatch,
-  onWillUnmount,
-  onPatched,
-  onWillUpdateProps,
-  onWillDestroy,
   onMounted,
+  onPatched,
+  onWillDestroy,
+  onWillPatch,
   onWillStart,
-  props,
+  onWillUnmount,
+  onWillUpdateProps,
+  proxy,
+  useProps,
+  xml,
 } from "../../src";
 import { status } from "../../src/status";
 import {
   elem,
+  getConsoleOutput,
   logStep,
   makeDeferred,
   makeTestFixture,
   nextMicroTick,
   nextTick,
+  render,
   snapshotEverything,
   steps,
   useLogLifecycle,
-  render,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -304,7 +304,7 @@ describe("lifecycle hooks", () => {
       static template = xml`
         <div><t t-out="this.props.n"/></div>
       `;
-      props = props();
+      props = useProps();
 
       setup() {
         onWillPatch(() => {
@@ -321,7 +321,7 @@ describe("lifecycle hooks", () => {
         <div><ChildChild n="this.props.n"/></div>
       `;
       static components = { ChildChild };
-      props = props();
+      props = useProps();
 
       setup() {
         onWillPatch(() => {
@@ -445,7 +445,7 @@ describe("lifecycle hooks", () => {
   test("components are unmounted and destroyed if no longer in DOM, even after updateprops", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.n"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         useLogLifecycle(this);
       }
@@ -554,7 +554,7 @@ describe("lifecycle hooks", () => {
 
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.n"/></span>`;
-      props = props();
+      props = useProps();
 
       setup() {
         onWillUpdateProps((nextProps) => {
@@ -1218,7 +1218,7 @@ describe("lifecycle hooks", () => {
 
     class Test extends Component {
       static template = xml`<t t-out="this.props.rev" />`;
-      props = props();
+      props = useProps();
       setup() {
         instance = this;
         onWillStart(this.logger("onWillStart"));

--- a/packages/owl-runtime/tests/components/plugins.test.ts
+++ b/packages/owl-runtime/tests/components/plugins.test.ts
@@ -2,30 +2,29 @@ import {
   App,
   Component,
   computed,
-  config,
   mount,
   onWillDestroy,
   onWillStart,
-  plugin,
   Plugin,
   PluginConstructor,
   PluginInstance,
   providePlugins,
   Resource,
-  Scope,
   signal,
   types as t,
   useApp,
+  useConfig,
   useEffect,
+  usePlugin,
   xml,
 } from "../../src";
 import {
+  getConsoleOutput,
   makeDeferred,
   makeTestFixture,
   nextMicroTick,
-  snapshotEverything,
   nextTick,
-  getConsoleOutput,
+  snapshotEverything,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -42,7 +41,7 @@ test("basic use", async () => {
 
   class Test extends Component {
     static template = xml`<t t-out="this.a.value"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
 
   await mount(Test, fixture, { plugins: [PluginA] });
@@ -56,7 +55,7 @@ test("can be started with resource", async () => {
 
   class Test extends Component {
     static template = xml`<t t-out="this.a.value"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
 
   const plugins = new Resource<PluginConstructor>().add(PluginA);
@@ -115,7 +114,7 @@ test("basic use (setup)", async () => {
     declare a: PluginInstance<typeof PluginA>;
 
     setup() {
-      this.a = plugin(PluginA);
+      this.a = usePlugin(PluginA);
     }
   }
 
@@ -137,7 +136,7 @@ test("get plugin which is not started", async () => {
 
     setup() {
       try {
-        this.a = plugin(PluginA);
+        this.a = usePlugin(PluginA);
       } catch (e) {
         steps.push((e as Error).message);
       }
@@ -163,11 +162,11 @@ test("components can start plugins", async () => {
     declare b: PluginInstance<typeof PluginB>;
 
     setup() {
-      this.a = plugin(PluginA); // PluginA is already started, we can get it
+      this.a = usePlugin(PluginA); // PluginA is already started, we can get it
       // PluginB is not started yet so we'll crash if we try to get it (tested in a previous test)
 
       providePlugins([PluginB]);
-      this.b = plugin(PluginB); // PluginB is now started, we can get it
+      this.b = usePlugin(PluginB); // PluginB is now started, we can get it
     }
   }
 
@@ -189,15 +188,15 @@ test("components start plugins at their level", async () => {
   class Level3 extends Component {
     static template = xml`3: <t t-out="this.a.value"/> - <t t-out="this.b.value"/>`;
 
-    a = plugin(PluginA);
-    b = plugin(PluginB);
+    a = usePlugin(PluginA);
+    b = usePlugin(PluginB);
   }
 
   class Level2 extends Component {
     static template = xml`2: <t t-out="this.a.value"/> | <Level3/>`;
     static components = { Level3 };
 
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
 
     setup() {
       providePlugins([PluginB]);
@@ -222,11 +221,11 @@ test("components start plugins at their level", async () => {
 
 test("components can give config to plugins", async () => {
   class PluginA extends Plugin {
-    inputA = config("inputAlias", t.string());
+    inputA = useConfig("inputAlias", t.string());
   }
 
   class PluginB extends Plugin {
-    inputB = config("otherInput", t.number());
+    inputB = useConfig("otherInput", t.number());
     other = 1;
   }
 
@@ -237,8 +236,8 @@ test("components can give config to plugins", async () => {
 
     setup() {
       providePlugins([PluginA, PluginB], { inputAlias: "hamburger", otherInput: 123 });
-      this.a = plugin(PluginA);
-      this.b = plugin(PluginB);
+      this.a = usePlugin(PluginA);
+      this.b = usePlugin(PluginB);
     }
   }
   await mount(Test, fixture);
@@ -247,7 +246,7 @@ test("components can give config to plugins", async () => {
 
 test("plugin config are validated", async () => {
   class PluginA extends Plugin {
-    inputA = config("input", t.string());
+    inputA = useConfig("input", t.string());
   }
 
   class Test extends Component {
@@ -256,7 +255,7 @@ test("plugin config are validated", async () => {
 
     setup() {
       providePlugins([PluginA], { input: 123 } as any);
-      this.a = plugin(PluginA);
+      this.a = usePlugin(PluginA);
     }
   }
   await expect(mount(Test, fixture, { dev: true })).rejects.toThrow(
@@ -267,12 +266,12 @@ test("plugin config are validated", async () => {
 
 test("optional plugin config work as expected (value given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input", t.string().optional()) || "abc";
+    inputA = useConfig("input", t.string().optional()) || "abc";
   }
 
   class Test extends Component {
     static template = xml`<t t-out="this.a.inputA"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
   await mount(Test, fixture, { plugins: [PluginA], dev: true, config: { input: "def" } });
   expect(fixture.innerHTML).toBe("def");
@@ -280,12 +279,12 @@ test("optional plugin config work as expected (value given)", async () => {
 
 test("optional plugin config work as expected (no value given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input", t.string().optional()) || "abc";
+    inputA = useConfig("input", t.string().optional()) || "abc";
   }
 
   class Test extends Component {
     static template = xml`<t t-out="this.a.inputA"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
   await mount(Test, fixture, { plugins: [PluginA], dev: true, config: {} });
   expect(fixture.innerHTML).toBe("abc");
@@ -293,12 +292,12 @@ test("optional plugin config work as expected (no value given)", async () => {
 
 test("optional plugin config work as expected (no config given)", async () => {
   class PluginA extends Plugin {
-    inputA = config("input", t.string().optional()) || "abc";
+    inputA = useConfig("input", t.string().optional()) || "abc";
   }
 
   class Test extends Component {
     static template = xml`<t t-out="this.a.inputA"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
   await mount(Test, fixture, { plugins: [PluginA], dev: true });
   expect(fixture.innerHTML).toBe("abc");
@@ -317,7 +316,7 @@ test("shadow plugin", async () => {
 
   class Level3 extends Component {
     static template = xml`<t t-out="this.a.value"/>`;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
 
   class Level2 extends Component {
@@ -333,7 +332,7 @@ test("shadow plugin", async () => {
     static template = xml`<t t-out="this.a.value"/> | <Level2/>`;
     static components = { Level2 };
 
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
 
   await mount(Level1, fixture, { plugins: [PluginA] });
@@ -352,7 +351,7 @@ test("components can register resources", async () => {
   class Level2 extends Component {
     static template = xml`2: <t t-out="this.a.value()"/> `;
 
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
     setup() {
       this.a.colors.use("from lvl 2");
       expect(this.a.colors.items()).toEqual(["from lvl 1", "from lvl 2"]);
@@ -364,7 +363,7 @@ test("components can register resources", async () => {
     static components = { Level2 };
 
     setup() {
-      const a = plugin(PluginA);
+      const a = usePlugin(PluginA);
       a.colors.use("from lvl 1");
       expect(a.colors.items()).toEqual(["from lvl 1"]);
     }
@@ -416,7 +415,7 @@ test("components, plugins, useEffect", async () => {
 test("components mounted by plugin", async () => {
   class R2 extends Component {
     static template = xml`<t t-out="this.p.value"/>`;
-    p = plugin(P);
+    p = usePlugin(P);
   }
 
   class P extends Plugin {
@@ -453,8 +452,8 @@ test("usePlugin returns the scoped view when the plugin defines one", async () =
   let comp: Test;
   class Test extends Component {
     static template = xml``;
-    orm = plugin(ORM);
-    orm2 = plugin(ORM);
+    orm = usePlugin(ORM);
+    orm2 = usePlugin(ORM);
     setup() {
       comp = this;
     }
@@ -489,7 +488,7 @@ test("scoped plugin methods are guarded by the consumer's lifetime", async () =>
   let comp: Test;
   class Test extends Component {
     static template = xml``;
-    orm = plugin(ORM);
+    orm = usePlugin(ORM);
     setup() {
       comp = this;
     }
@@ -522,7 +521,7 @@ test("providePlugins respects plugin sequence", async () => {
   }
 
   class Feature extends Plugin {
-    foundation = plugin(Foundation);
+    foundation = usePlugin(Foundation);
     setup() {
       steps.push(`feature:setup (data=${this.foundation.data})`);
     }

--- a/packages/owl-runtime/tests/components/portal.test.ts
+++ b/packages/owl-runtime/tests/components/portal.test.ts
@@ -5,10 +5,10 @@ import {
   onWillStart,
   Plugin,
   Portal,
-  plugin,
   providePlugins,
   signal,
-  xml,
+  usePlugin,
+  xml
 } from "../../src";
 import { makeDeferred, makeTestFixture, nextTick } from "../helpers";
 
@@ -185,7 +185,7 @@ test("forwards plugin chain: providePlugins ancestor is visible to portaled cont
   let inside: any = null;
   class Inside extends Component {
     static template = xml`<span class="payload" t-out="this.foo.value"/>`;
-    foo = plugin(FooPlugin);
+    foo = usePlugin(FooPlugin);
     setup() {
       inside = this;
     }

--- a/packages/owl-runtime/tests/components/prop.test.ts
+++ b/packages/owl-runtime/tests/components/prop.test.ts
@@ -1,4 +1,4 @@
-import { Component, mount, props, proxy, signal, types as t, xml } from "../../src";
+import { Component, mount, proxy, signal, types as t, useProps, xml } from "../../src";
 import {
   getConsoleOutput,
   makeTestFixture,
@@ -24,7 +24,7 @@ describe("basics", () => {
   test("reads the named prop", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.value"/></span>`;
-      value = props.static("value", t.number());
+      value = useProps.static("value", t.number());
     }
     class Parent extends Component {
       static template = xml`<div><Child value="42"/></div>`;
@@ -38,7 +38,7 @@ describe("basics", () => {
   test("default value when prop is absent", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.label"/></span>`;
-      label = props.static("label", t.string().optional("untitled"));
+      label = useProps.static("label", t.string().optional("untitled"));
     }
     class Parent extends Component {
       static template = xml`<div><Child/></div>`;
@@ -52,7 +52,7 @@ describe("basics", () => {
   test("provided value takes precedence over default", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.label"/></span>`;
-      label = props.static("label", t.string().optional("untitled"));
+      label = useProps.static("label", t.string().optional("untitled"));
     }
     class Parent extends Component {
       static template = xml`<div><Child label="'hello'"/></div>`;
@@ -66,8 +66,8 @@ describe("basics", () => {
   test("multiple prop fields in same component", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.a"/>/<t t-out="this.b"/></span>`;
-      a = props.static("a", t.string());
-      b = props.static("b", t.number());
+      a = useProps.static("a", t.string());
+      b = useProps.static("b", t.number());
     }
     class Parent extends Component {
       static template = xml`<div><Child a="'x'" b="2"/></div>`;
@@ -81,8 +81,8 @@ describe("basics", () => {
   test("can be mixed with props()", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.all.extra"/>/<t t-out="this.main"/></span>`;
-      all = props({ extra: t.string().optional() });
-      main = props.static("main", t.number());
+      all = useProps({ extra: t.string().optional() });
+      main = useProps.static("main", t.number());
     }
     class Parent extends Component {
       static template = xml`<div><Child main="7" extra="'side'"/></div>`;
@@ -96,7 +96,7 @@ describe("basics", () => {
   test("type argument is optional (accepts any value)", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.value"/></span>`;
-      value = props.static("value");
+      value = useProps.static("value");
     }
     class Parent extends Component {
       static template = xml`<div><Child value="'anything'"/></div>`;
@@ -116,7 +116,7 @@ describe("basics", () => {
     }
     class Child extends Component {
       static template = xml`<span><t t-out="this.todo.name"/></span>`;
-      todo = props.static("todo", t.instanceOf(Todo));
+      todo = useProps.static("todo", t.instanceOf(Todo));
     }
     class Parent extends Component {
       static template = xml`<div><Child todo="this.myTodo"/></div>`;
@@ -137,7 +137,7 @@ describe("dev mode", () => {
   test("validates initial type on mount (root component)", async () => {
     class Root extends Component {
       static template = xml`<div/>`;
-      value = props.static("value", t.number());
+      value = useProps.static("value", t.number());
     }
 
     let error: any;
@@ -154,7 +154,7 @@ describe("dev mode", () => {
   test("validates initial type on mount (child component)", async () => {
     class Child extends Component {
       static template = xml`<div/>`;
-      value = props.static("value", t.number());
+      value = useProps.static("value", t.number());
     }
     class Parent extends Component {
       static template = xml`<Child value="'not-a-number'"/>`;
@@ -175,7 +175,7 @@ describe("dev mode", () => {
     class Todo {}
     class Child extends Component {
       static template = xml`<div/>`;
-      todo = props.static("todo", t.instanceOf(Todo));
+      todo = useProps.static("todo", t.instanceOf(Todo));
     }
     class Parent extends Component {
       static template = xml`<Child todo="this.state.todo"/>`;
@@ -196,7 +196,7 @@ describe("dev mode", () => {
 
     class Child extends Component {
       static template = xml`<div/>`;
-      todo = props.static("todo", t.signal());
+      todo = useProps.static("todo", t.signal());
     }
     class Parent extends Component {
       static template = xml`<Child todo="this.todoSig"/>`;
@@ -217,7 +217,7 @@ describe("dev mode", () => {
   test("skips validation in non-dev mode", async () => {
     class Root extends Component {
       static template = xml`<div/>`;
-      value = props.static("value", t.number());
+      value = useProps.static("value", t.number());
     }
 
     let error: any;
@@ -233,7 +233,7 @@ describe("dev mode", () => {
     class Todo {}
     class Child extends Component {
       static template = xml`<div/>`;
-      todo = props.static("todo", t.instanceOf(Todo));
+      todo = useProps.static("todo", t.instanceOf(Todo));
     }
     class Parent extends Component {
       static template = xml`<Child todo="this.state.todo"/>`;
@@ -252,7 +252,7 @@ describe("dev mode", () => {
   test("default value skips validation when prop is absent", async () => {
     class Root extends Component {
       static template = xml`<div t-out="this.label"/>`;
-      label = props.static("label", t.string().optional("fallback"));
+      label = useProps.static("label", t.string().optional("fallback"));
     }
 
     // No error even though prop is missing: default covers it
@@ -263,7 +263,7 @@ describe("dev mode", () => {
   test("omitted prop with default does not trigger static-prop error on re-render", async () => {
     class Child extends Component {
       static template = xml`<div t-out="this.label"/>`;
-      label = props.static("label", t.string().optional("fallback"));
+      label = useProps.static("label", t.string().optional("fallback"));
     }
     class Parent extends Component {
       static template = xml`<Child/>`;
@@ -288,7 +288,7 @@ describe("dev mode", () => {
 test("throws if called outside a component scope", () => {
   let error: any;
   try {
-    props.static("foo", t.string());
+    useProps.static("foo", t.string());
   } catch (e) {
     error = e;
   }

--- a/packages/owl-runtime/tests/components/props.test.ts
+++ b/packages/owl-runtime/tests/components/props.test.ts
@@ -3,19 +3,19 @@ import {
   effect,
   mount,
   onWillUpdateProps,
-  props,
   proxy,
   signal,
   types as t,
+  useProps,
   xml,
 } from "../../src";
 import {
+  getConsoleOutput,
   makeTestFixture,
   nextTick,
   snapshotEverything,
   steps,
   useLogLifecycle,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -30,7 +30,7 @@ describe("basics", () => {
   test("explicit object prop", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.state.someval"/></span>`;
-      props = props();
+      props = useProps();
       state: any;
       setup() {
         this.state = proxy({ someval: this.props.value });
@@ -50,7 +50,7 @@ describe("basics", () => {
   test("prop names can contain -", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props['prop-name']"/></div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -65,7 +65,7 @@ describe("basics", () => {
   test("accept ES6-like syntax for props (with getters)", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.greetings"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -84,7 +84,7 @@ describe("basics", () => {
   test("t-set works ", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.val"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -102,7 +102,7 @@ describe("basics", () => {
   test("t-set with a body expression can be used as textual prop", async () => {
     class Child extends Component {
       static template = xml`<span t-out="this.props.val"/>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static components = { Child };
@@ -123,7 +123,7 @@ describe("basics", () => {
         <span>
           <t t-out="this.props.val"/>
         </span>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static components = { Child };
@@ -141,7 +141,7 @@ describe("basics", () => {
   test("arrow functions as prop correctly capture their scope", async () => {
     class Child extends Component {
       static template = xml`<button t-on-click="this.props.onClick"/>`;
-      props = props();
+      props = useProps();
     }
 
     let onClickArgs: [number, MouseEvent] | null = null;
@@ -168,7 +168,7 @@ describe("basics", () => {
     let childProps: any;
     class Child extends Component {
       static template = xml`<span><t t-esc="this.props.onClick"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         childProps = this.props;
       }
@@ -195,7 +195,7 @@ describe("basics", () => {
     expect.assertions(3);
     class Child extends Component {
       static template = xml`<button t-on-click="this.props.onClick"/>`;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props["some-dashed-prop"]).toBe(5);
       }
@@ -212,7 +212,7 @@ describe("basics", () => {
     expect.assertions(3);
     class Child extends Component {
       static template = xml``;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props.propName).toBe("123");
       }
@@ -230,7 +230,7 @@ describe("basics", () => {
 test("can bind function prop with bind suffix", async () => {
   class Child extends Component {
     static template = xml`child`;
-    props = props();
+    props = useProps();
     setup() {
       this.props.doSomething(123);
     }
@@ -256,7 +256,7 @@ test("can bind function prop with bind suffix", async () => {
 test("do not crash when binding anonymous function prop with bind suffix", async () => {
   class Child extends Component {
     static template = xml`child`;
-    props = props();
+    props = useProps();
     setup() {
       this.props.doSomething(123);
     }
@@ -283,7 +283,7 @@ test("bound functions is not referentially equal after update", async () => {
   let isEqual = false;
   class Child extends Component {
     static template = xml`<t t-out="this.props.val"/>`;
-    props = props();
+    props = useProps();
     setup() {
       onWillUpdateProps((nextProps: any) => {
         isEqual = nextProps.fn === this.props.fn;
@@ -351,7 +351,7 @@ test("bound functions are considered 'alike'", async () => {
 test("can use .translate suffix", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.message"/>`;
-    props = props();
+    props = useProps();
   }
 
   class Parent extends Component {
@@ -366,7 +366,7 @@ test("can use .translate suffix", async () => {
 test(".translate props are translated", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.message"/>`;
-    props = props();
+    props = useProps();
   }
 
   class Parent extends Component {
@@ -381,7 +381,7 @@ test(".translate props are translated", async () => {
 test("throw if prop uses an unknown suffix", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.val"/>`;
-    props = props();
+    props = useProps();
   }
 
   class Parent extends Component {
@@ -397,7 +397,7 @@ test("throw if prop uses an unknown suffix", async () => {
 test(".alike suffix in a simple case", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.fn()"/>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -444,7 +444,7 @@ test(".alike suffix in a list", async () => {
       <button t-on-click="this.props.toggle">
         <t t-out="this.props.todo.id"/><t t-if="this.props.todo.isChecked">V</t>
       </button>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -501,7 +501,7 @@ test(".alike suffix in a list", async () => {
 test("arrow function props auto-skip re-render when captured variables don't change", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.fn()"/>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -548,7 +548,7 @@ test("arrow function props re-render when captured variable changes", async () =
       <button t-on-click="this.props.toggle">
         <t t-out="this.props.todo.id"/><t t-if="this.props.todo.isChecked">V</t>
       </button>`;
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
     }
@@ -610,7 +610,7 @@ test("arrow function props re-render when captured variable changes", async () =
 test("schema defaults and signal-driven props", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.width"/> / <t t-out="this.props.height"/>`;
-    props = props({
+    props = useProps({
       width: t.number().optional(1),
       height: t.number().optional(1),
     });
@@ -647,7 +647,7 @@ test("default props don't cause spurious updates with t-props", async () => {
   const updates: number[] = [];
   class Child extends Component {
     static template = xml`<t t-out="this.props.b"/>`;
-    props = props({ a: t.string().optional("default value"), b: t.number() });
+    props = useProps({ a: t.string().optional("default value"), b: t.number() });
     setup() {
       onWillUpdateProps(() => {
         updates.push(this.props.b);
@@ -694,7 +694,7 @@ test("default props don't cause spurious updates with t-props", async () => {
 test(".signal suffix promotes a plain value to a signal", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
-    props = props({ count: t.signal(t.number()) });
+    props = useProps({ count: t.signal(t.number()) });
   }
 
   class Parent extends Component {
@@ -710,7 +710,7 @@ test(".signal suffix promotes a plain value to a signal", async () => {
 test(".signal suffix: child re-reads updated value when parent state changes", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
-    props = props({ count: t.signal(t.number()) });
+    props = useProps({ count: t.signal(t.number()) });
   }
 
   class Parent extends Component {
@@ -731,7 +731,7 @@ test(".signal suffix: signal reference is stable across updates", async () => {
   let sameRef: boolean | null = null;
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/><t t-out="this.props.tick"/>`;
-    props = props();
+    props = useProps();
     setup() {
       onWillUpdateProps((nextProps: any) => {
         sameRef = nextProps.count === this.props.count;
@@ -757,7 +757,7 @@ test(".signal suffix: effects in child react to parent value changes", async () 
   const observed: number[] = [];
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
-    props = props({ count: t.signal(t.number()) });
+    props = useProps({ count: t.signal(t.number()) });
     setup() {
       effect(() => {
         observed.push(this.props.count());
@@ -786,7 +786,7 @@ test(".signal suffix: effects in child react to parent value changes", async () 
 test(".signal suffix works in a t-foreach loop", async () => {
   class Item extends Component {
     static template = xml`<span><t t-out="this.props.value()"/></span>`;
-    props = props({ value: t.signal(t.number()) });
+    props = useProps({ value: t.signal(t.number()) });
   }
 
   class Parent extends Component {
@@ -814,7 +814,7 @@ test(".signal suffix works in a t-foreach loop", async () => {
 test(".signal suffix accepts a signal-typed prop without validation error", async () => {
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
-    props = props({ count: t.signal(t.number()) });
+    props = useProps({ count: t.signal(t.number()) });
   }
 
   class Parent extends Component {
@@ -837,7 +837,7 @@ test(".signal suffix: child receives a read-only reactive value", async () => {
   let childError: any;
   class Child extends Component {
     static template = xml`<t t-out="this.props.count()"/>`;
-    props = props({ count: t.signal(t.number()) });
+    props = useProps({ count: t.signal(t.number()) });
     setup() {
       try {
         (this.props.count as any).set(99);
@@ -864,7 +864,7 @@ describe("reactive props (issue #1908)", () => {
     const observed: number[] = [];
     class Test extends Component {
       static template = xml`<span t-out="this.props.o.val"/>`;
-      props = props(["o"]);
+      props = useProps(["o"]);
       setup() {
         effect(() => observed.push(this.props.o.val));
       }
@@ -896,7 +896,7 @@ describe("reactive props (issue #1908)", () => {
     const observed: number[] = [];
     class Test extends Component {
       static template = xml`<span>hi</span>`;
-      props = props(["o"]);
+      props = useProps(["o"]);
       setup() {
         effect(() => observed.push(this.props.o.val));
       }
@@ -924,7 +924,7 @@ describe("reactive props (issue #1908)", () => {
     const observed: number[] = [];
     class Test extends Component {
       static template = xml`<span t-out="this.tick()"/>`;
-      props = props(["o"]);
+      props = useProps(["o"]);
       setup() {
         effect(() => observed.push(this.props.o.val));
       }
@@ -956,7 +956,7 @@ describe("reactive props (issue #1908)", () => {
   test("props() tracks new and deleted keys from t-props", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.label()"/></span>`;
-      props = props();
+      props = useProps();
       label() {
         return `${Object.keys(this.props).join(",")}:${this.props.a || ""}${this.props.b || ""}`;
       }
@@ -979,7 +979,7 @@ describe("reactive props (issue #1908)", () => {
     const seen: { next: number; current: number }[] = [];
     class Child extends Component {
       static template = xml`<span t-out="this.props.value"/>`;
-      props = props(["value"]);
+      props = useProps(["value"]);
       setup() {
         onWillUpdateProps((nextProps) => {
           seen.push({ next: nextProps.value, current: this.props.value });

--- a/packages/owl-runtime/tests/components/props_validation.test.ts
+++ b/packages/owl-runtime/tests/components/props_validation.test.ts
@@ -1,10 +1,10 @@
-import { applyDefaults, Component, mount, onError, props, types as t, xml } from "../../src";
+import { applyDefaults, Component, mount, onError, types as t, useProps, xml } from "../../src";
 import {
+  getConsoleOutput,
   makeTestFixture,
   nextTick,
   render,
   snapshotEverything,
-  getConsoleOutput,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -23,7 +23,7 @@ describe("props validation", () => {
   test("validation is only done in dev mode", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
     class Parent extends Component {
       static components = { SubComp };
@@ -51,7 +51,7 @@ describe("props validation", () => {
   test("props: list of strings", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
     class Parent extends Component {
       static components = { SubComp };
@@ -71,7 +71,7 @@ describe("props validation", () => {
   test("validate props for root component", async () => {
     class Root extends Component {
       static template = xml`<div t-out="this.props.message"/>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
 
     let error: Error;
@@ -104,7 +104,7 @@ describe("props validation", () => {
     for (const test of Tests) {
       const SubComp = class extends Component {
         static template = xml`<div>hey</div>`;
-        props = props({ p: test.type });
+        props = useProps({ p: test.type });
       };
       (Parent as any).components = { SubComp };
 
@@ -143,7 +143,7 @@ describe("props validation", () => {
   test("can validate a prop with multiple types", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.or([t.string(), t.boolean()]) });
+      props = useProps({ p: t.or([t.string(), t.boolean()]) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -181,7 +181,7 @@ describe("props validation", () => {
   test("can validate an optional props", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.string().optional() });
+      props = useProps({ p: t.string().optional() });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -219,7 +219,7 @@ describe("props validation", () => {
   test("can validate an array with given primitive type", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.array(t.string()) });
+      props = useProps({ p: t.array(t.string()) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -263,7 +263,7 @@ describe("props validation", () => {
   test("can validate an array with multiple sub element types", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ p: t.array(t.or([t.string(), t.boolean()])) });
+      props = useProps({ p: t.array(t.or([t.string(), t.boolean()])) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.p"/></div>`;
@@ -308,7 +308,7 @@ describe("props validation", () => {
   test("can validate an object with simple shape", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({
+      props = useProps({
         p: t.object({ id: t.number(), url: t.string() }),
       });
     }
@@ -355,7 +355,7 @@ describe("props validation", () => {
   test("can validate recursively complicated prop def", async () => {
     class SubComp extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({
+      props = useProps({
         p: t.object({
           id: t.number(),
           url: t.or([t.boolean(), t.array(t.number())]),
@@ -397,7 +397,7 @@ describe("props validation", () => {
   test("can validate optional attributes in nested sub props", async () => {
     class TestComponent extends Component {
       static template = xml``;
-      props = props({
+      props = useProps({
         myprop: t.array(t.object({ num: t.number().optional() })),
       });
     }
@@ -425,7 +425,7 @@ describe("props validation", () => {
   test("can validate with a custom validator", async () => {
     class TestComponent extends Component {
       static template = xml``;
-      props = props({
+      props = useProps({
         size: t.customValidator(t.string(), (e: string) =>
           ["small", "medium", "large"].includes(e)
         ),
@@ -457,7 +457,7 @@ describe("props validation", () => {
     const validator = vi.fn((n) => 0 <= n && n <= 10);
     class TestComponent extends Component {
       static template = xml``;
-      props = props({
+      props = useProps({
         n: t.customValidator(t.number(), validator),
       });
     }
@@ -500,7 +500,7 @@ describe("props validation", () => {
   test("props are validated in dev mode (code snapshot)", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.message"/></div>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
     class Parent extends Component {
       static components = { Child };
@@ -513,7 +513,7 @@ describe("props validation", () => {
   test("props: shape with optional props", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any(), someProp: t.any().optional() });
+      props = useProps({ message: t.any(), someProp: t.any().optional() });
     }
 
     await expect(
@@ -534,7 +534,7 @@ describe("props validation", () => {
   test("props: can be defined with a type any", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any() });
+      props = useProps({ message: t.any() });
     }
     await expect(
       mount(SubComp, fixture, {
@@ -547,7 +547,7 @@ describe("props validation", () => {
   test("props with type array, and no element", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ myprop: t.array() });
+      props = useProps({ myprop: t.array() });
     }
 
     await expect(
@@ -568,7 +568,7 @@ describe("props validation", () => {
   test("props with type object, and no shape", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ myprop: t.object() });
+      props = useProps({ myprop: t.object() });
     }
 
     await expect(
@@ -589,7 +589,7 @@ describe("props validation", () => {
   test.skip("props: extra props cause an error", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
 
     await expect(
@@ -603,7 +603,7 @@ describe("props validation", () => {
   test.skip("props: extra props cause an error, part 2", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any() });
+      props = useProps({ message: t.any() });
     }
 
     await expect(
@@ -617,7 +617,7 @@ describe("props validation", () => {
   test("props: optional prop do not cause an error", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.any().optional() });
+      props = useProps({ message: t.any().optional() });
     }
 
     await expect(
@@ -631,7 +631,7 @@ describe("props validation", () => {
   test("optional prop do not cause an error if value is undefined", async () => {
     class SubComp extends Component {
       static template = xml``;
-      props = props({ message: t.string().optional() });
+      props = useProps({ message: t.string().optional() });
     }
 
     await expect(
@@ -652,7 +652,7 @@ describe("props validation", () => {
   test("missing required boolean prop causes an error", async () => {
     class SubComp extends Component {
       static template = xml`<span><t t-if="this.props.p">hey</t></span>`;
-      props = props(["p"]);
+      props = useProps(["p"]);
     }
     class Parent extends Component {
       static template = xml`<div><SubComp/></div>`;
@@ -672,7 +672,7 @@ describe("props validation", () => {
     let error: Error;
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number() });
+      props = useProps({ p: t.number() });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.state.p"/></div>`;
@@ -695,7 +695,7 @@ describe("props validation", () => {
     // need to do something about errors catched in render
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number().optional(4) });
+      props = useProps({ p: t.number().optional(4) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.state.p"/></div>`;
@@ -714,7 +714,7 @@ describe("props validation", () => {
   test("mix of optional and mandatory", async () => {
     class Child extends Component {
       static template = xml` <div><t t-out="this.props.mandatory"/></div>`;
-      props = props({
+      props = useProps({
         optional: t.string().optional(),
         mandatory: t.number(),
       });
@@ -735,7 +735,7 @@ describe("props validation", () => {
   test("additional props are allowed (array)", async () => {
     class Child extends Component {
       static template = xml`<div>hey</div>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
     class Parent extends Component {
       static template = xml`<Child message="'m'" otherProp="'o'"/>`;
@@ -748,7 +748,7 @@ describe("props validation", () => {
   test("additional props are allowed (object)", async () => {
     class Child extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({
+      props = useProps({
         message: t.string(),
       });
     }
@@ -764,7 +764,7 @@ describe("props validation", () => {
   test("can validate through slots", async () => {
     class Child extends Component {
       static template = xml`<div>hey</div>`;
-      props = props(["message"]);
+      props = useProps(["message"]);
     }
 
     class Wrapper extends Component {
@@ -791,7 +791,7 @@ describe("props validation", () => {
     }
     class Child extends Component {
       static template = xml`<t t-out="this.props.customObj.val"/>`;
-      props = props({ customObj: t.instanceOf(CustomClass) });
+      props = useProps({ customObj: t.instanceOf(CustomClass) });
     }
 
     class Parent extends Component {
@@ -808,7 +808,7 @@ describe("props validation", () => {
     class CustomClass {}
     class Child extends Component {
       static template = xml`<div>hey</div>`;
-      props = props({ customObj: t.instanceOf(CustomClass) });
+      props = useProps({ customObj: t.instanceOf(CustomClass) });
     }
 
     class Parent extends Component {
@@ -835,7 +835,7 @@ describe("schema defaults", () => {
   test("default values can be declared in the schema", async () => {
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number().optional(4) });
+      props = useProps({ p: t.number().optional(4) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp /></div>`;
@@ -848,7 +848,7 @@ describe("schema defaults", () => {
   test("a key with a schema default may be omitted", async () => {
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number().optional(4) });
+      props = useProps({ p: t.number().optional(4) });
     }
     // no error in dev mode even though p is not given
     await mount(SubComp, fixture, { dev: true });
@@ -858,7 +858,7 @@ describe("schema defaults", () => {
   test("schema defaults work next to optional props", async () => {
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/>|<t t-out="this.props.q"/></div>`;
-      props = props({ p: t.number().optional(4), q: t.string().optional() });
+      props = useProps({ p: t.number().optional(4), q: t.string().optional() });
     }
     await mount(SubComp, fixture, { dev: true });
     expect(fixture.innerHTML).toBe("<div>4|</div>");
@@ -867,7 +867,7 @@ describe("schema defaults", () => {
   test("schema defaults are applied whenever component is updated", async () => {
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number().optional(4) });
+      props = useProps({ p: t.number().optional(4) });
     }
     class Parent extends Component {
       static template = xml`<div><SubComp p="this.state.p"/></div>`;
@@ -885,7 +885,7 @@ describe("schema defaults", () => {
   test("falsy default values are applied", async () => {
     class SubComp extends Component {
       static template = xml`<span><t t-if="this.props.p">hey</t><t t-if="!this.props.q">hey</t></span>`;
-      props = props({
+      props = useProps({
         p: t.boolean().optional(true),
         q: t.boolean().optional(false),
       });
@@ -902,7 +902,7 @@ describe("schema defaults", () => {
     const values: number[][] = [];
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p.length"/></div>`;
-      props: any = props({ p: t.array(t.number()).optional(() => []) });
+      props: any = useProps({ p: t.array(t.number()).optional(() => []) });
       setup() {
         values.push(this.props.p);
       }
@@ -922,7 +922,7 @@ describe("schema defaults", () => {
     const values: number[][] = [];
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p.length"/></div>`;
-      props: any = props({ p: t.array(t.number()).optional(defaultValue) });
+      props: any = useProps({ p: t.array(t.number()).optional(defaultValue) });
       setup() {
         values.push(this.props.p);
       }
@@ -941,7 +941,7 @@ describe("schema defaults", () => {
   test("schema defaults are validated in dev mode", async () => {
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.p"/></div>`;
-      props = props({ p: t.number().optional("4" as any) });
+      props = useProps({ p: t.number().optional("4" as any) });
     }
     let error: any;
     try {
@@ -985,7 +985,7 @@ describe("schema.toShape()", () => {
     let captured: any;
     class SubComp extends Component {
       static template = xml`<div><t t-out="this.props.title"/></div>`;
-      props = props(t.object({ title: t.string(), color: t.string().optional("red") }).toShape());
+      props = useProps(t.object({ title: t.string(), color: t.string().optional("red") }).toShape());
       setup() {
         captured = this.props;
       }
@@ -1013,7 +1013,7 @@ describe("schema.toShape()", () => {
     let captured: any;
     class Notification extends Component {
       static template = xml`<h1/>`;
-      props = props(Schema.toShape());
+      props = useProps(Schema.toShape());
       setup() {
         captured = this.props;
       }
@@ -1033,7 +1033,7 @@ describe("schema.toShape()", () => {
   test("a schema's props still rejects invalid values", async () => {
     class SubComp extends Component {
       static template = xml`<div/>`;
-      props = props(t.object({ count: t.number() }).toShape());
+      props = useProps(t.object({ count: t.number() }).toShape());
     }
     class Parent extends Component {
       static template = xml`<div><SubComp count="'not a number'"/></div>`;
@@ -1053,7 +1053,7 @@ describe("schema.toShape()", () => {
   test("a schema's props reports genuinely missing required keys", async () => {
     class SubComp extends Component {
       static template = xml`<div/>`;
-      props = props(t.and([t.object({ a: t.string() }), t.object({ b: t.string() })]).toShape());
+      props = useProps(t.and([t.object({ a: t.string() }), t.object({ b: t.string() })]).toShape());
     }
     class Parent extends Component {
       static template = xml`<div><SubComp a="'x'"/></div>`;
@@ -1087,7 +1087,7 @@ describe("schema.toShape()", () => {
     let captured: any;
     class Notification extends Component {
       static template = xml`<h1/>`;
-      props = applyDefaults(props(Schema.toShape()), Schema);
+      props = applyDefaults(useProps(Schema.toShape()), Schema);
       setup() {
         captured = this.props;
       }

--- a/packages/owl-runtime/tests/components/reactivity.test.ts
+++ b/packages/owl-runtime/tests/components/reactivity.test.ts
@@ -1,3 +1,4 @@
+import { Atom, atomSymbol } from "@odoo/owl-core";
 import {
   Component,
   computed,
@@ -5,13 +6,12 @@ import {
   onPatched,
   onWillPatch,
   onWillUnmount,
-  props,
+  proxy,
   shallowEqual,
   signal,
-  proxy,
+  useProps,
   xml,
 } from "../../src";
-import { atomSymbol, Atom } from "@odoo/owl-core";
 import {
   makeDeferred,
   makeTestFixture,
@@ -109,7 +109,7 @@ describe("reactivity in lifecycle", () => {
           <t t-set="noop" t-value="this.notify()"/>
           <span><t t-out="this.props.val"/><t t-out="this.state.n"/></span>
         `;
-      props = props();
+      props = useProps();
       state = proxy({ n: 2 });
       setup() {
         onWillPatch(() => {
@@ -202,7 +202,7 @@ describe("reactivity in lifecycle", () => {
   test("Child component doesn't render when state they depend on changes but their parent is about to unmount them", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.state.content.a"/>`;
-      props = props();
+      props = useProps();
       setup() {
         useLogLifecycle(this);
       }
@@ -249,7 +249,7 @@ describe("reactivity in lifecycle", () => {
       static template = xml`
           <t t-set="noop" t-value="this.notify()"/>
           <t t-out="this.props.obj.a"/><t t-out="this.props.proxyObj.b"/>`;
-      props = props();
+      props = useProps();
       notify() {
         childRenderCount++;
       }
@@ -294,7 +294,7 @@ describe("reactivity in lifecycle", () => {
 
     class Child extends Component {
       static template = xml`<t t-set="_" t-value="this.notify()"/>child:bv=<t t-out="this.props.bv"/>:a=<t t-out="this.a()"/>`;
-      props = props();
+      props = useProps();
       a = a;
       notify() {
         childRenderCount++;
@@ -406,7 +406,7 @@ describe("reactive cleanup on component destruction", () => {
 
     class Child extends Component {
       static template = xml`<span t-out="this.isSelected()"/>`;
-      p = props();
+      p = useProps();
       isSelected = computed(() => this.p.selected() === 1);
     }
 
@@ -439,7 +439,7 @@ describe("reactive cleanup on component destruction", () => {
 
     class Row extends Component {
       static template = xml`<span t-out="this.isSelected()"/>`;
-      p = props();
+      p = useProps();
       isSelected = computed(() => this.p.selected() === this.p.id);
     }
 
@@ -483,7 +483,7 @@ describe("reactive cleanup on component destruction", () => {
           <td t-out="this.p.row.id"/>
           <td><a t-out="this.p.row.label()"/></td>
         </tr>`;
-      p = props();
+      p = useProps();
       isSelected = computed(() => {
         return this.p.selected() === this.p.row.id;
       });

--- a/packages/owl-runtime/tests/components/refs.test.ts
+++ b/packages/owl-runtime/tests/components/refs.test.ts
@@ -1,17 +1,17 @@
 import {
   App,
   Component,
+  computed,
   mount,
   onMounted,
   onPatched,
   onWillDestroy,
   proxy,
-  xml,
-  props,
-  signal,
-  computed,
   Resource,
+  signal,
   useListener,
+  useProps,
+  xml,
 } from "../../src";
 import { logStep, makeTestFixture, nextAppError, nextTick, snapshotEverything } from "../helpers";
 
@@ -61,7 +61,7 @@ describe("refs", () => {
   test("refs are properly bound in slots", async () => {
     class Dialog extends Component {
       static template = xml`<span><t t-call-slot="footer"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -177,7 +177,7 @@ describe("refs", () => {
           <t t-out="this.props.tree.value"/>
           <t t-if="this.props.tree.child"><Test tree="this.props.tree.child"/></t>
         </p>`;
-      props = props();
+      props = useProps();
       root = signal<HTMLElement | null>(null);
 
       setup() {
@@ -225,7 +225,7 @@ describe("refs", () => {
   test("ref is set by child component", async () => {
     class Child extends Component {
       static template = xml`<div id="ref" t-ref="this.props.ref"/>`;
-      props = props({ ref: Function });
+      props = useProps({ ref: Function });
     }
 
     class Parent extends Component {

--- a/packages/owl-runtime/tests/components/rendering.test.ts
+++ b/packages/owl-runtime/tests/components/rendering.test.ts
@@ -4,22 +4,22 @@ import {
   onWillStart,
   onWillUpdateProps,
   OwlError,
-  props,
   proxy,
   signal,
   t,
+  useProps,
   xml,
 } from "../../src";
 import {
-  makeTestFixture,
-  snapshotEverything,
-  nextTick,
-  useLogLifecycle,
-  makeDeferred,
-  nextMicroTick,
-  render,
-  steps,
   getConsoleOutput,
+  makeDeferred,
+  makeTestFixture,
+  nextMicroTick,
+  nextTick,
+  render,
+  snapshotEverything,
+  steps,
+  useLogLifecycle,
 } from "../helpers";
 
 let fixture: HTMLElement;
@@ -187,7 +187,7 @@ describe("rendering semantics", () => {
   test("props are proxy", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.a.b"/>`;
-      props = props();
+      props = useProps();
       setup() {
         useLogLifecycle(this);
       }
@@ -232,7 +232,7 @@ describe("rendering semantics", () => {
   test("props are proxy (nested prop)", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.a.b.c"/>`;
-      props = props();
+      props = useProps();
 
       setup() {
         useLogLifecycle(this);
@@ -289,7 +289,7 @@ describe("rendering semantics", () => {
   test("works as expected for dynamic number of props", async () => {
     class Child extends Component {
       static template = xml`<t t-out="Object.keys(this.props).length"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -313,7 +313,7 @@ describe("rendering semantics", () => {
 
     class C extends Component {
       static template = xml`<t t-out="this.props.obj.val"/>`;
-      props = props();
+      props = useProps();
 
       setup() {
         useLogLifecycle(this);
@@ -323,7 +323,7 @@ describe("rendering semantics", () => {
     class B extends Component {
       static template = xml`<C obj="this.props.obj"/>`;
       static components = { C };
-      props = props();
+      props = useProps();
 
       setup() {
         useLogLifecycle(this);
@@ -388,7 +388,7 @@ test("force render in case of existing render", async () => {
   class B extends Component {
     static template = xml`<C/><t t-out="this.props.val"/>`;
     static components = { C };
-    props = props();
+    props = useProps();
     setup() {
       useLogLifecycle(this);
       onWillUpdateProps(() => def);
@@ -456,7 +456,7 @@ test("force render in case of existing render", async () => {
 test("children, default props and renderings", async () => {
   class Child extends Component {
     static template = xml`child`;
-    props = props({
+    props = useProps({
       value: { optional: true, defaultValue: 1 },
     });
     setup() {
@@ -506,7 +506,7 @@ describe("render loop detection", () => {
   test("throws a clear error instead of freezing on a render loop (#1968)", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.value"/>`;
-      props = props({ value: t.number(), inc: t.function() });
+      props = useProps({ value: t.number(), inc: t.function() });
       setup() {
         // Updating parent state during setup retriggers the parent render, which
         // recreates this child, whose setup runs again: an infinite render loop.

--- a/packages/owl-runtime/tests/components/scope.test.ts
+++ b/packages/owl-runtime/tests/components/scope.test.ts
@@ -3,8 +3,8 @@ import {
   Component,
   onWillDestroy,
   onWillStart,
-  plugin,
   Plugin,
+  usePlugin,
   useScope,
   xml,
 } from "../../src";
@@ -23,7 +23,7 @@ test("component scope is set during setup", async () => {
 
   class Root extends Component {
     static template = xml``;
-    a = plugin(PluginA);
+    a = usePlugin(PluginA);
   }
 
   const app = new App({ plugins: [PluginA] });
@@ -47,11 +47,11 @@ describe("useScope", () => {
     }
 
     const app = new App({ plugins: [PluginA] });
-    expect(() => plugin(PluginB)).toThrow("No active scope");
+    expect(() => usePlugin(PluginB)).toThrow("No active scope");
 
     let value = 0;
     captured!.run(() => {
-      const b = plugin(PluginB);
+      const b = usePlugin(PluginB);
       value = b.value;
     });
     expect(value).toBe(123);
@@ -76,11 +76,11 @@ describe("useScope", () => {
 
     const app = new App({ plugins: [PluginA] });
     await app.createRoot(Root).mount(fixture);
-    expect(() => plugin(PluginA)).toThrow("No active scope");
+    expect(() => usePlugin(PluginA)).toThrow("No active scope");
 
     let value = 0;
     captured!.run(() => {
-      const a = plugin(PluginA);
+      const a = usePlugin(PluginA);
       value = a.value;
     });
     expect(value).toBe(123);

--- a/packages/owl-runtime/tests/components/slots.test.ts
+++ b/packages/owl-runtime/tests/components/slots.test.ts
@@ -1,10 +1,10 @@
-import { App, Component, mount, onMounted, props, proxy, signal, xml } from "../../src";
+import { App, Component, mount, onMounted, proxy, signal, useProps, xml } from "../../src";
 import {
   children,
+  getConsoleOutput,
   makeTestFixture,
   nextTick,
   snapshotEverything,
-  getConsoleOutput,
 } from "../helpers";
 
 snapshotEverything();
@@ -143,7 +143,7 @@ describe("slots", () => {
   test("simple named and empty slot", async () => {
     class Child extends Component {
       static template = xml`<span><t t-call-slot="default" /><t t-call-slot="myEmptySlot"/></span>`;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props.slots["myEmptySlot"]).toBeTruthy();
       }
@@ -161,7 +161,7 @@ describe("slots", () => {
   test("simple named and empty slot -- 2", async () => {
     class Child extends Component {
       static template = xml`<span><t t-call-slot="myEmptySlot">default empty</t></span>`;
-      props = props();
+      props = useProps();
 
       setup() {
         expect(this.props.slots["myEmptySlot"]).toBeTruthy();
@@ -181,7 +181,7 @@ describe("slots", () => {
   test("can use .translate suffix on slot props", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.slots.default.message"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -196,7 +196,7 @@ describe("slots", () => {
   test(".translate slot props are translated", async () => {
     class Child extends Component {
       static template = xml`<t t-out="this.props.slots.default.message"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -391,7 +391,7 @@ describe("slots", () => {
           <t t-out="this.props.slots['footer'].param"/>
           <div><t t-call-slot="footer"/></div>
         </div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -417,7 +417,7 @@ describe("slots", () => {
       static template = xml`
         <t t-call-slot="abc"/>
         <t t-out="this.props.slots['abc'].getValue()"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -592,7 +592,7 @@ describe("slots", () => {
             <a t-att-href="this.props.to">
               <t t-call-slot="default"/>
             </a>`;
-      props = props();
+      props = useProps();
     }
 
     class App extends Component {
@@ -632,7 +632,7 @@ describe("slots", () => {
             <a t-att-href="this.props.to">
               <t t-call-slot="default"/>
             </a>`;
-      props = props();
+      props = useProps();
     }
 
     class App extends Component {
@@ -672,7 +672,7 @@ describe("slots", () => {
             <a t-att-href="this.props.to">
               <t t-call-slot="default"/>
             </a>`;
-      props = props();
+      props = useProps();
     }
 
     class App extends Component {
@@ -1223,7 +1223,7 @@ describe("slots", () => {
         <div>
           SC:<t t-out="this.props.val"/>
         </div>`;
-      props = props();
+      props = useProps();
     }
     class GenericComponent extends Component {
       static template = xml`<div><t t-call-slot="default"/></div>`;
@@ -1273,7 +1273,7 @@ describe("slots", () => {
   test("template can just return a slot", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
     }
     class SlotComponent extends Component {
       static template = xml`<t t-call-slot="default"/>`;
@@ -1299,7 +1299,7 @@ describe("slots", () => {
   test("multiple slots containing components", async () => {
     class C extends Component {
       static template = xml`<span><t t-out="this.props.val"/></span>`;
-      props = props();
+      props = useProps();
     }
     class B extends Component {
       static template = xml`<div><t t-call-slot="s1"/><t t-call-slot="s2"/></div>`;
@@ -1567,7 +1567,7 @@ describe("slots", () => {
 
     class Slot extends Component {
       static template = xml`<span t-out="this.props.val"/>`;
-      props = props();
+      props = useProps();
       setup() {
         slot = this;
       }
@@ -1783,7 +1783,7 @@ describe("slots", () => {
   test("slot content has different key from other content -- static slot", async () => {
     class Child extends Component {
       static template = xml`<div t-out="this.props.parent" />`;
-      props = props();
+      props = useProps();
     }
 
     class SlotDisplay extends Component {
@@ -1806,7 +1806,7 @@ describe("slots", () => {
   test("slot content has different key from other content -- dynamic slot", async () => {
     class Child extends Component {
       static template = xml`<div t-out="this.props.parent" />`;
-      props = props();
+      props = useProps();
     }
 
     class SlotDisplay extends Component {
@@ -1836,7 +1836,7 @@ describe("slots", () => {
     class B extends Component {
       static template = xml`[B]<C slots="this.props.slots" />`;
       static components = { C };
-      props = props();
+      props = useProps();
     }
 
     const subTemplate2 = xml`[sub2<t t-out="v"/>]`;
@@ -1849,7 +1849,7 @@ describe("slots", () => {
     class A extends Component {
       static components = { B };
       static template = xml`<B>[A]<t t-call="${subTemplate1}"/></B>`;
-      props = props();
+      props = useProps();
       setup() {
         a = this;
       }
@@ -1899,7 +1899,7 @@ describe("slots", () => {
             <t t-call-slot="default"/>
           </t>
       `;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -1933,7 +1933,7 @@ describe("slots", () => {
             <t t-call-slot="{{'coffee'}}"/>
           </t>
       `;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -1964,7 +1964,7 @@ describe("slots", () => {
             <p><t t-out="elem"/><t t-call-slot="default"/></p>
           </t>
       `;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {

--- a/packages/owl-runtime/tests/components/style_class.test.ts
+++ b/packages/owl-runtime/tests/components/style_class.test.ts
@@ -1,5 +1,5 @@
-import { Component, mount, onMounted, props, proxy, xml } from "../../src";
-import { makeTestFixture, nextTick, snapshotEverything, getConsoleOutput } from "../helpers";
+import { Component, mount, onMounted, proxy, useProps, xml } from "../../src";
+import { getConsoleOutput, makeTestFixture, nextTick, snapshotEverything } from "../helpers";
 
 snapshotEverything();
 let fixture: HTMLElement;
@@ -22,7 +22,7 @@ describe("style and class handling", () => {
   test("can set class on sub component, as prop", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -36,7 +36,7 @@ describe("style and class handling", () => {
   test("no class is set is parent does not give it as prop", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -63,7 +63,7 @@ describe("style and class handling", () => {
   test("empty class attribute is not added on widget root el", async () => {
     class Child extends Component {
       static template = xml`<span t-att-class="this.props.class"/>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<div><Child class=""/></div>`;
@@ -76,7 +76,7 @@ describe("style and class handling", () => {
   test("can set more than one class on sub component", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -90,7 +90,7 @@ describe("style and class handling", () => {
   test("component class and parent class combine together", async () => {
     class Child extends Component {
       static template = xml`<div class="child" t-att-class="this.props.class">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -104,13 +104,13 @@ describe("style and class handling", () => {
   test("can set class on sub sub component", async () => {
     class ChildChild extends Component {
       static template = xml`<div t-att-class="this.props.class">childchild</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Child extends Component {
       static template = xml`<ChildChild class="(this.props.class || '') + ' fromchild'" />`;
       static components = { ChildChild };
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -124,7 +124,7 @@ describe("style and class handling", () => {
   test("can set class on multi root component", async () => {
     class Child extends Component {
       static template = xml`<div>a</div><span t-att-class="this.props.class">b</span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -138,16 +138,16 @@ describe("style and class handling", () => {
   test("class on sub component, which is switched to another", async () => {
     class ChildA extends Component {
       static template = xml`<div t-att-class="this.props.class">a</div>`;
-      props = props();
+      props = useProps();
     }
     class ChildB extends Component {
       static template = xml`<span t-att-class="this.props.class">b</span>`;
-      props = props();
+      props = useProps();
     }
     class Child extends Component {
       static template = xml`<ChildA class="this.props.class" t-if="this.props.child==='a'"/><ChildB class="this.props.class" t-else=""/>`;
       static components = { ChildA, ChildB };
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -185,7 +185,7 @@ describe("style and class handling", () => {
   test("class with extra whitespaces", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class"/>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<Child class="'a  b c   d'"/>`;
@@ -198,7 +198,7 @@ describe("style and class handling", () => {
   test("class with extra whitespaces (variation)", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class"/>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<p><Child class="'a  b c   d'"/></p>`;
@@ -213,7 +213,7 @@ describe("style and class handling", () => {
     let child: Child;
     class Child extends Component {
       static template = xml`<span class="c" t-att-class="{ d: this.state.d, ...this.props.class }"/>`;
-      props = props();
+      props = useProps();
       state = proxy({ d: true });
       setup() {
         child = this;
@@ -255,7 +255,7 @@ describe("style and class handling", () => {
     let child: Child;
     class Child extends Component {
       static template = xml`<span class="c" t-att-class="{ d: this.state.d, ...this.props.class }"/>`;
-      props = props();
+      props = useProps();
       state = proxy({ d: true });
       setup() {
         child = this;
@@ -312,7 +312,7 @@ describe("style and class handling", () => {
   test("style is properly added on widget root el", async () => {
     class SomeComponent extends Component {
       static template = xml`<div t-att-style="this.props.style"/>`;
-      props = props();
+      props = useProps();
     }
 
     class ParentWidget extends Component {
@@ -326,7 +326,7 @@ describe("style and class handling", () => {
   test("dynamic t-att-style is properly added and updated on widget root el", async () => {
     class SomeComponent extends Component {
       static template = xml`<div t-att-style="{ 'font-size': '20px', ...this.props.style }"/>`;
-      props = props();
+      props = useProps();
     }
 
     class ParentWidget extends Component {
@@ -347,7 +347,7 @@ describe("style and class handling", () => {
   test("component static style and dynamic t-att-style combine together", async () => {
     class Child extends Component {
       static template = xml`<div style="color: red;" t-att-style="this.props.style">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -363,7 +363,7 @@ describe("style and class handling", () => {
   test("static style and dynamic t-att-style with object combine together", async () => {
     class Child extends Component {
       static template = xml`<div style="color: red;" t-att-style="{ fontWeight: 'bold', ...this.props.style }">child</div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -520,7 +520,7 @@ describe("style and class handling", () => {
   test("error in subcomponent with class", async () => {
     class Child extends Component {
       static template = xml`<div t-att-class="this.props.class" t-out="this.will.crash"/>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`<Child class="'a'"/>`;

--- a/packages/owl-runtime/tests/components/t_call.test.ts
+++ b/packages/owl-runtime/tests/components/t_call.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, mount, props, proxy, signal, xml } from "../../src";
+import { App, Component, mount, proxy, signal, useProps, xml } from "../../src";
 import { isDirectChildOf, makeTestFixture, nextTick, render, snapshotEverything } from "../helpers";
 
 snapshotEverything();
@@ -36,7 +36,7 @@ describe("t-call", () => {
   test("sub components in two t-calls", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.val"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -128,7 +128,7 @@ describe("t-call", () => {
 
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.val"/></span>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static components = { Child };
@@ -265,7 +265,7 @@ describe("t-call", () => {
   test("t-call with t-call-context and subcomponent", async () => {
     class Child extends Component {
       static template = xml`child<t t-out="this.props.name"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Root extends Component {
@@ -292,7 +292,7 @@ describe("t-call", () => {
   test("t-call with t-call-context and subcomponent, in dev mode", async () => {
     class Child extends Component {
       static template = xml`child<t t-out="this.props.name"/>`;
-      props = props(["name"]);
+      props = useProps(["name"]);
     }
 
     class Root extends Component {
@@ -321,7 +321,7 @@ describe("t-call", () => {
     let child: any;
     class Child extends Component {
       static template = xml`<t t-call-slot="default"/>`;
-      props = props();
+      props = useProps();
       myRef = signal<any>(null);
       myRef2 = signal<any>(null);
       setup() {
@@ -365,7 +365,7 @@ describe("t-call", () => {
   test("t-call-context: slots don't make component available again when context is captured", async () => {
     class Child extends Component {
       static template = xml`<t t-call-slot="default"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Root extends Component {

--- a/packages/owl-runtime/tests/components/t_foreach.test.ts
+++ b/packages/owl-runtime/tests/components/t_foreach.test.ts
@@ -1,12 +1,12 @@
-import { Component, mount, onMounted, props, proxy, xml } from "../../src";
+import { Component, mount, onMounted, proxy, useProps, xml } from "../../src";
 import {
+  getConsoleOutput,
   makeTestFixture,
   nextTick,
   render,
   snapshotEverything,
   steps,
   useLogLifecycle,
-  getConsoleOutput,
 } from "../helpers";
 
 snapshotEverything();
@@ -21,7 +21,7 @@ describe("list of components", () => {
   test("simple list", async () => {
     class Child extends Component {
       static template = xml`<span><t t-out="this.props.value"/></span>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -54,7 +54,7 @@ describe("list of components", () => {
   test("components in a node in a t-foreach ", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.item"/></div>`;
-      props = props();
+      props = useProps();
       setup() {
         useLogLifecycle(this);
       }
@@ -104,7 +104,7 @@ describe("list of components", () => {
   test("reconciliation alg works for t-foreach in t-foreach", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.blip"/></div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -127,7 +127,7 @@ describe("list of components", () => {
   test("reconciliation alg works for t-foreach in t-foreach, 2", async () => {
     class Child extends Component {
       static template = xml`<div><t t-out="this.props.row + '_' + this.props.col"/></div>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -157,7 +157,7 @@ describe("list of components", () => {
   test("sub components rendered in a loop", async () => {
     class Child extends Component {
       static template = xml`<p><t t-out="this.props.n"/></p>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -247,7 +247,7 @@ describe("list of components", () => {
             <t t-out="this.state.val"/>
             <t t-out="this.props.val"/>
           </span>`;
-      props = props();
+      props = useProps();
       state = proxy({ val: "A" });
       setup() {
         onMounted(() => {
@@ -276,7 +276,7 @@ describe("list of components", () => {
     const childInstances = [];
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
       setup() {
         childInstances.push(this);
       }
@@ -354,7 +354,7 @@ describe("list of components", () => {
       static template = xml`
           <t t-foreach="this.slotNames" t-as="slotName" t-key="slotName" t-call-slot="{{ slotName }}"/>
       `;
-      props = props();
+      props = useProps();
       get slotNames() {
         return Object.entries(this.props.slots)
           .filter((entry: any) => entry[1].active)

--- a/packages/owl-runtime/tests/components/t_key.test.ts
+++ b/packages/owl-runtime/tests/components/t_key.test.ts
@@ -1,5 +1,5 @@
-import { snapshotEverything, makeTestFixture, render, nextTick, elem } from "../helpers";
-import { Component, mount, props, xml } from "../../src";
+import { Component, mount, useProps, xml } from "../../src";
+import { elem, makeTestFixture, nextTick, render, snapshotEverything } from "../helpers";
 
 snapshotEverything();
 
@@ -14,7 +14,7 @@ describe("t-key", () => {
     let childInstance = null;
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
 
       setup() {
         childInstance = this;
@@ -45,7 +45,7 @@ describe("t-key", () => {
         <t t-foreach="this.props.items" t-as="item" t-key="item_index">
           <t t-out="item"/>
         </t>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -84,7 +84,7 @@ describe("t-key", () => {
     let childInstance = null;
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
 
       setup() {
         childInstance = this;
@@ -120,7 +120,7 @@ describe("t-key", () => {
     const childInstances = [];
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
 
       setup() {
         childInstances.push(this);
@@ -153,7 +153,7 @@ describe("t-key", () => {
     const childInstances = [];
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
 
       setup() {
         childInstances.push(this);
@@ -193,7 +193,7 @@ describe("t-key", () => {
     const childInstances = [];
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
 
       setup() {
         childInstances.push(this);
@@ -232,7 +232,7 @@ describe("t-key", () => {
     const childInstances = [];
     class Child extends Component {
       static template = xml`<div t-out="this.props.key"></div>`;
-      props = props();
+      props = useProps();
       setup() {
         childInstances.push(this);
       }

--- a/packages/owl-runtime/tests/components/t_on.test.ts
+++ b/packages/owl-runtime/tests/components/t_on.test.ts
@@ -1,6 +1,6 @@
-import { Component, mount, onMounted, props, proxy, xml } from "../../src";
-import { elem, logStep, makeTestFixture, nextTick, snapshotEverything } from "../helpers";
+import { Component, mount, onMounted, proxy, useProps, xml } from "../../src";
 import { status } from "../../src/status";
+import { elem, logStep, makeTestFixture, nextTick, snapshotEverything } from "../helpers";
 
 snapshotEverything();
 
@@ -46,7 +46,7 @@ describe("t-on", () => {
       static template = xml`
         <span t-foreach="this.props.list" t-as="c" t-key="c_index" t-out="c"/>
       `;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static template = xml`
@@ -171,7 +171,7 @@ describe("t-on", () => {
   test("t-on on components", async () => {
     class Child extends Component {
       static template = xml`<button t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -192,7 +192,7 @@ describe("t-on", () => {
   test("t-on on components, variation", async () => {
     class Child extends Component {
       static template = xml`<button t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -227,7 +227,7 @@ describe("t-on", () => {
   test("t-on on component next to t-on on div", async () => {
     class Child extends Component {
       static template = xml`<button t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -260,7 +260,7 @@ describe("t-on", () => {
       static template = xml`
         [<t t-out="this.state.count"/>]
         <t t-call-slot="default" t-on-click="() => this.state.count++"/>`;
-      props = props();
+      props = useProps();
       state = proxy({ count: 0 });
     }
 
@@ -282,7 +282,7 @@ describe("t-on", () => {
   test("t-on on t-set-slots", async () => {
     class Child extends Component {
       static template = xml`<t t-call-slot="myslot"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -309,7 +309,7 @@ describe("t-on", () => {
     expect.assertions(4); // 2 snaps and 2 expects
     class Child extends Component {
       static template = xml`<button t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -330,7 +330,7 @@ describe("t-on", () => {
   test("t-on on slot, with 'prevent' modifier", async () => {
     class Child extends Component {
       static template = xml`<t t-call-slot="default" t-on-click.prevent="this.doSomething"/>`;
-      props = props();
+      props = useProps();
       doSomething(ev: MouseEvent) {
         expect(ev.defaultPrevented).toBe(true);
         logStep("hey");
@@ -354,7 +354,7 @@ describe("t-on", () => {
   test("t-on on components and t-foreach", async () => {
     class Child extends Component {
       static template = xml`<div t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {
@@ -386,7 +386,7 @@ describe("t-on", () => {
   test("t-on on components, with a handler update", async () => {
     class Child extends Component {
       static template = xml`<div t-out="this.props.value"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Parent extends Component {

--- a/packages/owl-runtime/tests/components/t_props.test.ts
+++ b/packages/owl-runtime/tests/components/t_props.test.ts
@@ -1,4 +1,4 @@
-import { Component, mount, props, proxy, xml } from "../../src";
+import { Component, mount, proxy, useProps, xml } from "../../src";
 import { makeTestFixture, nextTick, render, snapshotEverything } from "../helpers";
 
 snapshotEverything();
@@ -13,7 +13,7 @@ describe("t-props", () => {
   test("t-props only", async () => {
     class Comp extends Component {
       static template = xml`<div><t t-out="this.props.a"/></div>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static components = { Comp };
@@ -35,7 +35,7 @@ describe("t-props", () => {
   test("t-props and other props", async () => {
     class Comp extends Component {
       static template = xml`<div><t t-out="this.props.a"/><t t-out="this.props.b"/></div>`;
-      props = props();
+      props = useProps();
     }
     class Parent extends Component {
       static components = { Comp };
@@ -65,7 +65,7 @@ describe("t-props", () => {
               <t t-out="this.props.a + this.props.b"/>
           </span>
         `;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props).toEqual({ a: 1, b: 2 });
         expect(this.props).not.toBe(state);
@@ -91,7 +91,7 @@ describe("t-props", () => {
 
     class Child extends Component {
       static template = xml`<div />`;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props).toEqual({ a: 1, b: 2, c: "c" });
       }
@@ -113,7 +113,7 @@ describe("t-props", () => {
   test("child receives a copy of the t-props object, not the original", async () => {
     class Child extends Component {
       static template = xml`<div/>`;
-      props = props();
+      props = useProps();
       setup() {
         expect(this.props).toEqual({ a: 1, b: 2 });
         this.props.d = 5;

--- a/packages/owl-runtime/tests/components/t_set.test.ts
+++ b/packages/owl-runtime/tests/components/t_set.test.ts
@@ -1,4 +1,4 @@
-import { Component, mount, props, xml } from "../../src";
+import { Component, mount, useProps, xml } from "../../src";
 import { makeTestFixture, nextTick, render, snapshotEverything } from "../helpers";
 
 snapshotEverything();
@@ -207,7 +207,7 @@ describe("t-set", () => {
   test("slots with an unused t-set with a component in body", async () => {
     class Child extends Component {
       static template = xml`Child <t t-call-slot="default"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Comp extends Component {
@@ -232,7 +232,7 @@ describe("t-set", () => {
     }
     class Child extends Component {
       static template = xml`Child <t t-call-slot="default"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Comp extends Component {
@@ -258,7 +258,7 @@ describe("t-set", () => {
     }
     class Blorg extends Component {
       static template = xml`Blorg <t t-call-slot="default"/>`;
-      props = props();
+      props = useProps();
     }
 
     class Comp extends Component {

--- a/packages/owl-runtime/tests/plugins.test.ts
+++ b/packages/owl-runtime/tests/plugins.test.ts
@@ -1,14 +1,13 @@
+import { Atom, atomSymbol, PluginManager, types, usePlugin } from "@odoo/owl-core";
 import { describe, expect, test } from "vitest";
 import {
   App,
   Component,
   computed,
-  config,
   effect,
   mount,
   onWillDestroy,
   onWillStart,
-  plugin,
   Plugin,
   PluginInstance,
   providePlugins,
@@ -16,10 +15,10 @@ import {
   signal,
   status,
   types as t,
+  useConfig,
   useListener,
-  xml,
+  xml
 } from "../src";
-import { atomSymbol, Atom, PluginManager, types } from "@odoo/owl-core";
 import { STATUS } from "../src/status";
 import { makeDeferred, makeTestFixture, nextMicroTick, nextTick, waitScheduler } from "./helpers";
 
@@ -114,7 +113,7 @@ describe("basic features", () => {
     }
 
     class A extends Plugin {
-      p = plugin(P);
+      p = usePlugin(P);
     }
 
     const manager = new PluginManager(new App());
@@ -138,7 +137,7 @@ describe("basic features", () => {
   test("plugin depending on another plugin with the same id (start only A, B is started implicitly)", () => {
     class A extends Plugin {
       static id = "plugin";
-      b = plugin(B);
+      b = usePlugin(B);
     }
     class B extends Plugin {
       static id = "plugin";
@@ -149,7 +148,7 @@ describe("basic features", () => {
   test("plugin depending on another plugin with the same id (start A and B)", () => {
     class A extends Plugin {
       static id = "plugin";
-      b = plugin(B);
+      b = usePlugin(B);
     }
     class B extends Plugin {
       static id = "plugin";
@@ -162,7 +161,7 @@ describe("basic features", () => {
   test("plugin depending on another plugin with the same id (start B then A)", () => {
     class A extends Plugin {
       static id = "plugin";
-      b = plugin(B);
+      b = usePlugin(B);
     }
     class B extends Plugin {
       static id = "plugin";
@@ -234,7 +233,7 @@ describe("basic features", () => {
     class B extends Plugin {
       static id = "b";
 
-      a = plugin(A);
+      a = usePlugin(A);
       setup() {
         b = this;
         steps.push("setup B");
@@ -244,8 +243,8 @@ describe("basic features", () => {
     class C extends Plugin {
       static id = "c";
 
-      a = plugin(A);
-      b = plugin(B);
+      a = usePlugin(A);
+      b = usePlugin(B);
       setup() {
         steps.push("setup C");
       }
@@ -294,7 +293,7 @@ describe("basic features", () => {
     class B extends Plugin {
       static id = "b";
 
-      a = plugin(A);
+      a = usePlugin(A);
       setup() {
         b = this;
         steps.push("setup B");
@@ -304,8 +303,8 @@ describe("basic features", () => {
     class C extends Plugin {
       static id = "c";
 
-      b = plugin(B);
-      a = plugin(A);
+      b = usePlugin(B);
+      a = usePlugin(A);
       setup() {
         steps.push("setup C");
       }
@@ -335,7 +334,7 @@ describe("basic features", () => {
 
       declare a: PluginInstance<typeof A>;
       setup() {
-        this.a = plugin(A);
+        this.a = usePlugin(A);
       }
     }
 
@@ -346,7 +345,7 @@ describe("basic features", () => {
 
   test("plugin fn cannot be called outside Plugin and Component", () => {
     class A extends Plugin {}
-    expect(() => plugin(A)).toThrow(`No active scope`);
+    expect(() => usePlugin(A)).toThrow(`No active scope`);
   });
 
   test("plugin lifecycle", () => {
@@ -393,8 +392,8 @@ describe("basic features", () => {
     const steps: string[] = [];
 
     class PluginA extends Plugin {
-      input = config("input");
-      defaulted = config("defaulted", types.string().optional("default"));
+      input = useConfig("input");
+      defaulted = useConfig("defaulted", types.string().optional("default"));
 
       setup(): void {
         steps.push(`PluginA - ${this.input} - ${this.defaulted}`);
@@ -412,8 +411,8 @@ describe("basic features", () => {
     const steps: string[] = [];
 
     class PluginA extends Plugin {
-      defaulted = config("defaulted", types.string().optional("default"));
-      given = config("given", types.string().optional("unused"));
+      defaulted = useConfig("defaulted", types.string().optional("default"));
+      given = useConfig("given", types.string().optional("unused"));
 
       setup(): void {
         steps.push(`PluginA - ${this.defaulted} - ${this.given}`);
@@ -564,7 +563,7 @@ describe("sub plugin managers", () => {
     }
 
     class B extends Plugin {
-      a = plugin(A);
+      a = usePlugin(A);
       setup() {
         steps.push("setup B");
         steps.push("value " + this.a.someFunction());
@@ -612,7 +611,7 @@ describe("plugins and resources", () => {
       colors = new Resource({ name: "colors", validation: t.string() });
     }
     class B extends Plugin {
-      a = plugin(A);
+      a = usePlugin(A);
 
       setup() {
         this.a.colors.add("red");
@@ -620,7 +619,7 @@ describe("plugins and resources", () => {
     }
     class C extends Plugin {
       setup() {
-        plugin(A).colors.use("green").use("blue");
+        usePlugin(A).colors.use("green").use("blue");
       }
     }
 
@@ -636,12 +635,12 @@ describe("plugins and resources", () => {
     }
     class B extends Plugin {
       setup() {
-        plugin(A).colors.use("red");
+        usePlugin(A).colors.use("red");
       }
     }
     class C extends Plugin {
       setup() {
-        plugin(A).colors.use("green").use("blue");
+        usePlugin(A).colors.use("green").use("blue");
       }
     }
 
@@ -666,12 +665,12 @@ describe("plugins and resources", () => {
 
     class B extends Plugin {
       setup() {
-        plugin(A).colors.use("red");
+        usePlugin(A).colors.use("red");
       }
     }
     class C extends Plugin {
       setup() {
-        plugin(A).colors.use("green").use("blue");
+        usePlugin(A).colors.use("green").use("blue");
       }
     }
 
@@ -739,7 +738,7 @@ describe("onWillStart in plugins", () => {
 
     class Root extends Component {
       static template = xml`<span>ok</span>`;
-      p = plugin(AsyncPlugin);
+      p = usePlugin(AsyncPlugin);
     }
 
     const fixture = makeTestFixture();
@@ -759,7 +758,7 @@ describe("onWillStart in plugins", () => {
     // The root reads state from a plugin (OtherPlugin) that only starts after
     // an async foundational plugin (DataPlugin, lower sequence). mount() must
     // wait for every configured plugin before building the root, otherwise
-    // `plugin(OtherPlugin)` in the root's field initializer throws.
+    // `usePlugin(OtherPlugin)` in the root's field initializer throws.
     const rpc = makeDeferred<void>();
 
     class DataPlugin extends Plugin {
@@ -771,12 +770,12 @@ describe("onWillStart in plugins", () => {
     }
 
     class OtherPlugin extends Plugin {
-      data = plugin(DataPlugin);
+      data = usePlugin(DataPlugin);
     }
 
     class Root extends Component {
       static template = xml`<t t-out="this.other.data.state().length"/>`;
-      other = plugin(OtherPlugin);
+      other = usePlugin(OtherPlugin);
     }
 
     const fixture = makeTestFixture();
@@ -883,7 +882,7 @@ describe("onWillStart in plugins", () => {
 
     class Child extends Component {
       static template = xml`<span>child</span>`;
-      p = plugin(AsyncPlugin);
+      p = usePlugin(AsyncPlugin);
       setup() {
         valueAtChildSetup = this.p.value;
       }
@@ -993,7 +992,7 @@ describe("plugin sequence", () => {
     }
 
     class Feature extends Plugin {
-      foundation = plugin(Foundation);
+      foundation = usePlugin(Foundation);
       setup() {
         steps.push(`feature:setup (data=${this.foundation.data})`);
       }
@@ -1045,7 +1044,7 @@ describe("plugin sequence", () => {
     manager.destroy();
   });
 
-  test("explicit plugin() dependency starts immediately regardless of sequence", () => {
+  test("explicit usePlugin() dependency starts immediately regardless of sequence", () => {
     const steps: string[] = [];
 
     class Z extends Plugin {
@@ -1056,7 +1055,7 @@ describe("plugin sequence", () => {
     }
     class A extends Plugin {
       static sequence = 10;
-      z = plugin(Z);
+      z = usePlugin(Z);
       setup() {
         steps.push("A");
       }

--- a/packages/owl-runtime/tests/reactivity/proxy.test.ts
+++ b/packages/owl-runtime/tests/reactivity/proxy.test.ts
@@ -1,6 +1,5 @@
 import { vi, type Mock } from "vitest";
-import { Component, mount, onWillStart, onWillUpdateProps, xml } from "../../src";
-import { effect, markRaw, props, proxy, toRaw } from "../../src";
+import { Component, effect, markRaw, mount, onWillStart, onWillUpdateProps, proxy, toRaw, useProps, xml } from "../../src";
 
 import {
   makeDeferred,
@@ -2180,7 +2179,7 @@ describe("Reactivity: proxy", () => {
 
     class Quantity extends Component {
       static template = xml`<t t-set="noop" t-value="this.notify()"/><div><t t-out="this.state.quantity"/></div>`;
-      props = props();
+      props = useProps();
       state = proxy(testContext[this.props.id]);
 
       notify() {
@@ -2261,7 +2260,7 @@ describe("Reactivity: proxy", () => {
     let stateC: any;
     class ComponentC extends Component {
       static template = xml`<span><t t-out="context[this.props.key].n"/><t t-out="state.x"/></span>`;
-      props = props();
+      props = useProps();
       context = proxy(testContext);
       state = proxy({ x: "a" });
       setup() {
@@ -2271,7 +2270,7 @@ describe("Reactivity: proxy", () => {
     class ComponentB extends Component {
       static components = { ComponentC };
       static template = xml`<p><ComponentC key="this.props.key"/></p>`;
-      props = props();
+      props = useProps();
       setup() {
         onWillUpdateProps(() => def);
       }

--- a/packages/owl/tests/types_defaults.ts
+++ b/packages/owl/tests/types_defaults.ts
@@ -1,13 +1,13 @@
 // Compile-time checks for schema defaults (.optional(value)). This file is
 // only typechecked (npm run test:types); it is not executed.
-import { config, props, Registry, Resource, t, type GetProps } from "../src";
+import { Registry, Resource, t, useConfig, useProps, type GetProps } from "../src";
 
 // A call to assertEq<A, B>() only typechecks if A and B are mutually assignable
 type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 declare function assertEq<A, B>(...args: Eq<A, B> extends true ? [] : [never]): void;
 
 class Comp {
-  props = props({
+  props = useProps({
     p: t.number().optional(4),
     q: t.string().optional("a"),
     r: t.string(),
@@ -38,7 +38,7 @@ const ko3: ParentProps = { r: "x", s: 1 };
 // without defaults, the reader and parent views coincide (and the props type
 // displays as a plain flat object)
 class OnlyOptionals {
-  props = props({
+  props = useProps({
     className: t.string().optional(),
     close: t.function().optional(),
   });
@@ -53,33 +53,33 @@ const ok4: OptParentProps = { className: "a" };
 const ko4: OptParentProps = { className: 4 };
 
 // defaults must match the declared type, as a plain value or a factory
-props({ p: t.number().optional(4) });
-props({ p: t.number().optional(() => 4) });
+useProps({ p: t.number().optional(4) });
+useProps({ p: t.number().optional(() => 4) });
 // @ts-expect-error default must be a number
-props({ p: t.number().optional("4") });
+useProps({ p: t.number().optional("4") });
 // a default for a function type must use the factory form
-props({ cb: t.function().optional(() => () => {}) });
+useProps({ cb: t.function().optional(() => () => {}) });
 // @ts-expect-error a plain function default is rejected (factory form only)
-props({ cb: t.function().optional(() => {}) });
+useProps({ cb: t.function().optional(() => {}) });
 
-// props.static: schema default strips to the value type, optional adds undefined
+// useProps.static: schema default strips to the value type, optional adds undefined
 function _staticPropCheck() {
-  const label = props.static("label", t.string().optional("fallback"));
+  const label = useProps.static("label", t.string().optional("fallback"));
   assertEq<typeof label, string>();
-  const plain = props.static("plain", t.string());
+  const plain = useProps.static("plain", t.string());
   assertEq<typeof plain, string>();
-  const opt = props.static("opt", t.string().optional());
+  const opt = useProps.static("opt", t.string().optional());
   assertEq<typeof opt, string | undefined>();
   void [label, plain, opt];
 }
 
-// config: schema default strips to the value type, optional adds undefined
+// useConfig: schema default strips to the value type, optional adds undefined
 function _configCheck() {
-  const delay = config("delay", t.number().optional(500));
+  const delay = useConfig("delay", t.number().optional(500));
   assertEq<typeof delay, number>();
-  const plain = config("plain", t.number());
+  const plain = useConfig("plain", t.number());
   assertEq<typeof plain, number>();
-  const opt = config("opt", t.number().optional());
+  const opt = useConfig("opt", t.number().optional());
   assertEq<typeof opt, number | undefined>();
   void [delay, plain, opt];
 }
@@ -111,7 +111,7 @@ const NotificationShape = {
   sticky: t.boolean().optional(),
 };
 class FromObjectSchema {
-  props = props(t.object(NotificationShape).toShape());
+  props = useProps(t.object(NotificationShape).toShape());
 }
 declare const fromObjectSchema: FromObjectSchema;
 assertEq<typeof fromObjectSchema.props.message, string>();
@@ -124,7 +124,7 @@ const ComposedSchema = t.and([
   t.object({ autocloseDelay: t.number().optional(4000), sticky: t.boolean().optional() }),
 ]);
 class FromComposedSchema {
-  props = props(ComposedSchema.toShape());
+  props = useProps(ComposedSchema.toShape());
 }
 declare const fromComposedSchema: FromComposedSchema;
 assertEq<typeof fromComposedSchema.props.message, string>();

--- a/packages/owl/tests/types_lists.ts
+++ b/packages/owl/tests/types_lists.ts
@@ -1,6 +1,6 @@
 // Compile-time checks for prop type lists e.g. t.or([...]). This file is
 // only typechecked (npm run test:types); it is not executed.
-import { props, t } from "../src";
+import { t, useProps } from "../src";
 
 type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
 declare function assertNotAny<T>(...args: IsAny<T> extends true ? [never] : []): void;
@@ -9,7 +9,7 @@ type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 declare function assertEq<A, B>(...args: Eq<A, B> extends true ? [] : [never]): void;
 
 class Comp {
-  props = props({
+  props = useProps({
     union: t.or([t.string(), t.number()]),
     tuple: t.tuple([t.string(), t.number()]),
     function: t.function([t.string(), t.number()]),


### PR DESCRIPTION
This commit removes the hooks `config`, `plugin` and `props` and the directive `t-slot`. They still exist with the names `useConfig`, `usePlugin`, `useProps` and `t-call-slot`.