### PR TITLE
[IMP] portal: add `ordered` to keep portals in declaration order

### DIFF
--- a/packages/owl-runtime/src/portal.ts
+++ b/packages/owl-runtime/src/portal.ts
@@ -1,5 +1,6 @@
 import { Signal } from "@odoo/owl-core";
 import { Component } from "./component";
+import { ComponentNode } from "./component_node";
 import { useEffect } from "./hooks";
 import { onWillDestroy } from "./lifecycle_hooks";
 import { useProps } from "./props";
@@ -21,6 +22,12 @@ export class Portal extends Component {
   props = useProps({
     slots: t.object(["default"]),
     target: t.or([t.string(), t.signal(t.instanceOf(HTMLElement)), t.instanceOf(HTMLElement)]),
+    // Opt in to keeping this portal's content ordered relative to the other
+    // ordered portals sharing the same target. Off by default: appending is
+    // both cheaper and the semantics most portals want (dialogs, popovers and
+    // tooltips stack in the order they open, not in the order they are
+    // declared). See OrderedPortals below.
+    ordered: t.boolean().optional(false),
   });
 
   setup() {
@@ -61,7 +68,25 @@ export class Portal extends Component {
 
       root.mount(target);
 
-      return tearDown;
+      if (!this.props.ordered) {
+        return tearDown;
+      }
+      const group = OrderedPortals.get(target);
+      const entry: OrderedEntry = { portalNode, contentNode: null };
+      group.add(entry);
+      // `Root` does not expose its node, so take it from the mounted instance.
+      // The promise settles in a microtask (before paint) unless the content
+      // has a pending `onWillStart`, and stays pending on a destroyed root.
+      root.promise.then((component: PortalContent) => {
+        if (group.entries.has(entry)) {
+          entry.contentNode = component.__owl__;
+          group.place();
+        }
+      }, () => {});
+      return () => {
+        group.delete(entry);
+        tearDown();
+      };
     });
 
     onWillDestroy(tearDown);
@@ -79,4 +104,145 @@ function resolveTarget(target: PortalTarget): HTMLElement | null {
     return target;
   }
   return null;
+}
+
+// -----------------------------------------------------------------------------
+// Ordered portals
+// -----------------------------------------------------------------------------
+
+interface OrderedEntry {
+  // The Portal itself, left in place in the source tree. Its bdom is a single
+  // empty text node (`Portal.template` is empty), which owl keeps where the
+  // Portal was declared and moves along with it — including when a keyed
+  // t-foreach reorders its items. That node is the only thing that knows the
+  // order the author wrote, so it is what we sort on.
+  portalNode: ComponentNode;
+  // The sub-root holding the portaled content, which is what we move. Null
+  // until that sub-root has mounted.
+  contentNode: ComponentNode | null;
+}
+
+/**
+ * Keeps the content of the `ordered` portals sharing one target in the order
+ * their `<Portal/>` tags appear in the document, rather than in the order they
+ * happened to mount.
+ *
+ * A portal cannot do this alone: it knows nothing of its siblings, so the
+ * comparison has to happen per target. Two things can put the group out of
+ * order, and each needs its own trigger:
+ *  - a portal mounting or unmounting, which `add`/`delete` handle;
+ *  - a plain reorder of an unchanged set of portals, which owl performs by
+ *    moving nodes without re-rendering, so nothing in owl reports it. Hence the
+ *    MutationObserver on the parents the anchors live under.
+ */
+class OrderedPortals {
+  static groups = new WeakMap<HTMLElement, OrderedPortals>();
+
+  static get(target: HTMLElement): OrderedPortals {
+    let group = OrderedPortals.groups.get(target);
+    if (!group) {
+      group = new OrderedPortals(target);
+      OrderedPortals.groups.set(target, group);
+    }
+    return group;
+  }
+
+  entries = new Set<OrderedEntry>();
+  observers = new Map<Node, MutationObserver>();
+  // Marks the end of the group inside the target, so the ordered content stays
+  // where the group first landed instead of being appended past whatever else
+  // the target may hold.
+  end = document.createComment("");
+
+  constructor(public target: HTMLElement) {}
+
+  add(entry: OrderedEntry) {
+    if (!this.end.isConnected) {
+      this.target.appendChild(this.end);
+    }
+    this.entries.add(entry);
+    this.place();
+  }
+
+  delete(entry: OrderedEntry) {
+    this.entries.delete(entry);
+    if (this.entries.size) {
+      this.place();
+      return;
+    }
+    for (const observer of this.observers.values()) {
+      observer.disconnect();
+    }
+    this.observers.clear();
+    this.end.remove();
+    OrderedPortals.groups.delete(this.target);
+  }
+
+  /** Sorted entries, and the first DOM node of each one's content. */
+  sorted(): [OrderedEntry, Node][] {
+    const placeable: [OrderedEntry, Node, Node][] = [];
+    for (const entry of this.entries) {
+      const anchorEl = entry.portalNode.firstNode();
+      const firstEl = entry.contentNode?.firstNode();
+      if (anchorEl?.isConnected && firstEl) {
+        placeable.push([entry, firstEl, anchorEl]);
+      }
+    }
+    placeable.sort(([, , anchorEl], [, , otherAnchorEl]) =>
+      anchorEl.compareDocumentPosition(otherAnchorEl) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+    );
+    return placeable.map(([entry, firstEl]) => [entry, firstEl]);
+  }
+
+  place() {
+    this.observe();
+    const sorted = this.sorted();
+    if (this.isOrdered(sorted)) {
+      return;
+    }
+    // Moving each one in turn to just before `end` leaves them in sorted order.
+    for (const [entry] of sorted) {
+      entry.contentNode!.moveBeforeDOMNode(this.end, this.target);
+    }
+  }
+
+  /** Whether the target already holds the group's content in sorted order. */
+  isOrdered(sorted: [OrderedEntry, Node][]): boolean {
+    const expected = new Set(sorted.map(([, firstEl]) => firstEl));
+    let index = 0;
+    for (const childEl of this.target.childNodes) {
+      if (expected.has(childEl) && childEl !== sorted[index++]?.[1]) {
+        return false;
+      }
+    }
+    return index === sorted.length;
+  }
+
+  /**
+   * Watch the parents the anchors sit under, so that a reorder among them
+   * re-sorts the target. Anchors of one group may live under different parents
+   * (portals to a shared target need not be siblings, or even share a root).
+   */
+  observe() {
+    const parentEls = new Set<Node>();
+    for (const entry of this.entries) {
+      const parentEl = entry.portalNode.firstNode()?.parentNode;
+      if (parentEl) {
+        parentEls.add(parentEl);
+      }
+    }
+    for (const [parentEl, observer] of this.observers) {
+      if (!parentEls.has(parentEl)) {
+        observer.disconnect();
+        this.observers.delete(parentEl);
+      }
+    }
+    for (const parentEl of parentEls) {
+      if (!this.observers.has(parentEl)) {
+        const observer = new MutationObserver(() => this.place());
+        observer.observe(parentEl, { childList: true });
+        this.observers.set(parentEl, observer);
+      }
+    }
+  }
 }

