### PR TITLE
[IMP] portal: add `position` to order portals sharing a target

### DIFF
--- a/doc/v3/owl/reference/portal.md
+++ b/doc/v3/owl/reference/portal.md
@@ -126,6 +126,49 @@ container:
 </t>
 ```
 
+Each portal appends to the target as it mounts, so the content ends up in
+**mount order**. For a stack of toasts or dialogs that is exactly right:
+they pile up in the order they opened.
+
+## The `position` prop
+
+Mount order is wrong when the target is an ordered list, because mounting
+is not ordered: a portal whose content has a pending `onWillStart` lands
+after a faster sibling, and one that appears later always lands last.
+
+Pass `position` — a number — to place a portal among the others sharing
+its target, in ascending order, whatever order they mounted in:
+
+```xml
+<Portal
+  t-foreach="this.tabs()"
+  t-as="tab"
+  t-key="tab.id"
+  target="this.navRoot"
+  position="tab_index">
+  <TabHeader t-props="tab"/>
+</Portal>
+```
+
+Because the rank arrives as a prop, reordering the source list is enough:
+the new `tab_index` reaches each Portal as a prop change and the target is
+re-sorted, with no re-render of the portaled content. Nothing inspects the
+source DOM, so it does not matter what markup sits between the `<Portal/>`
+and the list being reordered — a wrapping element, a `t-if` or a slot
+all behave the same.
+
+Details worth knowing:
+
+- **Positions are compared, not counted.** Any numbers in the right order
+  work; they need not be contiguous or start at zero.
+- **Ties keep mount order**, so use distinct positions when the order
+  matters.
+- **Portals without a `position` are left alone**, appended where they
+  landed. In a target that mixes both, the positioned ones are placed
+  after the rest.
+- **Placement is batched**: it happens once per microtick, after every
+  portal in the group has seen its new position, and before paint.
+
 ## How it works
 
 `<Portal>` uses `app.createRoot` plus the

--- a/packages/owl-runtime/src/portal.ts
+++ b/packages/owl-runtime/src/portal.ts
@@ -1,5 +1,6 @@
-import { Signal } from "@odoo/owl-core";
+import { batched, Signal } from "@odoo/owl-core";
 import { Component } from "./component";
+import type { ComponentNode } from "./component_node";
 import { useEffect } from "./hooks";
 import { onWillDestroy } from "./lifecycle_hooks";
 import { useProps } from "./props";
@@ -21,6 +22,11 @@ export class Portal extends Component {
   props = useProps({
     slots: t.object(["default"]),
     target: t.or([t.string(), t.signal(t.instanceOf(HTMLElement)), t.instanceOf(HTMLElement)]),
+    // Rank among the portals sharing this target: they are placed in ascending
+    // `position` order instead of in the order they happened to mount. Left out
+    // (the default), this portal simply appends, which is what a stack of
+    // dialogs or toasts wants. See PortalGroup below.
+    position: t.number().optional(),
   });
 
   setup() {
@@ -28,12 +34,19 @@ export class Portal extends Component {
     const app = portalNode.app;
     const slots = this.props.slots;
     let root: ReturnType<typeof app.createRoot> | null = null;
+    let group: PortalGroup | null = null;
+    const entry: PortalEntry = { position: undefined, contentNode: null };
 
     const tearDown = () => {
       if (root) {
         root.destroy();
         root = null;
       }
+      if (group) {
+        group.entries.delete(entry);
+        group = null;
+      }
+      entry.contentNode = null;
     };
 
     useEffect(() => {
@@ -61,10 +74,113 @@ export class Portal extends Component {
 
       root.mount(target);
 
+      group = PortalGroup.get(target);
+      group.entries.add(entry);
+      // `Root` does not expose its node, so take it from the mounted instance.
+      // The promise settles in a microtask (before paint) unless the content
+      // has a pending `onWillStart`, and stays pending on a destroyed root.
+      root.promise.then(
+        (component: PortalContent) => {
+          if (group?.entries.has(entry)) {
+            entry.contentNode = component.__owl__;
+            group.place();
+          }
+        },
+        () => {}
+      );
+
       return tearDown;
     });
 
+    // Deliberately its own effect: this one owns nothing, so a reorder costs a
+    // number and a batched re-placement. Reading the position in the effect
+    // above would tear the sub-root down and rebuild the portaled content.
+    useEffect(() => {
+      entry.position = this.props.position;
+      group?.place();
+    });
+
     onWillDestroy(tearDown);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Ordered portals
+// -----------------------------------------------------------------------------
+
+interface PortalEntry {
+  // Rank given by the `position` prop, or undefined for a portal that does not
+  // take part in the ordering and is left wherever it landed.
+  position: number | undefined;
+  // The sub-root holding the portaled content, which is what gets moved. Null
+  // until that sub-root has mounted.
+  contentNode: ComponentNode | null;
+}
+
+/**
+ * Places the content of the portals that share one target in ascending
+ * `position` order, rather than in the order they happened to mount.
+ *
+ * A portal cannot do this alone, knowing nothing of its siblings, so the
+ * ordering is held per target. The rank comes in as a prop, which means a
+ * reorder of the source list reaches us as a prop change: nothing here reads
+ * the source DOM, so the placement does not depend on what markup sits between
+ * a `<Portal/>` and the list that reorders it.
+ */
+export class PortalGroup {
+  // Weak, so a group dies with the target it is keyed on. `entries` cannot be:
+  // placing means iterating them, and a WeakSet is not iterable. It is drained
+  // by `tearDown`, from both the effect cleanup and `onWillDestroy`.
+  static groups = new WeakMap<HTMLElement, PortalGroup>();
+
+  static get(target: HTMLElement): PortalGroup {
+    let group = PortalGroup.groups.get(target);
+    if (!group) {
+      group = new PortalGroup(target);
+      PortalGroup.groups.set(target, group);
+    }
+    return group;
+  }
+
+  entries = new Set<PortalEntry>();
+
+  constructor(public target: HTMLElement) {}
+
+  /**
+   * Re-place the whole group, once per microtick. Each portal only knows its
+   * own position and their hooks run one at a time, so placing an entry as soon
+   * as its own position changes would sort it against its siblings' stale
+   * positions, and leave it there.
+   */
+  place = batched(() => {
+    const placed: PortalEntry[] = [];
+    for (const entry of this.entries) {
+      if (
+        entry.position !== undefined &&
+        entry.contentNode?.firstNode()?.parentNode === this.target
+      ) {
+        placed.push(entry);
+      }
+    }
+    placed.sort((entry, other) => entry.position! - other.position!);
+    if (this.isOrdered(placed)) {
+      return;
+    }
+    // Appending them in turn leaves the group ordered, at the end of the target.
+    for (const entry of placed) {
+      entry.contentNode!.moveBeforeDOMNode(null, this.target);
+    }
+  });
+
+  /** Whether the target already holds the group's content in `placed` order. */
+  isOrdered(placed: PortalEntry[]): boolean {
+    let index = 0;
+    for (const childEl of this.target.childNodes) {
+      if (childEl === placed[index]?.contentNode!.firstNode()) {
+        index++;
+      }
+    }
+    return index === placed.length;
   }
 }
 

--- a/packages/owl-runtime/tests/components/portal.test.ts
+++ b/packages/owl-runtime/tests/components/portal.test.ts
@@ -8,8 +8,9 @@ import {
   providePlugins,
   signal,
   usePlugin,
-  xml
+  xml,
 } from "../../src";
+import { PortalGroup } from "../../src/portal";
 import { makeDeferred, makeTestFixture, nextTick } from "../helpers";
 
 let fixture: HTMLElement;
@@ -402,5 +403,374 @@ test("waits for descendant onWillStart before mounting", async () => {
   await nextTick();
   expect(target.querySelector(".payload")!.textContent).toBe("ready");
 
+  app.destroy();
+});
+
+// -----------------------------------------------------------------------------
+// ordered portals
+// -----------------------------------------------------------------------------
+
+function orderIn(target: HTMLElement): string {
+  return [...target.querySelectorAll(".payload")].map((el) => el.textContent).join("");
+}
+
+test("position: content is placed in position order, not in mount order", async () => {
+  const target = makeOutside("portal-position-1");
+  target.dataset.testPortal = "1";
+  const def = makeDeferred();
+
+  class Slow extends Component {
+    static template = xml`<span class="payload">A</span>`;
+    setup() {
+      onWillStart(() => def);
+    }
+  }
+
+  class Root extends Component {
+    static components = { Portal, Slow };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" position="0"><Slow/></Portal>
+        <Portal target="this.target" position="1"><span class="payload">B</span></Portal>
+      </div>
+    `;
+    target = target;
+  }
+
+  const app = new App();
+  await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  // "A" is still held back by its onWillStart, so only "B" has mounted.
+  expect(orderIn(target)).toBe("B");
+
+  def.resolve();
+  await nextTick();
+
+  // Plain appending would have produced "BA".
+  expect(orderIn(target)).toBe("AB");
+  app.destroy();
+});
+
+test("position: a portal appearing later lands in the middle, not last", async () => {
+  const target = makeOutside("portal-position-2");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" position="0"><span class="payload">A</span></Portal>
+        <t t-if="this.showB()">
+          <Portal target="this.target" position="1"><span class="payload">B</span></Portal>
+        </t>
+        <Portal target="this.target" position="2"><span class="payload">C</span></Portal>
+      </div>
+    `;
+    target = target;
+    showB = signal(false);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("AC");
+
+  root.showB.set(true);
+  await nextTick();
+
+  // Plain appending would have produced "ACB".
+  expect(orderIn(target)).toBe("ABC");
+  app.destroy();
+});
+
+test("position: a keyed t-foreach reorder re-sorts the target", async () => {
+  const target = makeOutside("portal-position-3");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal
+          t-foreach="this.names()"
+          t-as="name"
+          t-key="name"
+          target="this.target"
+          position="name_index">
+          <span class="payload"><t t-out="name"/></span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("ABC");
+
+  root.names.set(["C", "A", "B"]);
+  await nextTick();
+  expect(orderIn(target)).toBe("CAB");
+
+  app.destroy();
+});
+
+test("position: the Portal may sit under any markup inside the reordered item", async () => {
+  const target = makeOutside("portal-position-4");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <div t-foreach="this.names()" t-as="name" t-key="name" class="wrap">
+          <Portal target="this.target" position="name_index">
+            <span class="payload"><t t-out="name"/></span>
+          </Portal>
+        </div>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("ABC");
+
+  // The reorder happens on the wrapping divs: the anchors the Portals leave
+  // behind never change parent, and their own parents see no mutation at all.
+  root.names.set(["C", "A", "B"]);
+  await nextTick();
+  expect(orderIn(target)).toBe("CAB");
+
+  app.destroy();
+});
+
+test("position: removing one portal leaves the others in order", async () => {
+  const target = makeOutside("portal-position-5");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal
+          t-foreach="this.names()"
+          t-as="name"
+          t-key="name"
+          target="this.target"
+          position="name_index">
+          <span class="payload"><t t-out="name"/></span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  root.names.set(["C", "A"]);
+  await nextTick();
+  expect(orderIn(target)).toBe("CA");
+
+  app.destroy();
+});
+
+test("position: multi-root content is placed as a unit", async () => {
+  const target = makeOutside("portal-position-multi-1");
+  target.dataset.testPortal = "1";
+  const def = makeDeferred();
+
+  class Slow extends Component {
+    static template = xml`
+      <span class="payload">A1</span>
+      <span class="payload">A2</span>
+    `;
+    setup() {
+      onWillStart(() => def);
+    }
+  }
+
+  class Root extends Component {
+    static components = { Portal, Slow };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" position="0"><Slow/></Portal>
+        <Portal target="this.target" position="1">
+          <span class="payload">B1</span>
+          <span class="payload">B2</span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+  }
+
+  const app = new App();
+  await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("B1B2");
+
+  def.resolve();
+  await nextTick();
+
+  // Every root of a portal's content moves with it: plain appending would have
+  // produced "B1B2A1A2", and moving only the first node would interleave them.
+  expect(orderIn(target)).toBe("A1A2B1B2");
+  app.destroy();
+});
+
+test("position: a keyed reorder moves every root of each content", async () => {
+  const target = makeOutside("portal-position-multi-2");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal
+          t-foreach="this.names()"
+          t-as="name"
+          t-key="name"
+          target="this.target"
+          position="name_index">
+          <span class="payload"><t t-out="name"/>1</span>
+          <span class="payload"><t t-out="name"/>2</span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("A1A2B1B2C1C2");
+
+  root.names.set(["C", "A", "B"]);
+  await nextTick();
+  expect(orderIn(target)).toBe("C1C2A1A2B1B2");
+
+  app.destroy();
+  await nextTick();
+  expect(target.innerHTML).toBe("");
+});
+
+test("position: a content whose first root appears later stays in place", async () => {
+  const target = makeOutside("portal-position-multi-3");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target" position="0">
+          <span t-if="this.showA1()" class="payload">A1</span>
+          <span class="payload">A2</span>
+        </Portal>
+        <Portal target="this.target" position="1">
+          <span class="payload">B1</span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+    showA1 = signal(false);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+  expect(orderIn(target)).toBe("A2B1");
+
+  // The absent root leaves an anchor behind, so the content keeps a stable
+  // first node and stays contiguous when the root fills in.
+  root.showA1.set(true);
+  await nextTick();
+  expect(orderIn(target)).toBe("A1A2B1");
+  app.destroy();
+});
+
+test("position: the group drains as portals go away", async () => {
+  const target = makeOutside("portal-position-7");
+  target.dataset.testPortal = "1";
+
+  class Root extends Component {
+    static components = { Portal };
+    static template = xml`
+      <div class="src">
+        <Portal
+          t-foreach="this.names()"
+          t-as="name"
+          t-key="name"
+          target="this.target"
+          position="name_index">
+          <span class="payload"><t t-out="name"/></span>
+        </Portal>
+      </div>
+    `;
+    target = target;
+    names = signal(["A", "B", "C"]);
+  }
+
+  const app = new App();
+  const root = await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  // The entries are held in a plain Set (placing means iterating them, and a
+  // WeakSet is not iterable), so every way a portal can go away has to remove
+  // its entry, or the group retains the portaled content forever.
+  const group = PortalGroup.groups.get(target)!;
+  expect(group.entries.size).toBe(3);
+
+  root.names.set(["A"]);
+  await nextTick();
+  expect(group.entries.size).toBe(1);
+
+  app.destroy();
+  await nextTick();
+  expect(group.entries.size).toBe(0);
+  expect(target.innerHTML).toBe("");
+});
+
+test("portals without a position keep appending in mount order", async () => {
+  const target = makeOutside("portal-position-6");
+  target.dataset.testPortal = "1";
+  const def = makeDeferred();
+
+  class Slow extends Component {
+    static template = xml`<span class="payload">A</span>`;
+    setup() {
+      onWillStart(() => def);
+    }
+  }
+
+  class Root extends Component {
+    static components = { Portal, Slow };
+    static template = xml`
+      <div class="src">
+        <Portal target="this.target"><Slow/></Portal>
+        <Portal target="this.target"><span class="payload">B</span></Portal>
+      </div>
+    `;
+    target = target;
+  }
+
+  const app = new App();
+  await app.createRoot(Root).mount(fixture);
+  await nextTick();
+
+  def.resolve();
+  await nextTick();
+
+  // A stack of dialogs or toasts wants the order they opened in.
+  expect(orderIn(target)).toBe("BA");
   app.destroy();
 });


### PR DESCRIPTION
Alternative to #2035, same problem, different mechanism. Opened as a draft so
the two can be diffed; not meant to land as-is.

## The problem

A Portal appends its content to the target when its sub-root mounts, so portals
sharing a target land in mount order — and mounting is not ordered. Measured on
master:

| shape | result |
|---|---|
| `t-foreach` A,B,C with B slow | `AC`, then `ACB` |
| all three slow, resolved C,A,B | `CAB` |
| `A` / `t-if B` / `C`, show B | `ACB` |
| `t-foreach` A,C → A,B,C | `ACB` |
| keyed reorder to C,A,B | stays `ABC` |

The root cause is narrower than "reorders aren't tracked". A `t-foreach` of
components commits atomically — a slow child holds back the whole commit, which
is why template order normally holds without anyone maintaining it. Portal opts
out of that by construction: each content is its own root with its own fiber and
`willStart`. So placement falls to whatever order the sub-root promises settle
in. Every row above is that one cause.

## The mechanism here

`position` — a number — ranks the portals sharing a target. The group re-places
its content in ascending rank, batched once per microtick.

The rank arrives as a **prop**, which is the whole point: a keyed `VList.patch`
calls `cPatch` on every matched child, so a reorder updates the moved portals'
props, and reactive props (#1908) re-run the effect. Nothing reads the source
DOM.

Two effects, deliberately: the existing one owns the sub-root and must only
re-run when `target` changes; the new one owns nothing and only records a
number, so re-running it on a reorder cannot remount the portaled content.

The effect records and invalidates rather than placing, because each portal
knows only its own position and their effects run one at a time — placing on the
spot sorts an entry against its siblings' stale positions and leaves it there.

## Versus #2035

The observable difference is markup sensitivity. #2035 sorts on the document
position of the anchors and watches each anchor's `parentNode` for mutations, so
it depends on where the Portal sits inside the reordered item:

```xml
<!-- #2035: works -->
<Portal t-foreach="names" t-as="name" t-key="name" ordered="true">…</Portal>

<!-- #2035: silently stays stale; the wrapping div never sees a childList
     mutation, only the list container does -->
<div t-foreach="names" t-as="name" t-key="name">
  <Portal ordered="true">…</Portal>
</div>
```

I ran both: the first reorders to `CAB`, the second stays `ABC` — and then
silently repairs itself on the next add or remove, which is the worst debugging
shape. `tests/components/portal.test.ts` here covers both, plus `t-if`
insertion, slow content, and removal.

Since the rank is data, this approach has no such shape: a wrapper, a `t-if` or
a slot all behave the same, because no DOM is inspected.

Three other things drop out rather than needing fixes: no MutationObserver
firing on unrelated sibling churn in the anchors' parents; no `end` marker (in
#2035 it is appended before any content exists, so it marks the group's *start* —
`isOrdered` then returns true on the first placement and the marker never ends up
after anything, letting a plain portal land inside the ordered group); and no
`compareDocumentPosition`, which in Blink is O(sibling distance) and invalidated
by any mutation of the parent's child list — not a problem at n=5 tabs, but it is
being called inside a sort, right after the patch that mutated that parent.

Code in `portal.ts`, excluding comments and blanks: **69 lines here vs 113 in
#2035**.

## What it gives up

The author supplies the number instead of it being inferred. For the `t-foreach`
case that's `tab_index`, which the compiler already provides; the static
`A / t-if B / C` case needs literal `0/1/2`, which is uglier but explicit.
Portals from unrelated components into one target now need an agreed numbering
scheme — there was no well-defined cross-tree order before either.

This is the real trade against #2035, and it is a genuine one: document order is
automatic, and it is what the rest of Owl guarantees. The argument for going
manual is that the automatic version needs a trigger that cannot miss, and an
anchor-position heuristic isn't it — which leaves hooking Owl's own move path
(`VList`/`VMulti`/`ComponentNode.moveBeforeVNode`, plus `Block` moves for wrapped
portals) or sweeping the groups once per commit in `Scheduler.processTasks`.
Both are exact; both are bigger than this.

## Open questions

- Positioned portals are placed after unpositioned ones in a mixed target
  (the group owns the tail). Fine, or should a mixed target be rejected?
- Ties keep mount order. Worth validating against, or leave it documented?
- Is `position` the right name — `index`, `order`, `rank`?