--- a/packages/owl-runtime/tests/components/portal.test.ts
+++ b/packages/owl-runtime/tests/components/portal.test.ts
@@ -8,6 +8,7 @@ import {
   providePlugins,
   signal,
   usePlugin,
+  useProps,
   xml
 } from "../../src";
 import { makeDeferred, makeTestFixture, nextTick } from "../helpers";
@@ -402,5 +403,190 @@ test("waits for descendant onWillStart before mounting", async () => {
   await nextTick();
   expect(target.querySelector(".payload")!.textContent).toBe("ready");
 
+  app.destroy();
+});
+
+// -----------------------------------------------------------------------------
+// ordered portals
+// -----------------------------------------------------------------------------
+
+function orderIn(target: HTMLElement): string {
+  return [...target.querySelectorAll(".payload")].map((el) => el.textContent).join("");
+}
+
+test("ordered: content follows declaration order, not mount order", async () => {
+  const target = makeOutside("portal-ordered-1");
+  target.dataset.testPortal = "1";
+  const def = makeDeferred();
+
+  class Slow extends Component {
+    static template = xml`<span class="payload">A</span>`;
+    setup() {
+      onWillStart(() => def);
+    }
+  }
+
+  class Root extends Component {
+    static components = { Portal, Slow };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" ordered="true"><Slow/></Portal>
+        <Portal target="this.target" ordered="true"><span class="payload">B</span></Portal>
+      </div>
+    `;
+    target = target;
+  }
+
+  const app = new App();
+  await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  // "A" is still held back by its onWillStart, so only "B" has mounted.
+  expect(orderIn(target)).toBe("B");
+
+  def.resolve();
+  await nextTick();
+
+  // Plain appending would have produced "BA".
+  expect(orderIn(target)).toBe("AB");
+  app.destroy();
+});
+
+test("ordered: a portal appearing later lands in the middle, not last", async () => {
+  const target = makeOutside("portal-ordered-2");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" ordered="true"><span class="payload">A</span></Portal>
+        <t t-if="this.showB()">
+          <Portal target="this.target" ordered="true"><span class="payload">B</span></Portal>
+        </t>
+        <Portal target="this.target" ordered="true"><span class="payload">C</span></Portal>
+      </div>
+    `;
+    target = target;
+    showB = signal(false);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("AC");
+
+  root.showB.set(true);
+  await nextTick();
+
+  // Plain appending would have produced "ACB".
+  expect(orderIn(target)).toBe("ABC");
+  app.destroy();
+});
+
+test("ordered: a keyed t-foreach reorder re-sorts the target", async () => {
+  const target = makeOutside("portal-ordered-3");
+  target.dataset.testPortal = "1";
+
+  class Item extends Component {
+    static components = { Portal };
+    static template = xml`
+      <Portal target="this.props.target" ordered="true">
+        <span class="payload" t-out="this.props.name"/>
+      </Portal>
+    `;
+    props = useProps(["target", "name"]);
+  }
+
+  class Root extends Component {
+    static components = { Item };
+    static template = xml`
+      <div class="src">
+        <Item t-foreach="this.names()" t-as="name" t-key="name" name="name" target="this.target"/>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("ABC");
+
+  // owl reorders a keyed list by moving nodes: no portal remounts, and no
+  // effect re-runs. Only the MutationObserver notices.
+  root.names.set(["C", "A", "B"]);
+  await nextTick();
+
+  expect(orderIn(target)).toBe("CAB");
+  app.destroy();
+});
+
+test("ordered: mixes with plain portals and leaves no trace once torn down", async () => {
+  const target = makeOutside("portal-ordered-4");
+  target.dataset.testPortal = "1";
+  target.innerHTML = `<span class="pre">pre</span>`;
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <t t-if="this.show()">
+          <Portal target="this.target" ordered="true"><span class="payload">A</span></Portal>
+          <Portal target="this.target" ordered="true"><span class="payload">B</span></Portal>
+        </t>
+      </div>
+    `;
+    target = target;
+    show = signal(true);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  // The group keeps to itself: content the target already had stays put.
+  expect(target.firstElementChild!.className).toBe("pre");
+  expect(orderIn(target)).toBe("AB");
+
+  root.show.set(false);
+  await nextTick();
+
+  expect(target.innerHTML).toBe(`<span class="pre">pre</span>`);
+  expect([...target.childNodes].some((n) => n.nodeType === Node.COMMENT_NODE)).toBe(false);
+  app.destroy();
+});
+
+test("unordered portals still append, in mount order", async () => {
+  const target = makeOutside("portal-ordered-5");
+  target.dataset.testPortal = "1";
+  const def = makeDeferred();
+
+  class Slow extends Component {
+    static template = xml`<span class="payload">A</span>`;
+    setup() {
+      onWillStart(() => def);
+    }
+  }
+
+  class Root extends Component {
+    static components = { Portal, Slow };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target"><Slow/></Portal>
+        <Portal target="this.target"><span class="payload">B</span></Portal>
+      </div>
+    `;
+    target = target;
+  }
+
+  const app = new App();
+  await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  def.resolve();
+  await nextTick();
+
+  expect(orderIn(target)).toBe("BA");
   app.destroy();
 });


### PR DESCRIPTION
A Portal appends to its target, so portals sharing a target land in mount order. That is right for dialogs and popovers, but wrong when the target is an ordered list: a portal appearing later always lands last, and a keyed t-foreach reorder moves the portals without re-rendering, so nothing puts the target back in order.

A portal cannot fix this alone, knowing nothing of its siblings. `ordered="true"` joins it to a per-target group that sorts on the document position of the empty text node every Portal already leaves in place, and observes those nodes' parents to catch a reorder owl performs by moving nodes.

Needed by mail's `Tabs`, which portals its tab headers into the nav from a t-foreach.

https://github.com/odoo/odoo/pull/287612